### PR TITLE
Fix the sigmoid cross entropy with logits.

### DIFF
--- a/Sources/DeepLearning/Loss.swift
+++ b/Sources/DeepLearning/Loss.swift
@@ -88,6 +88,6 @@ public func sigmoidCrossEntropy<Scalar: TensorFlowFloatingPoint>(
     let maxLogitsWithZero = max(logits, Tensor(0))
     // TODO(TF-349): Use abs directly once `abs` is differentiable.
     let absOfLogitsbsl = max(logits, -logits)
-    let loss =  maxLogitsWithZero - logits * labels + log(1 + exp(-absOfLogitsbsl))
+    let loss = maxLogitsWithZero - logits * labels + log(1 + exp(-absOfLogitsbsl))
     return loss.mean()
 }

--- a/Sources/DeepLearning/Loss.swift
+++ b/Sources/DeepLearning/Loss.swift
@@ -83,7 +83,7 @@ public func sigmoidCrossEntropy<Scalar: TensorFlowFloatingPoint>(
     // This numerical stable implementation is based on tf.nn.sigmoid_cross_entropy_with_logits.
 
     let maxLogitsWithZero = max(logits, Tensor(0))
-    // TODO(SR-10061): Use abs directly once abc is differentiable.
+    // TODO(TF-349): Use abs directly once abc is differentiable.
     let absOfLogitsbsl = max(logits, -logits)
     let loss =  maxLogitsWithZero - logits * labels + log(1 + exp(-absOfLogitsbsl))
     return loss.mean()

--- a/Sources/DeepLearning/Loss.swift
+++ b/Sources/DeepLearning/Loss.swift
@@ -73,6 +73,9 @@ func _vjpSoftmaxCrossEntropy<Scalar: TensorFlowFloatingPoint>(
 
 /// Computes the sigmoid cross entropy (binary cross entropy) between logits and labels.
 ///
+/// The reduction is reduced over all elements. If reduced over batch size is intended, please
+/// consider to scale the loss.
+///
 /// - Parameters:
 ///   - logits: The unscaled output of a neural network.
 ///   - labels: Integer values that correspond to the correct output.

--- a/Tests/DeepLearningTests/LossTests.swift
+++ b/Tests/DeepLearningTests/LossTests.swift
@@ -83,6 +83,43 @@ final class LossTests: XCTestCase {
         assertElementsEqual(expected: expectedGradients, actual: gradients)
     }
 
+    func testSigmoidCrossEntropyLoss() {
+        let logits = Tensor<Float>(
+            shape: [2, 4],
+            scalars: [-100, -2, -2, 0, 2, 2, 2, 100])
+
+        let labels = Tensor<Float>(
+            shape: [2, 4],
+            scalars: [0, 0, 1, 0, 0, 1, 0.5, 1])
+
+        let loss = sigmoidCrossEntropy(logits: logits, labels: labels)
+        let expectedLoss: Float = 0.7909734
+        assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
+    }
+
+    func testSigmoidCrossEntropyGrad() {
+        let logits = Tensor<Float>(
+            shape: [2, 4],
+            scalars: [-100, -2, -2, 0, 2, 2, 2, 100])
+
+        let labels = Tensor<Float>(
+            shape: [2, 4],
+            scalars: [0, 0, 1, 0, 0, 1, 0.5, 1])
+
+        // For each element x in logits and y in labels, the gradient is sigmoid(x) - y.
+        let expectedGradientsBeforeMean = Tensor<Float>(
+            shape: [2, 4],
+            scalars: [0.00,  0.11920291, -0.8807971,  0.5,
+                      0.8807971, -0.11920291,  0.3807971 , 0.0])
+
+        // As the loss is mean loss, we should scale the golden gradient numbers.
+        let expectedGradients = expectedGradientsBeforeMean / Float(logits.scalars.count)
+        let gradients = gradient(
+            at: logits,
+            in: { sigmoidCrossEntropy(logits: $0, labels: labels) })
+        assertElementsEqual(expected: expectedGradients, actual: gradients)
+    }
+
     func assertElementsEqual(
         expected: Tensor<Float>,
         actual: Tensor<Float>,
@@ -105,5 +142,7 @@ final class LossTests: XCTestCase {
          testSoftmaxCrossEntropyWithProbabilitiesLoss),
         ("testSoftmaxCrossEntropyWithProbabilitiesGrad",
          testSoftmaxCrossEntropyWithProbabilitiesGrad),
+        ("testSigmoidCrossEntropyLoss", testSigmoidCrossEntropyLoss),
+        ("testSigmoidCrossEntropyGrad", testSigmoidCrossEntropyGrad),
     ]
 }


### PR DESCRIPTION
Fix the sigmoid cross entropy with logits. 

Particularly,
1. logits should be wrapped into a sigmoid. The original impl actually assumes the logits are outputs of sigmoid.
2. The mean loss should be reduced by number of elements not batch size. 
3. Use a numerical stable implementation to avoid Nan.