### PR TITLE
[PRNG] Initialize tensors using Philox PRNG

### DIFF
--- a/Sources/DeepLearning/Initializers.swift
+++ b/Sources/DeepLearning/Initializers.swift
@@ -129,6 +129,21 @@ public extension Tensor where Scalar : BinaryFloatingPoint,
                               Scalar.RawSignificand : FixedWidthInteger {
     /// Performs Glorot uniform initialization for the specified shape, creating a tensor by
     /// randomly sampling scalar values from a uniform distribution between `-limit` and `limit`,
+    /// where limit is `sqrt(6 / (fanIn + fanOut))`.
+    ///
+    /// - Parameters:
+    ///   - shape: The dimensions of the tensor.
+    ///   - generator: Random number generator to use.
+    ///
+    init<G: RandomNumberGenerator>(glorotUniform shape: TensorShape, generator: inout G) {
+        let fanIn = shape[shape.count - 2]
+        let fanOut = shape[shape.count - 1]
+        let minusOneToOne = 2 * Tensor(randomUniform: shape, generator: &generator) - 1
+        self = sqrt(Scalar(6) / Scalar(fanIn + fanOut)) * minusOneToOne
+    }
+
+    /// Performs Glorot uniform initialization for the specified shape, creating a tensor by
+    /// randomly sampling scalar values from a uniform distribution between `-limit` and `limit`,
     /// where limit is `sqrt(6 / (fanIn + fanOut))`, using the default random number generator.
     ///
     /// - Parameters:

--- a/Sources/DeepLearning/Initializers.swift
+++ b/Sources/DeepLearning/Initializers.swift
@@ -45,7 +45,7 @@ public extension Tensor where Scalar == Int32 {
         let dist = UniformIntegerDistribution<Scalar>()
         var scalars: [Scalar] = []
         for _ in 0 ..< shape.contiguousSize {
-            scalars.append(dist.next(using: &ARC4RandomNumberGenerator.global))
+            scalars.append(dist.next(using: &PhiloxRandomNumberGenerator.global))
         }
         self.init(shape: shape, scalars: scalars)
     }
@@ -81,7 +81,7 @@ public extension Tensor where Scalar : BinaryFloatingPoint,
         let dist = UniformFloatingPointDistribution<Scalar>()
         var scalars: [Scalar] = []
         for _ in 0 ..< shape.contiguousSize {
-            scalars.append(dist.next(using: &ARC4RandomNumberGenerator.global))
+            scalars.append(dist.next(using: &PhiloxRandomNumberGenerator.global))
         }
         self.init(shape: shape, scalars: scalars)
     }
@@ -119,7 +119,7 @@ public extension Tensor where Scalar : BinaryFloatingPoint,
         let dist = NormalDistribution<Scalar>(mean: mean, standardDeviation: stddev)
         var scalars: [Scalar] = []
         for _ in 0 ..< shape.contiguousSize {
-            scalars.append(dist.next(using:&ARC4RandomNumberGenerator.global))
+            scalars.append(dist.next(using:&PhiloxRandomNumberGenerator.global))
         }
         self.init(shape: shape, scalars: scalars)
     }

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -91,7 +91,8 @@ public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
 public extension Dense where Scalar.RawSignificand: FixedWidthInteger {
     init(inputSize: Int, outputSize: Int, activation: @escaping Activation) {
         self.init(weight: Tensor(
-                  glorotUniform: [Int32(inputSize), Int32(outputSize)]),
+                      glorotUniform: [Int32(inputSize), Int32(outputSize)]
+                  ),
                   bias: Tensor(zeros: [Int32(outputSize)]),
                   activation: activation)
     }
@@ -103,8 +104,9 @@ public extension Dense where Scalar.RawSignificand: FixedWidthInteger {
         activation: @escaping Activation
     ) {
         self.init(weight: Tensor(
-                  glorotUniform: [Int32(inputSize), Int32(outputSize)],
-                  generator: &generator),
+                      glorotUniform: [Int32(inputSize), Int32(outputSize)],
+                      generator: &generator
+                  ),
                   bias: Tensor(zeros: [Int32(outputSize)]),
                   activation: activation)
     }

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -95,6 +95,19 @@ public extension Dense where Scalar.RawSignificand: FixedWidthInteger {
                   bias: Tensor(zeros: [Int32(outputSize)]),
                   activation: activation)
     }
