### PR TITLE
Improved mean squared error. 

### DIFF
--- a/Sources/DeepLearning/Loss.swift
+++ b/Sources/DeepLearning/Loss.swift
@@ -52,20 +52,21 @@ func _vjpSoftmaxCrossEntropy<Scalar: TensorFlowFloatingPoint>(
 /// Computes the softmax cross entropy (categorical cross entropy) between logits and labels.
 ///
 /// - Parameters:
-///   - logits: One-hot encoded outputs from a neural network.
-///   - oneHotLabels: One-hot encoded values that correspond to the correct output.
+///   - logits: Unscaled log probabilities from a neural network.
+///   - probabilities: Probability values that correspond to the correct output. Each row must be a
+///                    valid probability distribution.
 @differentiable(wrt: logits, vjp: _vjpSoftmaxCrossEntropy)
 public func softmaxCrossEntropy<Scalar: TensorFlowFloatingPoint>(
-    logits: Tensor<Scalar>, oneHotLabels: Tensor<Scalar>
+    logits: Tensor<Scalar>, probabilities: Tensor<Scalar>
 ) -> Tensor<Scalar> {
-    return Raw.softmaxCrossEntropyWithLogits(features: logits, labels: oneHotLabels).loss.mean()
+    return Raw.softmaxCrossEntropyWithLogits(features: logits, labels: probabilities).loss.mean()
 }
 
 @usableFromInline
 func _vjpSoftmaxCrossEntropy<Scalar: TensorFlowFloatingPoint>(
-    logits: Tensor<Scalar>, oneHotLabels: Tensor<Scalar>
+    logits: Tensor<Scalar>, probabilities: Tensor<Scalar>
 ) -> (Tensor<Scalar>, (Tensor<Scalar>) -> Tensor<Scalar>) {
-    let (loss, grad) = Raw.softmaxCrossEntropyWithLogits(features: logits, labels: oneHotLabels)
+    let (loss, grad) = Raw.softmaxCrossEntropyWithLogits(features: logits, labels: probabilities)
     let batchSize = Tensor<Scalar>(logits.shapeTensor[0])
     return (loss.mean(), { v in v / batchSize * grad })
 }

--- a/Sources/DeepLearning/Loss.swift
+++ b/Sources/DeepLearning/Loss.swift
@@ -20,7 +20,7 @@ import TensorFlow
 ///
 /// - Parameters:
 ///   - predicted: Predicted outputs from a neural network.
-///   - labels: Expected values, i.e., targets, that correspond to the correct output.
+///   - labels: Expected values, i.e. targets, that correspond to the correct output.
 @differentiable(wrt: predicted)
 public func meanSquaredError<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>, expected: Tensor<Scalar>

--- a/Sources/DeepLearning/Loss.swift
+++ b/Sources/DeepLearning/Loss.swift
@@ -16,12 +16,12 @@
 import TensorFlow
 #endif
 
-/// Computes the mean squared error between logits and labels.
+/// Computes the mean squared error between preditions and labels.
 ///
 /// - Parameters:
-///   - logits: One-hot encoded outputs from a neural network.
-///   - labels: One-hot encoded values that correspond to the correct output.
-@differentiable
+///   - predicted: Predicted outputs from a neural network.
+///   - labels: Expected values, i.e., targets, that correspond to the correct output.
+@differentiable(wrt: predicted)
 public func meanSquaredError<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>, expected: Tensor<Scalar>
 ) -> Tensor<Scalar> {

--- a/Sources/DeepLearning/Loss.swift
+++ b/Sources/DeepLearning/Loss.swift
@@ -16,7 +16,7 @@
 import TensorFlow
 #endif
 
-/// Computes the mean squared error between preditions and labels.
+/// Computes the mean squared error between predictions and labels.
 ///
 /// - Parameters:
 ///   - predicted: Predicted outputs from a neural network.

--- a/Tests/DeepLearningTests/LossTests.swift
+++ b/Tests/DeepLearningTests/LossTests.swift
@@ -46,19 +46,19 @@ final class LossTests: XCTestCase {
         assertElementsEqual(expected: expectedGradients, actual: gradients)
     }
 
-    func testSoftmaxCrossEntropyWithOneHotLabelsLoss() {
+    func testSoftmaxCrossEntropyWithProbabilitiesLoss() {
         let logits = Tensor<Float>(shape: [2, 4], scalars: [1, 2, 3, 4, 5, 6, 7, 8])
         let labels = Tensor<Float>(
             shape: [2, 4],
             scalars: [0.1, 0.2, 0.3, 0.4, 0.4, 0.3, 0.2, 0.1])
 
-        let loss = softmaxCrossEntropy(logits: logits, oneHotLabels: labels)
+        let loss = softmaxCrossEntropy(logits: logits, probabilities: labels)
         // Loss for two rows are 1.44019 and 2.44019 respectively.
         let expectedLoss: Float = (1.44019 + 2.44019) / 2.0
         assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
     }
 
-    func testSoftmaxCrossEntropyWithOneHotLabelsGrad() {
+    func testSoftmaxCrossEntropyWithProbabilitiesGrad() {
         let logits = Tensor<Float>(shape: [2, 4], scalars: [1, 2, 3, 4, 5, 6, 7, 8])
         let labels = Tensor<Float>(
             shape: [2, 4],
@@ -79,7 +79,7 @@ final class LossTests: XCTestCase {
         let expectedGradients = expectedGradientsBeforeMean / Float(logits.shape[0])
         let gradients = gradient(
             at: logits,
-            in: { softmaxCrossEntropy(logits: $0, oneHotLabels: labels) })
+            in: { softmaxCrossEntropy(logits: $0, probabilities: labels) })
         assertElementsEqual(expected: expectedGradients, actual: gradients)
     }
 
@@ -101,9 +101,9 @@ final class LossTests: XCTestCase {
     static var allTests = [
         ("testMeanSquaredErrorLoss", testMeanSquaredErrorLoss),
         ("testMeanSquaredErrorGrad", testMeanSquaredErrorGrad),
-        ("testSoftmaxCrossEntropyWithOneHotLabelsLoss",
-         testSoftmaxCrossEntropyWithOneHotLabelsLoss),
-        ("testSoftmaxCrossEntropyWithOneHotLabelsGrad",
-         testSoftmaxCrossEntropyWithOneHotLabelsGrad),
+        ("testSoftmaxCrossEntropyWithProbabilitiesLoss",
+         testSoftmaxCrossEntropyWithProbabilitiesLoss),
+        ("testSoftmaxCrossEntropyWithProbabilitiesGrad",
+         testSoftmaxCrossEntropyWithProbabilitiesGrad),
     ]
 }


### PR DESCRIPTION
This PR has the following changes.
1. Fixed the docstring for the meanSquaredError. The original version is likely due to copy-paste.
2. Restricted the wrt of gradient to make it consistent with other APIs.
3. Added numerical tests for loss and gradients. 