### PR TITLE
Add `Backpropagator` typealias.

### DIFF
--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -84,6 +84,9 @@ public extension Layer {
         return applied(to: input, in: context)
     }
 
+    typealias Backpropagator = (_ direction: Output.CotangentVector)
+        -> (layerGradient: CotangentVector, inputGradient: Input.CotangentVector)
+
     /// Returns the inference output and the backpropagation function obtained from applying the
     /// layer to the given input.
     ///
@@ -92,9 +95,7 @@ public extension Layer {
     ///   backpropagation function (a.k.a. backpropagator) takes a direction vector and returns the
     ///   gradients at the layer and at the input, respectively.
     func appliedForBackpropagation(to input: Input, in context: Context)
-        -> (output: Output,
-            backpropagator: (_ direction: Output.CotangentVector)
-                -> (layerGradient: CotangentVector, inputGradient: Input.CotangentVector)) {
+        -> (output: Output, backpropagator: Backpropagator) {
         let (out, pullback) = valueWithPullback(at: input) { layer, input in
             return layer.applied(to: input, in: context)
         }


### PR DESCRIPTION
Add a `Backpropagator` typealias for layers, and change `appliedForBackpropagation(to:)`'s return type to `(output: Output, backpropagator: Backpropagator)`. This simplifies the type signature.

The most common use case is manually collecting pullbacks for individual layers. In this [simple RNN example](https://gist.github.com/rxwei/ce6644efad8f229651050e096c05ccbb), collecting an array of backpropagators lets us do BPTT with good-looking code.