+
+    init<G: RandomNumberGenerator>(
+        inputSize: Int,
+        outputSize: Int,
+        generator: inout G,
+        activation: @escaping Activation
+    ) {
+        self.init(weight: Tensor(
+                  glorotUniform: [Int32(inputSize), Int32(outputSize)],
+                  generator: &generator),
+                  bias: Tensor(zeros: [Int32(outputSize)]),
+                  activation: activation)
+    }
 }
 
 @_fixed_layout

--- a/Sources/DeepLearning/Random.swift
+++ b/Sources/DeepLearning/Random.swift
@@ -125,6 +125,10 @@ private typealias UInt32x4 = (UInt32, UInt32, UInt32, UInt32)
 /// share state. The random data generated is of high-quality, but is not
 /// suitable for cryptographic applications.
 public struct ThreefryRandomNumberGenerator: SeedableRandomNumberGenerator {
+    public static var global = ThreefryRandomNumberGenerator(
+        uint64Seed: ARC4RandomNumberGenerator.global.next()
+    )
+
     private let rot: (UInt32, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32)
       = (13, 15, 26, 6, 17, 29, 16, 24)
 
@@ -278,6 +282,10 @@ public struct ThreefryRandomNumberGenerator: SeedableRandomNumberGenerator {
 /// share state. The random data generated is of high-quality, but is not
 /// suitable for cryptographic applications.
 public struct PhiloxRandomNumberGenerator: SeedableRandomNumberGenerator {
+    public static var global = PhiloxRandomNumberGenerator(
+        uint64Seed: ARC4RandomNumberGenerator.global.next()
+    )
+
     private var ctr: UInt64 = 0
     private let key: UInt32x2
 

--- a/Sources/DeepLearning/Random.swift
+++ b/Sources/DeepLearning/Random.swift
@@ -126,7 +126,7 @@ private typealias UInt32x4 = (UInt32, UInt32, UInt32, UInt32)
 /// suitable for cryptographic applications.
 public struct ThreefryRandomNumberGenerator: SeedableRandomNumberGenerator {
     public static var global = ThreefryRandomNumberGenerator(
-        uint64Seed: ARC4RandomNumberGenerator.global.next()
+        uint64Seed: UInt64(time(nil))
     )
 
     private let rot: (UInt32, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32)
@@ -283,7 +283,7 @@ public struct ThreefryRandomNumberGenerator: SeedableRandomNumberGenerator {
 /// suitable for cryptographic applications.
 public struct PhiloxRandomNumberGenerator: SeedableRandomNumberGenerator {
     public static var global = PhiloxRandomNumberGenerator(
-        uint64Seed: ARC4RandomNumberGenerator.global.next()
+        uint64Seed: UInt64(time(nil))
     )
 
     private var ctr: UInt64 = 0

--- a/Tests/DeepLearningTests/TrivialModelTests.swift
+++ b/Tests/DeepLearningTests/TrivialModelTests.swift
@@ -18,10 +18,21 @@ import XCTest
 final class TrivialModelTests: XCTestCase {
     func testXOR() {
         struct Classifier: Layer {
+            static var generator = PhiloxRandomNumberGenerator(uint64Seed: 51243124)
             var l1, l2: Dense<Float>
             init(hiddenSize: Int) {
-                l1 = Dense<Float>(inputSize: 2, outputSize: hiddenSize, activation: relu)
-                l2 = Dense<Float>(inputSize: hiddenSize, outputSize: 1, activation: relu)
+                l1 = Dense<Float>(
+                    inputSize: 2,
+                    outputSize: hiddenSize,
+                    generator: &Classifier.generator,
+                    activation: relu
+                )
+                l2 = Dense<Float>(
+                    inputSize: hiddenSize,
+                    outputSize: 1,
+                    generator: &Classifier.generator,
+                    activation: relu
+                )
             }
             @differentiable(wrt: (self, input))
             func applied(to input: Tensor<Float>) -> Tensor<Float> {
@@ -33,7 +44,7 @@ final class TrivialModelTests: XCTestCase {
         var classifier = Classifier(hiddenSize: 4)
         let x: Tensor<Float> = [[0, 0], [0, 1], [1, 0], [1, 1]]
         let y: Tensor<Float> = [[0], [1], [1], [0]]
-        for _ in 0..<1000 {
+        for _ in 0..<2000 {
             let (_, 𝛁model) = classifier.valueWithGradient { classifier -> Tensor<Float> in
                 let ŷ = classifier.applied(to: x)
                 return meanSquaredError(predicted: ŷ, expected: y)


### PR DESCRIPTION
Changes:
- Added global instances of Philox and Threefry PRNGs (seeded using arc4random)
- Tensor initializers now use Philox if no PRNG is specified