### PR TITLE
Add `RNNCell` protocol.

### DIFF
--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -1323,7 +1323,7 @@ public struct RNNInput<TimeStepInput: Differentiable, State: Differentiable>: Di
     public var previousState: State
 
     @differentiable
-    public init(timeStepInput: StepInput, previousState: State) {
+    public init(timeStepInput: TimeStepInput, previousState: State) {
         self.timeStepInput = timeStepInput
         self.previousState = previousState
     }

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -1350,7 +1350,7 @@ public extension RNNCell {
     ///     phase.
     /// - Returns: The output.
     @differentiable
-    func applied(to timeStepInput: StepInput, previous: State, in context: Context) -> State {
+    func applied(to timeStepInput: TimeStepInput, previous: State, in context: Context) -> State {
         return applied(to: Input(timeStepInput: timeStepInput, previousState: previous),
                        in: context)
     }

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -1351,7 +1351,7 @@ public extension RNNCell {
     /// - Returns: The output.
     @differentiable
     func applied(to timeStepInput: StepInput, previous: State, in context: Context) -> State {
-        return applied(to: Input(timeStepInput: timeStepInput, previousState: previousState),
+        return applied(to: Input(timeStepInput: timeStepInput, previousState: previous),
                        in: context)
     }
 }


### PR DESCRIPTION
This PR adds `RNNCell` that intends to generalize simple RNNs, LSTMs, GRUs, and NTMs. This will enable generic algorithms or layers that can be parameterized by any RNN.

See #71 for context.

cc @tanmayb123 @eaplatanios