### PR TITLE
Switch to reshaped(to:) and make more Keras-like

### DIFF
--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -621,18 +621,19 @@ public struct Flatten<Scalar: TensorFlowFloatingPoint>: Layer {
 
 @_fixed_layout
 public struct Reshape<Scalar: TensorFlowFloatingPoint>: Layer {
-    @noDerivative public let shape: Tensor<Int32>
+    @noDerivative public let shape: [Int32]
     
-    public init(shape: Tensor<Int32>) {
+    public init(shape: [Int32]) {
         self.shape = shape
     }
     
     public init(_ shape: TensorShape) {
-        self.init(shape: Tensor(shape.dimensions))
+        self.init(shape: shape.dimensions)
     }
     
     @differentiable
     public func applied(to input: Tensor<Scalar>, in _: Context) -> Tensor<Scalar> {
-        return input.reshaped(toShape: shape)
+        let batchSize = [input.shape[0]]
+        return input.reshaped(to: batchSize + shape)
     }
 }


### PR DESCRIPTION
There was a small issue with my last implementation - you'd need to specify the batch size in the initializer.