### PR TITLE
Fix initializer visibility and argument names

### DIFF
--- a/Sources/DeepLearning/Random.swift
+++ b/Sources/DeepLearning/Random.swift
@@ -162,7 +162,7 @@ public struct ThreefryRandomNumberGenerator: SeedableRandomNumberGenerator {
         return (X0, X1)
     }
 
-    private init(uint64Seed seed: UInt64) {
+    internal init(uint64Seed seed: UInt64) {
         key = ThreefryRandomNumberGenerator.split(seed)
     }
 
@@ -173,7 +173,7 @@ public struct ThreefryRandomNumberGenerator: SeedableRandomNumberGenerator {
         for i in 0..<seed.count {
             combinedSeed += UInt64(seed[i]) << UInt64(8 * i)
         }
-        self.init(uint64seed: combinedSeed)
+        self.init(uint64Seed: combinedSeed)
     }
 
     public mutating func next() -> UInt64 {

--- a/Tests/DeepLearningTests/PRNGTests.swift
+++ b/Tests/DeepLearningTests/PRNGTests.swift
@@ -20,7 +20,7 @@ final class ThreefryTests: XCTestCase {
         // Check the PRNG output given different seeds against reference values.
         // This guards against accidental changes to the generator which should
         // result in changes to its output.
-        var generator = ThreefryRandomNumberGenerator(uint64seed: 123159812)
+        var generator = ThreefryRandomNumberGenerator(uint64Seed: 123159812)
         XCTAssertEqual(generator.next(), 9411952874433594703)
         XCTAssertEqual(generator.next(), 6992100569504761807)
         XCTAssertEqual(generator.next(), 6249442510280393663)
@@ -30,7 +30,7 @@ final class ThreefryTests: XCTestCase {
         XCTAssertEqual(generator.next(), 14104268727839198528)
         XCTAssertEqual(generator.next(), 2729105059420396781)
 
-        generator = ThreefryRandomNumberGenerator(uint64seed: 58172950819076)
+        generator = ThreefryRandomNumberGenerator(uint64Seed: 58172950819076)
         XCTAssertEqual(generator.next(), 8181320043134006362)
         XCTAssertEqual(generator.next(), 14375459274817572790)
         XCTAssertEqual(generator.next(), 1051151592956420496)


### PR DESCRIPTION
Changing the initializer visibility to `private` was causing the tests to fail. I fixed the problem and verified that everything builds and works.