### PR TITLE
unify raw operator logic naming

### DIFF
--- a/Sources/DeepLearning/Operators.swift
+++ b/Sources/DeepLearning/Operators.swift
@@ -118,14 +118,6 @@ public extension Padding {
         case .valid: return .valid
         }
     }
-
-    @inlinable
-    internal var raw2: Raw.Padding2 {
-        switch self {
-        case .same: return .same
-        case .valid: return .valid
-        }
-    }
 }
 
 public extension Tensor where Scalar: TensorFlowFloatingPoint {
@@ -143,8 +135,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
             filter: filter,
             outBackprop: self,
             strides: [strides.0, strides.1, strides.2, strides.3],
-            padding: padding.raw2,
-            explicitPaddings: [])
+            padding: padding.raw)
     }
 
     /// TensorFlow builtin conv2d gradient helper for the filter.
@@ -161,8 +152,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
             filterSizes: filterSizes,
             outBackprop: self,
             strides: [strides.0, strides.1, strides.2, strides.3],
-            padding: padding.raw2,
-            explicitPaddings: [])
+            padding: padding.raw)
     }
 
     @inlinable
@@ -292,8 +282,7 @@ public extension Tensor where Scalar: FloatingPoint {
             self,
             filter: filter,
             strides: [strides.0, strides.1, strides.2, strides.3],
-            padding: padding.raw2,
-            explicitPaddings: [])
+            padding: padding.raw)
     }
 
     /// Computes a 2-D max pooling, with the specified kernel sizes, strides, and


### PR DESCRIPTION
as far as I can tell, this logic is now identical, and is not compiling here for me.
unified the namespaces and removed the extraneous function parameter.