### PR TITLE
[Random] Move all random number APIs from TF stdlib to DeepLearning.

### DIFF
--- a/Sources/DeepLearning/Initializers.swift
+++ b/Sources/DeepLearning/Initializers.swift
@@ -16,16 +16,140 @@
 @_exported import TensorFlow
 #endif
 
+public extension Tensor where Scalar == Int32 {
+  /// Creates a tensor with the specified shape, randomly sampling scalar values
+  /// from a discrete uniform distribution.
+  ///
+  /// - Parameters:
+  ///   - shape: The dimensions of the tensor.
+  ///   - generator: Random number generator to use.
+  ///
+    @inlinable @inline(__always)
+    init<G: RandomNumberGenerator>(randomStandardUniform shape: TensorShape,
+                                   generator: inout G) {
+        let dist = UniformIntegerDistribution<Scalar>()
+        var scalars: [Scalar] = []
+        for _ in 0 ..< shape.contiguousSize {
+            scalars.append(dist.next(using: &generator))
+        }
+        self.init(shape: shape, scalars: scalars)
+    }
+
+    /// Creates a tensor with the specified shape, randomly sampling scalar values
+    /// from a discrete uniform distribution, using the default random number
+    /// generator.
+    ///
+    /// - Parameters:
+    ///   - shape: The dimensions of the tensor.
+    ///
+    // FIXME: Simply call above init() function when Hoistable closures capture
+    // mutating references correctly
+    @inlinable @inline(__always)
+    init(randomStandardUniform shape: TensorShape) {
+        let dist = UniformIntegerDistribution<Scalar>()
+        var scalars: [Scalar] = []
+        for _ in 0 ..< shape.contiguousSize {
+            scalars.append(dist.next(using: &ARC4RandomNumberGenerator.global))
+        }
+        self.init(shape: shape, scalars: scalars)
+    }
+
+}
+
 public extension Tensor where Scalar : BinaryFloatingPoint,
                               Scalar.RawSignificand : FixedWidthInteger {
-   /// Performs Glorot uniform initialization for the specified shape,
-   /// creating a tensor by randomly sampling scalar values from a uniform
-   /// distribution between -limit and limit, where limit is
-   /// sqrt(6 / (fanIn + fanOut)), using the default RNG
-   ///
-   /// - Parameters:
-   ///   - shape: The dimensions of the tensor.
-   ///
+    /// Creates a tensor with the specified shape, randomly sampling scalar values
+    /// from a uniform distribution between 0 and 1.
+    ///
+    /// - Parameters:
+    ///   - shape: The dimensions of the tensor.
+    ///   - generator: Random number generator to use.
+    ///
+    @inlinable @inline(__always)
+    init<G: RandomNumberGenerator>(randomUniform shape: TensorShape,
+                                   generator: inout G) {
+        let dist = UniformFloatingPointDistribution<Scalar>()
+        var scalars: [Scalar] = []
+        for _ in 0 ..< shape.contiguousSize {
+            scalars.append(dist.next(using: &generator))
+        }
+        self.init(shape: shape, scalars: scalars)
+    }
+
+    /// Creates a tensor with the specified shape, randomly sampling scalar values
+    /// from a uniform distribution between 0 and 1, using the default random
+    /// number generator.
+    ///
+    /// - Parameters:
+    ///   - shape: The dimensions of the tensor.
+    ///
+    // FIXME: Simply call above init() function when Hoistable closures capture
+    // mutating references correctly
+    @inlinable @inline(__always)
+    init(randomUniform shape: TensorShape) {
+        let dist = UniformFloatingPointDistribution<Scalar>()
+        var scalars: [Scalar] = []
+        for _ in 0 ..< shape.contiguousSize {
+            scalars.append(dist.next(using: &ARC4RandomNumberGenerator.global))
+        }
+        self.init(shape: shape, scalars: scalars)
+    }
+
+    /// Creates a tensor with the specified shape, randomly sampling scalar values
+    /// from a normal distribution.
+    ///
+    /// - Parameters:
+    ///   - shape: The dimensions of the tensor.
+    ///   - mean: The mean of the distribution.
+    ///   - stddev: The standard deviation of the distribution.
+    ///   - generator: Random number generator to use.
+    ///
+    @inlinable @inline(__always)
+    init<G: RandomNumberGenerator>(randomNormal shape: TensorShape,
+                                   mean: Scalar = 0,
+                                   stddev: Scalar = 1,
+                                   generator: inout G) {
+        let dist = NormalDistribution<Scalar>(mean: mean, standardDeviation: stddev)
+        var scalars: [Scalar] = []
+        for _ in 0 ..< shape.contiguousSize {
+            scalars.append(dist.next(using: &generator))
+        }
+        self.init(shape: shape, scalars: scalars)
+    }
+
+    /// Creates a tensor with the specified shape, randomly sampling scalar values
+    /// from a normal distribution, using the default random number generator.
+    ///
+    /// - Parameters:
+    ///   - shape: The dimensions of the tensor.
+    ///   - mean: The mean of the distribution.
+    ///   - stddev: The standard deviation of the distribution.
+    ///
+    // FIXME: Simply call above init() function when Hoistable closures capture
+    // mutating references correctly
+    @inlinable @inline(__always)
+    init(randomNormal shape: TensorShape, mean: Scalar = 0, stddev: Scalar = 1) {
+        let dist = NormalDistribution<Scalar>(mean: mean, standardDeviation: stddev)
+        var scalars: [Scalar] = []
+        for _ in 0 ..< shape.contiguousSize {
+            scalars.append(dist.next(using:&ARC4RandomNumberGenerator.global))
+        }
+        self.init(shape: shape, scalars: scalars)
+    }
+}
+
+
+
+public extension Tensor where Scalar : BinaryFloatingPoint,
+                              Scalar.RawSignificand : FixedWidthInteger {
+    /// Performs Glorot uniform initialization for the specified shape,
+    /// creating a tensor by randomly sampling scalar values from a uniform
+    /// distribution between -limit and limit, where limit is
+    /// sqrt(6 / (fanIn + fanOut)), using the default RNG
+    ///
+    /// - Parameters:
+    ///   - shape: The dimensions of the tensor.
+    ///
     init(glorotUniform shape: TensorShape) {
         let fanIn = shape[shape.count - 2]
         let fanOut = shape[shape.count - 1]

--- a/Sources/DeepLearning/Initializers.swift
+++ b/Sources/DeepLearning/Initializers.swift
@@ -138,8 +138,6 @@ public extension Tensor where Scalar : BinaryFloatingPoint,
     }
 }
 
