### PR TITLE
Change implementation of softmax cross entropy loss 

### DIFF
--- a/Sources/DeepLearning/Loss.swift
+++ b/Sources/DeepLearning/Loss.swift
@@ -66,7 +66,7 @@ func _vjpSoftmaxCrossEntropy<Scalar: TensorFlowFloatingPoint>(
 ) -> (Tensor<Scalar>, (Tensor<Scalar>) -> Tensor<Scalar>) {
     let (loss, grad) = Raw.softmaxCrossEntropyWithLogits(features: logits, labels: oneHotLabels)
     let batchSize = Tensor<Scalar>(logits.shapeTensor[0])
-    return (loss.mean(), { v in (v / batchSize) * grad })
+    return (loss.mean(), { v in v / batchSize * grad })
 }
 
 /// Computes the sigmoid cross entropy (binary cross entropy) between logits and labels.

--- a/Tests/DeepLearningTests/LossTests.swift
+++ b/Tests/DeepLearningTests/LossTests.swift
@@ -1,0 +1,72 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+@testable import DeepLearning
+
+final class LossTests: XCTestCase {
+    func testSoftmaxCrossEntropyWithOneHotLabelsLoss() {
+        let logits = Tensor<Float>(shape: [2, 4], scalars: [1, 2, 3, 4, 5, 6, 7, 8])
+        let labels = Tensor<Float>(
+            shape: [2, 4],
+            scalars: [0.1, 0.2, 0.3, 0.4, 0.4, 0.3, 0.2, 0.1])
+
+        let loss = softmaxCrossEntropy(logits: logits, oneHotLabels: labels)
+        // Loss for two rows are 1.44019 and 2.44019 respectively.
+        let expectedLoss: Float = (1.44019 + 2.44019) / 2.0
+        assertAllClose(expected: Tensor(expectedLoss), got: loss)
+    }
+
+    func testSoftmaxCrossEntropyWithOneHotLabelsGrad() {
+        let logits = Tensor<Float>(shape: [2, 4], scalars: [1, 2, 3, 4, 5, 6, 7, 8])
+        let labels = Tensor<Float>(
+            shape: [2, 4],
+            scalars: [0.1, 0.2, 0.3, 0.4, 0.4, 0.3, 0.2, 0.1])
+
+        // For the logits and labels above, the gradients below are the golden values. To calcuate
+        // them by hand, you can do
+        //
+        //  D Loss / D logits_i = p_i - labels_i
+        //
+        //  where p_i is softmax(logits_i).
+        let expectedGradientsBeforeMean = Tensor<Float>(
+            shape: [2, 4],
+            scalars: [-0.067941, -0.112856, -0.063117, 0.243914,
+                      -0.367941, -0.212856, 0.036883, 0.543914])
+
+        // As the loss is mean loss, we should scale the golden loss numbers.
+        let expectedGradients = expectedGradientsBeforeMean / Float(logits.shape[0])
+        let gradients = gradient(
+            at: logits,
+            in: { softmaxCrossEntropy(logits: $0, oneHotLabels: labels) })
+        assertAllClose(expected: expectedGradients, got: gradients)
+    }
+
+    func assertAllClose(expected a: Tensor<Float>, got b: Tensor<Float>, tol: Float = 1e-6) {
+        XCTAssertEqual(a.shape, b.shape)
+        for (index, elementInA) in a.scalars.enumerated() {
+            let elementInB = b.scalars[index]
+            XCTAssertTrue(
+                abs(elementInA - elementInB) < tol,
+                "Found difference at \(index), expected: \(elementInA), got: \(elementInB).")
+        }
+    }
+
+    static var allTests = [
+        ("testSoftmaxCrossEntropyWithOneHotLabelsLoss",
+         testSoftmaxCrossEntropyWithOneHotLabelsLoss),
+        ("testSoftmaxCrossEntropyWithOneHotLabelsGrad",
+         testSoftmaxCrossEntropyWithOneHotLabelsGrad),
+    ]
+}

