### PR TITLE
Add default (identity)  activations to the Dense layer initializers.

### DIFF
--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -137,7 +137,7 @@ public extension Dense where Scalar.RawSignificand: FixedWidthInteger {
     init<G: RandomNumberGenerator>(
         inputSize: Int,
         outputSize: Int,
-        activation: @escaping Activation,
+        activation: @escaping Activation = identity,
         generator: inout G
     ) {
         self.init(weight: Tensor(glorotUniform: [Int32(inputSize), Int32(outputSize)],
@@ -146,7 +146,7 @@ public extension Dense where Scalar.RawSignificand: FixedWidthInteger {
                   activation: activation)
     }
 
-    init(inputSize: Int, outputSize: Int, activation: @escaping Activation) {
+    init(inputSize: Int, outputSize: Int, activation: @escaping Activation = identity) {
       self.init(inputSize: inputSize, outputSize: outputSize, activation: activation,
                 generator: &PhiloxRandomNumberGenerator.global)
     }


### PR DESCRIPTION
This change follows along with the defaulted values for Conv and other layers.