-
-
 public extension Tensor where Scalar : BinaryFloatingPoint,
                               Scalar.RawSignificand : FixedWidthInteger {
     /// Performs Glorot uniform initialization for the specified shape,

--- a/Sources/DeepLearning/Initializers.swift
+++ b/Sources/DeepLearning/Initializers.swift
@@ -17,14 +17,13 @@
 #endif
 
 public extension Tensor where Scalar == Int32 {
-  /// Creates a tensor with the specified shape, randomly sampling scalar values
-  /// from a discrete uniform distribution.
-  ///
-  /// - Parameters:
-  ///   - shape: The dimensions of the tensor.
-  ///   - generator: Random number generator to use.
-  ///
-    @inlinable @inline(__always)
+    /// Creates a tensor with the specified shape, randomly sampling scalar values
+    /// from a discrete uniform distribution.
+    ///
+    /// - Parameters:
+    ///   - shape: The dimensions of the tensor.
+    ///   - generator: Random number generator to use.
+    ///
     init<G: RandomNumberGenerator>(randomStandardUniform shape: TensorShape,
                                    generator: inout G) {
         let dist = UniformIntegerDistribution<Scalar>()
@@ -42,9 +41,6 @@ public extension Tensor where Scalar == Int32 {
     /// - Parameters:
     ///   - shape: The dimensions of the tensor.
     ///
-    // FIXME: Simply call above init() function when Hoistable closures capture
-    // mutating references correctly
-    @inlinable @inline(__always)
     init(randomStandardUniform shape: TensorShape) {
         let dist = UniformIntegerDistribution<Scalar>()
         var scalars: [Scalar] = []
@@ -53,7 +49,6 @@ public extension Tensor where Scalar == Int32 {
         }
         self.init(shape: shape, scalars: scalars)
     }
-
 }
 
 public extension Tensor where Scalar : BinaryFloatingPoint,
@@ -65,7 +60,6 @@ public extension Tensor where Scalar : BinaryFloatingPoint,
     ///   - shape: The dimensions of the tensor.
     ///   - generator: Random number generator to use.
     ///
-    @inlinable @inline(__always)
     init<G: RandomNumberGenerator>(randomUniform shape: TensorShape,
                                    generator: inout G) {
         let dist = UniformFloatingPointDistribution<Scalar>()
@@ -83,9 +77,6 @@ public extension Tensor where Scalar : BinaryFloatingPoint,
     /// - Parameters:
     ///   - shape: The dimensions of the tensor.
     ///
-    // FIXME: Simply call above init() function when Hoistable closures capture
-    // mutating references correctly
-    @inlinable @inline(__always)
     init(randomUniform shape: TensorShape) {
         let dist = UniformFloatingPointDistribution<Scalar>()
         var scalars: [Scalar] = []
@@ -104,7 +95,6 @@ public extension Tensor where Scalar : BinaryFloatingPoint,
     ///   - stddev: The standard deviation of the distribution.
     ///   - generator: Random number generator to use.
     ///
-    @inlinable @inline(__always)
     init<G: RandomNumberGenerator>(randomNormal shape: TensorShape,
                                    mean: Scalar = 0,
                                    stddev: Scalar = 1,
@@ -125,9 +115,6 @@ public extension Tensor where Scalar : BinaryFloatingPoint,
     ///   - mean: The mean of the distribution.
     ///   - stddev: The standard deviation of the distribution.
     ///
-    // FIXME: Simply call above init() function when Hoistable closures capture
-    // mutating references correctly
-    @inlinable @inline(__always)
     init(randomNormal shape: TensorShape, mean: Scalar = 0, stddev: Scalar = 1) {
         let dist = NormalDistribution<Scalar>(mean: mean, standardDeviation: stddev)
         var scalars: [Scalar] = []
@@ -140,10 +127,9 @@ public extension Tensor where Scalar : BinaryFloatingPoint,
 
 public extension Tensor where Scalar : BinaryFloatingPoint,
                               Scalar.RawSignificand : FixedWidthInteger {
-    /// Performs Glorot uniform initialization for the specified shape,
-    /// creating a tensor by randomly sampling scalar values from a uniform
-    /// distribution between -limit and limit, where limit is
-    /// sqrt(6 / (fanIn + fanOut)), using the default RNG
+    /// Performs Glorot uniform initialization for the specified shape, creating a tensor by
+    /// randomly sampling scalar values from a uniform distribution between `-limit` and `limit`,
+    /// where limit is `sqrt(6 / (fanIn + fanOut))`, using the default random number generator.
     ///
     /// - Parameters:
     ///   - shape: The dimensions of the tensor.

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -289,7 +289,8 @@ public struct LayerNorm<Scalar: TensorFlowFloatingPoint>: Layer {
     }
 }
 
-public extension Tensor where Scalar.RawSignificand: FixedWidthInteger {
+public extension Tensor
+    where Scalar : TensorFlowFloatingPoint, Scalar.RawSignificand: FixedWidthInteger {
     @differentiable(wrt: self where Scalar: Differentiable)
     func droppingOut(probability: Double) -> Tensor {
         let noise = Tensor(randomUniform: shape)

--- a/Sources/DeepLearning/Random.swift
+++ b/Sources/DeepLearning/Random.swift
@@ -12,9 +12,104 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !COMPILING_TENSORFLOW_MODULE
-import TensorFlow
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import Darwin
+#else
+import Glibc
 #endif
+
+//===----------------------------------------------------------------------===//
+// Random number generators
+//===----------------------------------------------------------------------===//
+
+/// A type that provides seedable deterministic pseudo-random data.
+///
+/// A SeedableRandomNumberGenerator can be used anywhere where a
+/// RandomNumberGenerator would be used. It is useful when the pseudo-random
+/// data needs to be reproducible across runs.
+///
+/// Conforming to the SeedableRandomNumberGenerator Protocol
+/// ========================================================
+///
+/// To make a custom type conform to the `SeedableRandomNumberGenerator`
+/// protocol, implement the `init(seed: [UInt8])` initializer, as well as the
+/// requirements for `RandomNumberGenerator`. The values returned by `next()`
+/// must form a deterministic sequence that depends only on the seed provided
+/// upon initialization.
+public protocol SeedableRandomNumberGenerator: RandomNumberGenerator {
+    init(seed: [UInt8])
+    init<T: BinaryInteger>(seed: T)
+}
+
+extension SeedableRandomNumberGenerator {
+    public init<T: BinaryInteger>(seed: T) {
+        var newSeed: [UInt8] = []
+        for i in 0..<seed.bitWidth / UInt8.bitWidth {
+            newSeed.append(UInt8(truncatingIfNeeded: seed >> (UInt8.bitWidth * i)))
+        }
+        self.init(seed: newSeed)
+    }
+}
+
+/// An implementation of `SeedableRandomNumberGenerator` using ARC4.
+///
+/// ARC4 is a stream cipher that generates a pseudo-random stream of bytes. This
+/// PRNG uses the seed as its key.
+///
+/// ARC4 is described in Schneier, B., "Applied Cryptography: Protocols,
+/// Algorithms, and Source Code in C", 2nd Edition, 1996.
+///
+/// An individual generator is not thread-safe, but distinct generators do not
+/// share state. The random data generated is of high-quality, but is not
+/// suitable for cryptographic applications.
+@_fixed_layout
+public struct ARC4RandomNumberGenerator: SeedableRandomNumberGenerator {
+    public static var global = ARC4RandomNumberGenerator(seed: UInt32(time(nil)))
+    var state: [UInt8] = Array(0...255)
+    var iPos: UInt8 = 0
+    var jPos: UInt8 = 0
+
+    /// Initialize ARC4RandomNumberGenerator using an array of UInt8. The array
+    /// must have length between 1 and 256 inclusive.
+    public init(seed: [UInt8]) {
+        precondition(seed.count > 0, "Length of seed must be positive")
+        precondition(seed.count <= 256, "Length of seed must be at most 256")
+        var j: UInt8 = 0
+        for i: UInt8 in 0...255 {
+            j &+= S(i) &+ seed[Int(i) % seed.count]
+            swapAt(i, j)
+        }
+    }
+
+    // Produce the next random UInt64 from the stream, and advance the internal
+    // state.
+    public mutating func next() -> UInt64 {
+        var result: UInt64 = 0
+        for _ in 0..<UInt64.bitWidth / UInt8.bitWidth {
+            result <<= UInt8.bitWidth
+            result += UInt64(nextByte())
+        }
+        return result
+    }
+
+    // Helper to access the state.
+    private func S(_ index: UInt8) -> UInt8 {
+        return state[Int(index)]
+    }
+
+    // Helper to swap elements of the state.
+    private mutating func swapAt(_ i: UInt8, _ j: UInt8) {
+        state.swapAt(Int(i), Int(j))
+    }
+
+    // Generates the next byte in the keystream.
+    private mutating func nextByte() -> UInt8 {
+        iPos &+= 1
+        jPos &+= S(iPos)
+        swapAt(iPos, jPos)
+        return S(S(iPos) &+ S(jPos))
+    }
+}
 
 private typealias UInt32x2 = (UInt32, UInt32)
 private typealias UInt32x4 = (UInt32, UInt32, UInt32, UInt32)
@@ -30,9 +125,8 @@ private typealias UInt32x4 = (UInt32, UInt32, UInt32, UInt32)
 /// share state. The random data generated is of high-quality, but is not
 /// suitable for cryptographic applications.
 public struct ThreefryRandomNumberGenerator: SeedableRandomNumberGenerator {
-    private let rot:
-        (UInt32, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32)
-        = (13, 15, 26, 6, 17, 29, 16, 24)
+    private let rot: (UInt32, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32)
+      = (13, 15, 26, 6, 17, 29, 16, 24)
 
     private func rotl32(value: UInt32, n: UInt32) -> UInt32 {
         return (value << (n & 31)) | (value >> ((32 - n) & 31))
@@ -169,7 +263,7 @@ public struct ThreefryRandomNumberGenerator: SeedableRandomNumberGenerator {
 
     public mutating func next() -> UInt64 {
         defer { ctr += 1 }
-        return UInt64(fromVector: random(forCtr: ctr.vector2, key: key))
+        return UInt64(vector: random(forCtr: ctr.vector2, key: key))
     }
 }
 
@@ -291,7 +385,7 @@ fileprivate extension UInt64 {
         return (0, 0, msb, lsb)
     }
 
-    init(fromVector vector: UInt32x2) {
+    init(vector: UInt32x2) {
         self = (UInt64(vector.0) << 32) + UInt64(vector.1)
     }
 }
@@ -300,4 +394,191 @@ private func makeUInt64Pair(_ vector: UInt32x4) -> (UInt64, UInt64) {
     let a = (UInt64(vector.0) << 32) + UInt64(vector.1)
     let b = (UInt64(vector.2) << 32) + UInt64(vector.3)
     return (a, b)
+}
+
+//===----------------------------------------------------------------------===//
+// Distributions
+//===----------------------------------------------------------------------===//
+
+@_fixed_layout
+public final class UniformIntegerDistribution<T: FixedWidthInteger> {
+    public let lowerBound: T
+    public let upperBound: T
+
+    public init(lowerBound: T = T.self.min, upperBound: T = T.self.max) {
+        self.lowerBound = lowerBound
+        self.upperBound = upperBound
+    }
+
+    public func next<G: RandomNumberGenerator>(using rng: inout G) -> T {
+        return T.random(in: lowerBound...upperBound, using: &rng)
+    }
+}
+
+@_fixed_layout
+public final class UniformFloatingPointDistribution<T : BinaryFloatingPoint>
+  where T.RawSignificand : FixedWidthInteger {
+    public let lowerBound: T
+    public let upperBound: T
+
+    public init(lowerBound: T = 0, upperBound: T = 1) {
+        self.lowerBound = lowerBound
+        self.upperBound = upperBound
+    }
+
+    public func next<G: RandomNumberGenerator>(using rng: inout G) -> T {
+        return T.random(in: lowerBound..<upperBound, using: &rng)
+    }
+}
+
+@_fixed_layout
+public final class NormalDistribution<T : BinaryFloatingPoint>
+  where T.RawSignificand : FixedWidthInteger {
+    public let mean: T
+    public let standardDeviation: T
+    private let uniformDist = UniformFloatingPointDistribution<T>()
+
+    public init(mean: T = 0, standardDeviation: T = 1) {
+        self.mean = mean
+        self.standardDeviation = standardDeviation
+    }
+
+    public func next<G: RandomNumberGenerator>(using rng: inout G) -> T {
+        // FIXME: Box-Muller can generate two values for only a little more than the
+        // cost of one.
+        let u1 = uniformDist.next(using: &rng)
+        let u2 = uniformDist.next(using: &rng)
+        let r = (-2 * T(log(Double(u1)))).squareRoot()
+        let theta: Double = 2 * Double.pi * Double(u2)
+        let normal01 = r * T(cos(theta))
+        return mean + standardDeviation * normal01
+    }
+}
+
+@_fixed_layout
+public final class BetaDistribution {
+    public let alpha: Float
+    public let beta: Float
+    private let uniformDistribution = UniformFloatingPointDistribution<Float>()
+
+    public init(alpha: Float = 0, beta: Float = 1) {
+        self.alpha = alpha
+        self.beta = beta
+    }
+
+    public func next<G: RandomNumberGenerator>(using rng: inout G) -> Float {
+        // Generate a sample using Cheng's sampling algorithm from:
+        // R. C. H. Cheng, "Generating beta variates with nonintegral shape
+        // parameters.". Communications of the ACM, 21, 317-322, 1978.
+        let a = min(alpha, beta)
+        let b = max(alpha, beta)
+        if a > 1 {
+            return BetaDistribution.chengsAlgorithmBB(alpha, a, b, using: &rng)
+        } else {
+            return BetaDistribution.chengsAlgorithmBC(alpha, b, a, using: &rng)
+        }
+    }
+
+    /// Returns one sample from a Beta(alpha, beta) distribution using Cheng's BB
+    /// algorithm, when both alpha and beta are greater than 1.
+    ///
+    /// - Parameters:
+    ///   - alpha: First Beta distribution shape parameter.
+    ///   - a: `min(alpha, beta)`.
+    ///   - b: `max(alpha, beta)`.
+    ///   - rng: Random number generator.
+    ///
+    /// - Returns: Sample obtained using Cheng's BB algorithm.
+    private static func chengsAlgorithmBB<G: RandomNumberGenerator>(
+      _ alpha0: Float,
+      _ a: Float,
+      _ b: Float,
+      using rng: inout G
+    ) -> Float {
+        let alpha = a + b
+        let beta  = sqrt((alpha - 2) / (2 * a * b - alpha))
+        let gamma = a + 1 / beta
+
+        var r: Float = 0.0
+        var w: Float = 0.0
+        var t: Float = 0.0
+
+        repeat {
+            let u1 = Float.random(in: 0.0...1.0, using: &rng)
+            let u2 = Float.random(in: 0.0...1.0, using: &rng)
+            let v = beta * (log(u1) - log1p(-u1))
+            r = gamma * v - 1.3862944
+            let z = u1 * u1 * u2
+            w = a * exp(v)
+
+            let s = a + r - w
+            if s + 2.609438 >= 5 * z {
+                break
+            }
+
+            t = log(z)
+            if s >= t {
+                break
+            }
+        } while r + alpha * (log(alpha) - log(b + w)) < t
+
+        w = min(w, Float.greatestFiniteMagnitude)
+        return a == alpha0 ? w / (b + w) : b / (b + w)
+    }
+
+    /// Returns one sample from a Beta(alpha, beta) distribution using Cheng's BC
+    /// algorithm, when at least one of alpha and beta is less than 1.
+    ///
+    /// - Parameters:
+    ///     - alpha: First Beta distribution shape parameter.
+    ///     - a: `max(alpha, beta)`.
+    ///     - b: `min(alpha, beta)`.
+    ///     - rng: Random number generator.
+    ///
+    /// - Returns: Sample obtained using Cheng's BB algorithm.
+    private static func chengsAlgorithmBC<G: RandomNumberGenerator>(
+      _ alpha0: Float,
+      _ a: Float,
+      _ b: Float,
+      using rng: inout G
+    ) -> Float {
+        let alpha = a + b
+        let beta  = 1 / b
+        let delta = 1 + a - b
+        let k1    = delta * (0.0138889 + 0.0416667 * b) / (a * beta - 0.777778)
+        let k2    = 0.25 + (0.5 + 0.25 / delta) * b
+
+        var w: Float = 0.0
+
+        while true {
+            let u1 = Float.random(in: 0.0...1.0, using: &rng)
+            let u2 = Float.random(in: 0.0...1.0, using: &rng)
+            let y = u1 * u2
+            let z = u1 * y
+
+            if u1 < 0.5 {
+                if 0.25 * u2 + z - y >= k1 {
+                    continue
+                }
+            } else {
+                if z <= 0.25 {
+                    let v = beta * (log(u1) - log1p(-u1))
+                    w = a * exp(v)
+                    break
+                }
+                if z >= k2 {
+                    continue
+                }
+            }
+
+            let v = beta * (log(u1) - log1p(-u1))
+            w = a * exp(v)
+            if alpha * (log(alpha) - log(b + 1) + v) - 1.3862944 >= log(z) {
+                break
+            }
+        }
+
+        w = min(w, Float.greatestFiniteMagnitude)
+        return a == alpha0 ? w / (b + w) : b / (b + w)
+    }
 }


### PR DESCRIPTION
- Move `Tensor`'s [random number initializers](https://github.com/apple/swift/blob/bf24b296929b49babe19b04da0554f5d9f885558/stdlib/public/TensorFlow/Tensor.swift#L615).
  - Replace the obsolete `_TFHoistable` hack with sane delegate initialization.
- Move [random number generators and distributions](https://github.com/apple/swift/blob/tensorflow/stdlib/public/TensorFlow/Random.swift) and their tests.

This enables developing these APIs without an active compiler build and XCTest (!), and is a part of our "move things out of the compiler repo" effort.

Corresponding PRs in the compiler repo will be available soon.