### PR TITLE
TF-245: Add the sequential combinator.

### DIFF
--- a/Tests/DeepLearningTests/LayerCombinatorTests.swift
+++ b/Tests/DeepLearningTests/LayerCombinatorTests.swift
@@ -23,7 +23,7 @@ final class LayerCombinatorTests: XCTestCase {
             Dense<Float>(inputSize: inputSize, outputSize: hiddenSize, activation: relu) >>
             Dense<Float>(inputSize: hiddenSize, outputSize: 1, activation: relu)
         
-        let optimizer = SGD<model.type, Float>(learningRate: 0.02)  // Doesn't compile... :-(
+        let optimizer = SGD<model.Type, Float>(learningRate: 0.02)  // Doesn't compile... :-(
         let x: Tensor<Float> = [[0, 0], [0, 1], [1, 0], [1, 1]]
         let y: Tensor<Float> = [0, 1, 1, 0]
         

--- a/Tests/DeepLearningTests/LayerCombinatorTests.swift
+++ b/Tests/DeepLearningTests/LayerCombinatorTests.swift
@@ -1,0 +1,43 @@
+// Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+@testable import DeepLearning
+
+final class LayerCombinatorTests: XCTestCase {
+    func testSequential() {
+        let inputSize = 2
+        let hiddenSize = 4
+        let model =
+            Dense<Float>(inputSize: inputSize, outputSize: hiddenSize, activation: relu) >>
+            Dense<Float>(inputSize: hiddenSize, outputSize: 1, activation: relu)
+        
+        let optimizer = SGD<model.type, Float>(learningRate: 0.02)  // Doesn't compile... :-(
+        let x: Tensor<Float> = [[0, 0], [0, 1], [1, 0], [1, 1]]
+        let y: Tensor<Float> = [0, 1, 1, 0]
+        
+        for _ in 0..<1000 {
+            let (_, 𝛁model) = model.valueWithGradient { model -> Tensor<Float> in
+                let ŷ = model.applied(to: x)
+                return meanSquaredError(predicted: ŷ, expected: y)
+            }
+            optimizer.update(&model.allDifferentiableVariables, along: 𝛁model)
+        }
+        print(model.applied(to: [[0, 0], [0, 1], [1, 0], [1, 1]]))
+    }
+    
+    static var allTests = [
+        ("testSequential", testSequential)
+    ]
+}


### PR DESCRIPTION
It's common to want to combine network layers sequentially. This commit adds
the >> operator that makes it trivial to feed the output of one layer to the
input of the next layer.

Note: this commit also adds in the skeleton for a parallel combinator (e.g.
one that could be easily used to form residual networks) but this triggers a
compiler crash. (TF-244)

Related bugs: TF-235