### PR TITLE
Execution context

### DIFF
--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -30,22 +30,6 @@ open class ExecutionContext {
     }
 }
 
-/// TODO: move this to wherever TensorShape is defined
-public extension TensorShape {
-    func flattened(axis: Int = 0) -> TensorShape {
-        precondition(axis < self.count)
-        var dims: [Int32]
-        switch axis {
-        case 0: dims = [self.indices.reduce(1, *)]
-        case 1: dims = [self[0], self.indices.suffix(axis).reduce(1, *)]
-        default: dims =
-            [Int32](self.indices.prefix(upTo: Int32(axis))) +
-            [self.indices.suffix(axis).reduce(1, *)]
-        }
-        return TensorShape(dims)
-    }
-}
-
 /// A neural network layer.
 ///
 /// Types that conform to `Layer` represent functions that map inputs to

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -16,10 +16,10 @@
 @_exported import TensorFlow
 #endif
 
-/// Specifies whether applied(in:to: should perform inference or training
+/// Specifies whether `applied(in:to:` should perform inference or training
 public enum ExecutionMode { case inference, training }
 
-/// The ExecutionContext is a base class used to configure
+/// The `ExecutionContext` is a base class used to configure
 /// model resources for execution in different environments such as
 /// CPU, GPU, Google Cloud, AWS, Azure, etc..
 open class ExecutionContext {

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -66,17 +66,6 @@ public protocol Layer: Differentiable & KeyPathIterable
     func applied(in context: ExecutionContext, to input: Input) -> Output
 }
 
-public extension Layer {
-    func valueWithPullback(at input: Input)
-        -> (output: Output,
-        pullback: (Output.CotangentVector)
-        -> (layerGradient: CotangentVector, inputGradient: Input.CotangentVector)) {
-            let (out, pullback) = _valueWithPullback(at: self, input,
-                                                     in: Self.applied(to:))
-            return (out, pullback)
-    }
-}
-
 /// A mutable, shareable reference to a tensor
 public final class Parameter<T: TensorFlowScalar> {
     public var value: Tensor<T>

--- a/Tests/DeepLearningTests/TrivialModelTests.swift
+++ b/Tests/DeepLearningTests/TrivialModelTests.swift
@@ -30,18 +30,19 @@ final class TrivialModelTests: XCTestCase {
                 return l2.applied(in: context, to: h1)
             }
         }
+        let context = ExecutionContext(executionMode: .training)
         let optimizer = SGD<Classifier, Float>(learningRate: 0.02)
         var classifier = Classifier(hiddenSize: 4)
         let x: Tensor<Float> = [[0, 0], [0, 1], [1, 0], [1, 1]]
         let y: Tensor<Float> = [0, 1, 1, 0]
         for _ in 0..<1000 {
             let (_, 𝛁model) = classifier.valueWithGradient { classifier -> Tensor<Float> in
-                let ŷ = classifier.applied(to: x)
+                let ŷ = classifier.applied(in: context, to: x)
                 return meanSquaredError(predicted: ŷ, expected: y)
             }
             optimizer.update(&classifier.allDifferentiableVariables, along: 𝛁model)
         }
-        print(classifier.applied(to: [[0, 0], [0, 1], [1, 0], [1, 1]]))
+        print(classifier.applied(in: context, to: [[0, 0], [0, 1], [1, 0], [1, 1]]))
     }
 
     static var allTests = [

--- a/Tests/DeepLearningTests/TrivialModelTests.swift
+++ b/Tests/DeepLearningTests/TrivialModelTests.swift
@@ -24,9 +24,10 @@ final class TrivialModelTests: XCTestCase {
                 l2 = Dense<Float>(inputSize: hiddenSize, outputSize: 1, activation: relu)
             }
             @differentiable(wrt: (self, input))
-            func applied(to input: Tensor<Float>) -> Tensor<Float> {
-                let h1 = l1.applied(to: input)
-                return l2.applied(to: h1)
+            func applied(in context: ExecutionContext,
+                         to input: Tensor<Float>) -> Tensor<Float> {
+                let h1 = l1.applied(in: context, to: input)
+                return l2.applied(in: context, to: h1)
             }
         }
         let optimizer = SGD<Classifier, Float>(learningRate: 0.02)


### PR DESCRIPTION
With the available time, I went with more code less talk. I believe this solution meets the desired goals and is pleasing to use.

- The execution context is fully extensible
- The context is passed as a parameter to the `applied(in:to:` function replacing the use of `LearningPhaseIndicator`
- The context is not held by the model, so models will now copy correctly without side effects
- The use is clean and nicely readable

Example use in a composite layer
```swift
public func applied(in context: ExecutionContext,
                    to input: Tensor<Float>) -> Tensor<Float> {
  let h0 = conv1.applied(in: context, to: input)
  let h1 = maxPool1.applied(in: context, to: h0)
  let bn = batchNorm.applied(in: context, to: h1)
  let h2 = conv2.applied(in: context, to: bn)
  let h3 = maxPool2.applied(in: context, to: h2)
  let dense1InputShape = Tensor<Int32>([h3.shape[0], 800])
  let h4 = dense1.applied(in: context, to: h3.reshaped(toShape: dense1InputShape))
  return dense2.applied(in: context, to: h4)
}
```
Selection within an operator such as `BatchNorm` is clear 
```swift
public func applied(in context: ExecutionContext,
                    to input: Tensor<Scalar>) -> Tensor<Scalar> {
    if context.executionMode == .training {
        return applyTraining(in: context, to: input)
    } else {
        return applyInference(in: context, to: input)
    }
}
```
Note: The apple/swift repo for the TensorFlowRuntime tests will need to be updated as well, once these changes are agreed on.

