### PR TITLE
Reduce explicit types required when instantiating the SGD optimizer.

### DIFF
--- a/Sources/DeepLearning/Optimizer.swift
+++ b/Sources/DeepLearning/Optimizer.swift
@@ -40,7 +40,7 @@ public class Adam<Model: Layer, Scalar: TensorFlowFloatingPoint>: Optimizer
         beta2: Scalar = 0.999,
         epsilon: Scalar = 1e-8,
         decay: Scalar = 0,
-        modelType: Model.Type = Model.self,
+        for _: __shared Model,
         scalarType: Scalar.Type = Scalar.self
     ) {
         precondition(learningRate >= 0, "Learning rate must be non-negative")
@@ -88,7 +88,7 @@ public class RMSProp<Model: Layer, Scalar: TensorFlowFloatingPoint>: Optimizer
         rho: Scalar = 0.9,
         epsilon: Scalar = 1e-8,
         decay: Scalar = 0,
-        modelType: Model.Type = Model.self,
+        for _: __shared Model,
         scalarType: Scalar.Type = Scalar.self
     ) {
         precondition(learningRate >= 0, "Learning rate must be non-negative")
@@ -129,7 +129,8 @@ public class SGD<Model: Layer, Scalar: TensorFlowFloatingPoint>: Optimizer
         momentum: Scalar = 0,
         decay: Scalar = 0,
         nesterov: Bool = false,
-        for _: __shared Model
+        for _: __shared Model,
+        scalarType: Scalar.Type = Scalar.self
     ) {
         precondition(learningRate >= 0, "Learning rate must be non-negative")
         precondition(momentum >= 0, "Momentum must be non-negative")

--- a/Sources/DeepLearning/Optimizer.swift
+++ b/Sources/DeepLearning/Optimizer.swift
@@ -35,12 +35,12 @@ public class Adam<Model: Layer, Scalar: TensorFlowFloatingPoint>: Optimizer
     public let decay: Scalar
 
     public init(
+        for _: __shared Model,
         learningRate: Scalar = 1e-3,
         beta1: Scalar = 0.9,
         beta2: Scalar = 0.999,
         epsilon: Scalar = 1e-8,
         decay: Scalar = 0,
-        for _: __shared Model,
         scalarType: Scalar.Type = Scalar.self
     ) {
         precondition(learningRate >= 0, "Learning rate must be non-negative")
@@ -84,11 +84,11 @@ public class RMSProp<Model: Layer, Scalar: TensorFlowFloatingPoint>: Optimizer
     public let decay: Scalar
 
     public init(
+        for _: __shared Model,
         learningRate: Scalar = 0.001,
         rho: Scalar = 0.9,
         epsilon: Scalar = 1e-8,
         decay: Scalar = 0,
-        for _: __shared Model,
         scalarType: Scalar.Type = Scalar.self
     ) {
         precondition(learningRate >= 0, "Learning rate must be non-negative")
@@ -125,11 +125,11 @@ public class SGD<Model: Layer, Scalar: TensorFlowFloatingPoint>: Optimizer
     public let nesterov: Bool
 
     public init(
+        for _: __shared Model,
         learningRate: Scalar = 0.01,
         momentum: Scalar = 0,
         decay: Scalar = 0,
         nesterov: Bool = false,
-        for _: __shared Model,
         scalarType: Scalar.Type = Scalar.self
     ) {
         precondition(learningRate >= 0, "Learning rate must be non-negative")

--- a/Sources/DeepLearning/Optimizer.swift
+++ b/Sources/DeepLearning/Optimizer.swift
@@ -41,7 +41,7 @@ public class Adam<Model: Layer, Scalar: TensorFlowFloatingPoint>: Optimizer
         beta2: Scalar = 0.999,
         epsilon: Scalar = 1e-8,
         decay: Scalar = 0,
-        scalarType: Scalar.Type = Scalar.self
+        scalarType: Scalar.Type
     ) {
         precondition(learningRate >= 0, "Learning rate must be non-negative")
         precondition(0 <= beta1 && beta1 <= 1, "Beta parameter must be between 0 and 1")
@@ -89,7 +89,7 @@ public class RMSProp<Model: Layer, Scalar: TensorFlowFloatingPoint>: Optimizer
         rho: Scalar = 0.9,
         epsilon: Scalar = 1e-8,
         decay: Scalar = 0,
-        scalarType: Scalar.Type = Scalar.self
+        scalarType: Scalar.Type
     ) {
         precondition(learningRate >= 0, "Learning rate must be non-negative")
         precondition(rho >= 0, "Rho must be non-negative")
@@ -130,7 +130,7 @@ public class SGD<Model: Layer, Scalar: TensorFlowFloatingPoint>: Optimizer
         momentum: Scalar = 0,
         decay: Scalar = 0,
         nesterov: Bool = false,
-        scalarType: Scalar.Type = Scalar.self
+        scalarType: Scalar.Type
     ) {
         precondition(learningRate >= 0, "Learning rate must be non-negative")
         precondition(momentum >= 0, "Momentum must be non-negative")
@@ -171,7 +171,7 @@ public class RiemannSGD<Model: Layer, Scalar: FloatingPoint>: Optimizer
     public init(
         learningRate: Scalar,
         modelType: Model.Type = Model.self,
-        scalarType: Scalar.Type = Scalar.self
+        scalarType: Scalar.Type
     ) {
         self.learningRate = learningRate
     }

--- a/Sources/DeepLearning/Optimizer.swift
+++ b/Sources/DeepLearning/Optimizer.swift
@@ -129,7 +129,7 @@ public class SGD<Model: Layer, Scalar: TensorFlowFloatingPoint>: Optimizer
         momentum: Scalar = 0,
         decay: Scalar = 0,
         nesterov: Bool = false,
-        for model: Model
+        for _: __shared Model
     ) {
         precondition(learningRate >= 0, "Learning rate must be non-negative")
         precondition(momentum >= 0, "Momentum must be non-negative")

--- a/Sources/DeepLearning/Optimizer.swift
+++ b/Sources/DeepLearning/Optimizer.swift
@@ -129,8 +129,7 @@ public class SGD<Model: Layer, Scalar: TensorFlowFloatingPoint>: Optimizer
         momentum: Scalar = 0,
         decay: Scalar = 0,
         nesterov: Bool = false,
-        modelType: Model.Type = Model.self,
-        scalarType: Scalar.Type = Scalar.self
+        for model: Model
     ) {
         precondition(learningRate >= 0, "Learning rate must be non-negative")
         precondition(momentum >= 0, "Momentum must be non-negative")

--- a/Tests/DeepLearningTests/SequentialTests.swift
+++ b/Tests/DeepLearningTests/SequentialTests.swift
@@ -27,7 +27,7 @@ final class SequentialTests: XCTestCase {
             }
         }
         var model = Model()
-        let optimizer = SGD(learningRate: 0.02, for: model)
+        let optimizer = SGD(for: model, learningRate: 0.02, scalarType: Float.self)
         let x: Tensor<Float> = [[0, 0], [0, 1], [1, 0], [1, 1]]
         let y: Tensor<Float> = [0, 1, 1, 0]
         let context = Context(learningPhase: .training)

--- a/Tests/DeepLearningTests/SequentialTests.swift
+++ b/Tests/DeepLearningTests/SequentialTests.swift
@@ -27,7 +27,7 @@ final class SequentialTests: XCTestCase {
             }
         }
         var model = Model()
-        let optimizer = SGD(learningRate: 0.02, modelType: type(of: model), scalarType: Float.self)
+        let optimizer = SGD(learningRate: 0.02, for: model)
         let x: Tensor<Float> = [[0, 0], [0, 1], [1, 0], [1, 1]]
         let y: Tensor<Float> = [0, 1, 1, 0]
         let context = Context(learningPhase: .training)

--- a/Tests/DeepLearningTests/TrivialModelTests.swift
+++ b/Tests/DeepLearningTests/TrivialModelTests.swift
@@ -41,7 +41,7 @@ final class TrivialModelTests: XCTestCase {
             }
         }
         var classifier = Classifier(hiddenSize: 4)
-        let optimizer = SGD(learningRate: 0.02, for: classifier, scalarType: Float.self)
+        let optimizer = SGD(for: classifier, learningRate: 0.02, scalarType: Float.self)
         let x: Tensor<Float> = [[0, 0], [0, 1], [1, 0], [1, 1]]
         let y: Tensor<Float> = [[0], [1], [1], [0]]
 

--- a/Tests/DeepLearningTests/TrivialModelTests.swift
+++ b/Tests/DeepLearningTests/TrivialModelTests.swift
@@ -41,7 +41,7 @@ final class TrivialModelTests: XCTestCase {
             }
         }
         var classifier = Classifier(hiddenSize: 4)
