### PR TITLE
Aggregate improvements.

### DIFF
--- a/Sources/DeepLearning/Initializers.swift
+++ b/Sources/DeepLearning/Initializers.swift
@@ -51,8 +51,8 @@ public extension Tensor where Scalar == Int32 {
     }
 }
 
-public extension Tensor where Scalar : BinaryFloatingPoint,
-                              Scalar.RawSignificand : FixedWidthInteger {
+public extension Tensor where Scalar: BinaryFloatingPoint,
+                              Scalar.RawSignificand: FixedWidthInteger {
     /// Creates a tensor with the specified shape, randomly sampling scalar values
     /// from a uniform distribution between 0 and 1.
     ///
@@ -125,8 +125,8 @@ public extension Tensor where Scalar : BinaryFloatingPoint,
     }
 }
 
-public extension Tensor where Scalar : BinaryFloatingPoint,
-                              Scalar.RawSignificand : FixedWidthInteger {
+public extension Tensor where Scalar: TensorFlowFloatingPoint,
+                              Scalar.RawSignificand: FixedWidthInteger {
     /// Performs Glorot uniform initialization for the specified shape, creating a tensor by
     /// randomly sampling scalar values from a uniform distribution between `-limit` and `limit`,
     /// where limit is `sqrt(6 / (fanIn + fanOut))`.
@@ -142,7 +142,7 @@ public extension Tensor where Scalar : BinaryFloatingPoint,
         self = sqrt(Scalar(6) / Scalar(fanIn + fanOut)) * minusOneToOne
     }
 
-    /// Performs Glorot uniform initialization for the specified shape, creating a tensor by
+    /// Creates a tensor by performing Glorot uniform initialization for the specified shape,
     /// randomly sampling scalar values from a uniform distribution between `-limit` and `limit`,
     /// where limit is `sqrt(6 / (fanIn + fanOut))`, using the default random number generator.
     ///
@@ -150,9 +150,6 @@ public extension Tensor where Scalar : BinaryFloatingPoint,
     ///   - shape: The dimensions of the tensor.
     ///
     init(glorotUniform shape: TensorShape) {
-        let fanIn = shape[shape.count - 2]
-        let fanOut = shape[shape.count - 1]
-        let minusOneToOne = 2 * Tensor(randomUniform: shape) - 1
-        self = sqrt(Scalar(6) / Scalar(fanIn + fanOut)) * minusOneToOne
+        self.init(glorotUniform: shape, generator: &PhiloxRandomNumberGenerator.global)
     }
 }

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -16,19 +16,28 @@
 @_exported import TensorFlow
 #endif
 
+/// A value that indicates either a training phase or an inference phase for a layer.
 public enum LearningPhase {
     case training
     case inference
 }
 
+/// A context that stores contextual information used for the application of layers.
 open class Context {
+    /// The current learning phase.
     public var learningPhase: LearningPhase
 
-    public init(learningPhase: LearningPhase) {
+    /// Creates a context.
+    ///
+    /// - Parameter learningPhase: The current learning phase.
+    public required init(learningPhase: LearningPhase) {
         self.learningPhase = learningPhase
     }
 
-    public init(_ other: Context) {
+    /// Creates a context by copying all information from an existing context.
+    ///
+    /// - Parameter context: The existing context to copy from.
+    public required init(_ other: Context) {
         self.learningPhase = other.learningPhase
     }
 }

--- a/Sources/DeepLearning/Operators.swift
+++ b/Sources/DeepLearning/Operators.swift
@@ -16,8 +16,12 @@
 import TensorFlow
 #endif
 
-// `round` Tensor Float or Double values to the to closest integral values with greater magnitude
-// This is a manual definition.
-func round<T : BinaryFloatingPoint>(_ t: Tensor<T>) -> Tensor<T> {
-    return Raw.round(t)
+// Rounds the values of a tensor to the nearest integer, element-wise.
+func round<Scalar: BinaryFloatingPoint>(_ x: Tensor<Scalar>) -> Tensor<Scalar> {
+    return Raw.round(x)
+}
+
+// Return a tensor with the same shape and contents as input.
+func identity<Scalar>(_ x: Tensor<Scalar>) -> Tensor<Scalar> {
+    return x
 }

--- a/Sources/DeepLearning/Random.swift
+++ b/Sources/DeepLearning/Random.swift
@@ -18,9 +18,9 @@ import Darwin
 import Glibc
 #endif
 
-//===----------------------------------------------------------------------===//
+//===------------------------------------------------------------------------------------------===//
 // Random number generators
-//===----------------------------------------------------------------------===//
+//===------------------------------------------------------------------------------------------===//
 
 /// A type that provides seedable deterministic pseudo-random data.
 ///
@@ -404,12 +404,17 @@ private func makeUInt64Pair(_ vector: UInt32x4) -> (UInt64, UInt64) {
     return (a, b)
 }
 
-//===----------------------------------------------------------------------===//
+//===------------------------------------------------------------------------------------------===//
 // Distributions
-//===----------------------------------------------------------------------===//
+//===------------------------------------------------------------------------------------------===//
+
+public protocol RandomDistribution {
+  associatedtype Sample
+  func next<G: RandomNumberGenerator>(using generator: inout G) -> Sample
+}
 
 @_fixed_layout
-public final class UniformIntegerDistribution<T: FixedWidthInteger> {
+public final class UniformIntegerDistribution<T: FixedWidthInteger>: RandomDistribution {
     public let lowerBound: T
     public let upperBound: T
 
@@ -424,7 +429,7 @@ public final class UniformIntegerDistribution<T: FixedWidthInteger> {
 }
 
 @_fixed_layout
-public final class UniformFloatingPointDistribution<T : BinaryFloatingPoint>
+public final class UniformFloatingPointDistribution<T : BinaryFloatingPoint>: RandomDistribution
   where T.RawSignificand : FixedWidthInteger {
     public let lowerBound: T
     public let upperBound: T
@@ -440,7 +445,7 @@ public final class UniformFloatingPointDistribution<T : BinaryFloatingPoint>
 }
 
 @_fixed_layout
-public final class NormalDistribution<T : BinaryFloatingPoint>
+public final class NormalDistribution<T : BinaryFloatingPoint>: RandomDistribution
   where T.RawSignificand : FixedWidthInteger {
     public let mean: T
     public let standardDeviation: T
@@ -464,7 +469,7 @@ public final class NormalDistribution<T : BinaryFloatingPoint>
 }
 
 @_fixed_layout
-public final class BetaDistribution {
+public final class BetaDistribution: RandomDistribution {
     public let alpha: Float
     public let beta: Float
     private let uniformDistribution = UniformFloatingPointDistribution<Float>()


### PR DESCRIPTION
1. Introduce a `RandomDistribution` protocol that unifies all random distribution classes in the library.
2. Clean up tensor initializers to reduce code duplication.
3. Add `identity(_:)` function.
4. Make two `Context` initializers be `required` since they can be subclassed.
5. Enhance `Layer` methods and make backward-compatible. 
  * Introduce `inferring(from:)`, which is equivalent to `applied(to:in:)` with a default inference context.
  * Add back `applied(to:)` that simply calls `inferring(from:)`. Add a deprecation warning that tells people to switch to either `applied(to:in:)` or `inferring(from:)`.
  * Rename `Layer.valueWithPullback(at:in:)` to `appliedForBackpropagation(to:in:)` to ease the learning curve.
6. Improve documentation on everything.