### PR TITLE
Rename GlobalAveragePooling to GlobalAvgPool

### DIFF
--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -943,7 +943,7 @@ public struct AvgPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
 
 /// A global average pooling layer for temporal data.
 @_fixed_layout
-public struct GlobalAveragePooling1D<Scalar: TensorFlowFloatingPoint>: Layer {
+public struct GlobalAvgPool1D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// Creates a global average pooling layer.
     public init() {}
 
@@ -954,13 +954,13 @@ public struct GlobalAveragePooling1D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Returns: The output.
     @differentiable
     public func applied(to input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.mean(alongAxes: 1).reshaped(to: [input.shape[0], input.shape[2]])
+        return input.mean(squeezingAxes: 1)
     }
 }
 
 /// A global average pooling layer for spatial data.
 @_fixed_layout
-public struct GlobalAveragePooling2D<Scalar: TensorFlowFloatingPoint>: Layer {
+public struct GlobalAvgPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// Creates a global average pooling layer.
     public init() {}
 
@@ -971,13 +971,13 @@ public struct GlobalAveragePooling2D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Returns: The output.
     @differentiable
     public func applied(to input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.mean(alongAxes: [1, 2]).reshaped(to: [input.shape[0], input.shape[3]])
+        return input.mean(squeezingAxes: [1, 2])
     }
 }
 
 /// A global average pooling layer for spatial and spatio-temporal data.
 @_fixed_layout
-public struct GlobalAveragePooling3D<Scalar: TensorFlowFloatingPoint>: Layer {
+public struct GlobalAvgPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// Creates a global average pooling layer.
     public init() {}
 
@@ -988,7 +988,7 @@ public struct GlobalAveragePooling3D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Returns: The output.
     @differentiable
     public func applied(to input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.mean(alongAxes: [1, 2, 3]).reshaped(to: [input.shape[0], input.shape[4]])
+        return input.mean(squeezingAxes: [1, 2, 3])
     }
 }
 

--- a/Tests/DeepLearningTests/LayerTests.swift
+++ b/Tests/DeepLearningTests/LayerTests.swift
@@ -43,7 +43,7 @@ final class LayerTests: XCTestCase {
     }
 
     func testGlobalAvgPool1D() {
-        let layer = GlobalAveragePooling1D<Float>()
+        let layer = GlobalAvgPool1D<Float>()
         let input = Tensor(shape: [2, 5, 1], scalars: (0..<10).map(Float.init))
         let output = layer.inferring(from: input)
         let expected = Tensor<Float>([[2], [7]])
@@ -51,7 +51,7 @@ final class LayerTests: XCTestCase {
     }
 
     func testGlobalAvgPool2D() {
-        let layer = GlobalAveragePooling2D<Float>()
+        let layer = GlobalAvgPool2D<Float>()
         let input = Tensor(shape: [2, 6, 2, 1], scalars: (0..<24).map(Float.init))
         let output = layer.inferring(from: input)
         let expected = Tensor<Float>([[5.5], [17.5]])
@@ -59,7 +59,7 @@ final class LayerTests: XCTestCase {
     }
 
     func testGlobalAvgPool3D() {
-        let layer = GlobalAveragePooling3D<Float>()
+        let layer = GlobalAvgPool3D<Float>()
         let input = Tensor<Float>(shape: [2, 6, 2, 1, 1], scalars: (0..<24).map(Float.init))
         let output = layer.inferring(from: input)
         let expected = Tensor<Float>([[5.5], [17.5]])


### PR DESCRIPTION
For consistency with the other pooling APIs. Also updates to use `squeezingAxes` (should be NFC).