-        let optimizer = SGD(learningRate: 0.02, for: classifier)
+        let optimizer = SGD(learningRate: 0.02, for: classifier, scalarType: Float.self)
         let x: Tensor<Float> = [[0, 0], [0, 1], [1, 0], [1, 1]]
         let y: Tensor<Float> = [[0], [1], [1], [0]]
 

--- a/Tests/DeepLearningTests/TrivialModelTests.swift
+++ b/Tests/DeepLearningTests/TrivialModelTests.swift
@@ -40,8 +40,8 @@ final class TrivialModelTests: XCTestCase {
                 return l2.applied(to: h1, in: context)
             }
         }
-        let optimizer = SGD<Classifier, Float>(learningRate: 0.02)
         var classifier = Classifier(hiddenSize: 4)
+        let optimizer = SGD(learningRate: 0.02, for: classifier)
         let x: Tensor<Float> = [[0, 0], [0, 1], [1, 0], [1, 1]]
         let y: Tensor<Float> = [[0], [1], [1], [0]]
 


### PR DESCRIPTION
Previously, in order to instantiate the Optimizer, you had to call
`type(of: model)` and pass that into the Optimizer constructor in order to get
type inference to pick the right type for `Model`. This could be a little
confusing for new users.

This commit proposes an alternate way to write this:

```swift
let optimizer = SGD(learningRate: 0.01, for: model)
```

The above formulation is clear and readable. It avoids any unnecessary typing
of types, and should be generalizable to the other optimizers. (This is left as
an exercise for the reader. :-D)

We rely on the Swift optimizer to do the right thing such that only a reference
to the model is passed to the `SGD.init` call so that we don't pay for the cost
of a full model copy (which could eventually be very expensive). This is deemed
to be a reasonably safe assumption, especially given the ABI standardization in
Swift 5.