--- a/Tests/DeepLearningTests/LossTests.swift
+++ b/Tests/DeepLearningTests/LossTests.swift
@@ -53,7 +53,7 @@ final class LossTests: XCTestCase {
         assertAllClose(expected: expectedGradients, got: gradients)
     }
 
-    func assertAllClose(expected a: Tensor<Float>, got b: Tensor<Float>, tol: Float = 1e-6) {
+    func assertAllClose(expected: Tensor<Float>, actual: Tensor<Float>, tolerance: Float = 1e-6) {
         XCTAssertEqual(a.shape, b.shape)
         for (index, elementInA) in a.scalars.enumerated() {
             let elementInB = b.scalars[index]

--- a/Tests/DeepLearningTests/LossTests.swift
+++ b/Tests/DeepLearningTests/LossTests.swift
@@ -25,7 +25,7 @@ final class LossTests: XCTestCase {
         let loss = softmaxCrossEntropy(logits: logits, oneHotLabels: labels)
         // Loss for two rows are 1.44019 and 2.44019 respectively.
         let expectedLoss: Float = (1.44019 + 2.44019) / 2.0
-        assertAllClose(expected: Tensor(expectedLoss), got: loss)
+        assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
     }
 
     func testSoftmaxCrossEntropyWithOneHotLabelsGrad() {
@@ -50,16 +50,21 @@ final class LossTests: XCTestCase {
         let gradients = gradient(
             at: logits,
             in: { softmaxCrossEntropy(logits: $0, oneHotLabels: labels) })
-        assertAllClose(expected: expectedGradients, got: gradients)
+        assertElementsEqual(expected: expectedGradients, actual: gradients)
     }
 
-    func assertAllClose(expected: Tensor<Float>, actual: Tensor<Float>, tolerance: Float = 1e-6) {
-        XCTAssertEqual(a.shape, b.shape)
-        for (index, elementInA) in a.scalars.enumerated() {
-            let elementInB = b.scalars[index]
+    func assertElementsEqual(
+        expected: Tensor<Float>,
+        actual: Tensor<Float>,
+        tolerance: Float = 1e-6
+    ) {
+        XCTAssertEqual(expected.shape, actual.shape, "Shape mismatch.")
+        for (index, expectedElement) in expected.scalars.enumerated() {
+            let actualElement = actual.scalars[index]
             XCTAssertLessThan(
-                abs(elementInA - elementInB), tol,
-                "Found difference at \(index), expected: \(elementInA), got: \(elementInB).")
+                abs(expectedElement - actualElement), tolerance,
+                "Found difference at \(index), " +
+                "expected: \(expectedElement), actual: \(actualElement).")
         }
     }
 

--- a/Tests/DeepLearningTests/LossTests.swift
+++ b/Tests/DeepLearningTests/LossTests.swift
@@ -57,8 +57,8 @@ final class LossTests: XCTestCase {
         XCTAssertEqual(a.shape, b.shape)
         for (index, elementInA) in a.scalars.enumerated() {
             let elementInB = b.scalars[index]
-            XCTAssertTrue(
-                abs(elementInA - elementInB) < tol,
+            XCTAssertLessThan(
+                abs(elementInA - elementInB), tol,
                 "Found difference at \(index), expected: \(elementInA), got: \(elementInB).")
         }
     }

--- a/Tests/DeepLearningTests/XCTestManifests.swift
+++ b/Tests/DeepLearningTests/XCTestManifests.swift
@@ -17,6 +17,7 @@ import XCTest
 #if !os(macOS)
 public func allTests() -> [XCTestCaseEntry] {
     return [
+        testCase(LossTests.allTests),
         testCase(PRNGTests.allTests),
         testCase(TrivialModelTests.allTests),
         testCase(SequentialTests.allTests),


### PR DESCRIPTION
This PR changed two things. 

1. Used a numerical stable implementation for softmax cross entropy.
2. Changed the gradient wr.t. Now the loss only generates the gradient w.r.t. logits. This is consistent with its variant (Int label version).

In addition, added numerical tests to verify the correctness. 