### PR TITLE
Explicitly qualify `LearningPhase.inference` to prevent ambiguity err…

### DIFF
--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -46,7 +46,7 @@ public extension Layer {
     /// - Returns: The inference output.
     @differentiable
     func inferring(from input: Input) -> Output {
-        return withLearningPhase(.inference) {
+        return withLearningPhase(LearningPhase.inference) {
             applied(to: input)
         }
     }
@@ -57,7 +57,7 @@ public extension Layer {
     internal func _vjpInferring(from input: Input)
         -> (value: Output, pullback: (Output.CotangentVector)
             -> (CotangentVector, Input.CotangentVector)) {
-        return withLearningPhase(.inference) {
+        return withLearningPhase(LearningPhase.inference) {
             let (output, pullback) = appliedForBackpropagation(to: input)
             return (output, { v in pullback(v) })
         }

--- a/Tests/DeepLearningTests/ContextTests.swift
+++ b/Tests/DeepLearningTests/ContextTests.swift
@@ -22,9 +22,9 @@ final class ContextTests: XCTestCase {
         let dropout = Dropout<Float>(probability: 0.5)
         let x = Tensor<Float>(repeating: 1.0, shape: [5, 5])
         XCTAssertEqual(dropout.applied(to: x), x)
-        withLearningPhase(.inference) {
+        withLearningPhase(LearningPhase.inference) {
             XCTAssertEqual(dropout.applied(to: x), x)
-            withLearningPhase(.training) {
+            withLearningPhase(LearningPhase.training) {
                 XCTAssertNotEqual(dropout.applied(to: x), x)
             }
             XCTAssertEqual(dropout.applied(to: x), x)
@@ -39,7 +39,7 @@ final class ContextTests: XCTestCase {
         DispatchQueue.concurrentPerform(iterations: 10) { i in
             if i.isMultiple(of: 2) {
                 XCTAssertEqual(dropout.applied(to: x), x)
-                withLearningPhase(.training) {
+                withLearningPhase(LearningPhase.training) {
                     XCTAssertNotEqual(dropout.applied(to: x), x)
                 }
                 XCTAssertEqual(dropout.applied(to: x), x)


### PR DESCRIPTION
…ors.

Fixes `swift build`. Without this change, `swift build` fails:
```console
$ swift build
Compile Swift Module 'DeepLearning' (8 sources)
/Users/danielzheng/swift-dev/tensorflow-swift-apis/Sources/DeepLearning/Layer.swift:49:35: error: ambiguous use of 'inference'
        return withLearningPhase(.inference) {
                                  ^
/Users/danielzheng/swift-dev/tensorflow-swift-apis/Sources/DeepLearning/Context.swift:28:10: note: found this candidate
    case inference
         ^
TensorFlow.LearningPhase:3:10: note: found this candidate
    case inference
         ^
/Users/danielzheng/swift-dev/tensorflow-swift-apis/Sources/DeepLearning/Layer.swift:60:35: error: ambiguous use of 'inference'
        return withLearningPhase(.inference) {
                                  ^
/Users/danielzheng/swift-dev/tensorflow-swift-apis/Sources/DeepLearning/Context.swift:28:10: note: found this candidate
    case inference
         ^
TensorFlow.LearningPhase:3:10: note: found this candidate
    case inference
         ^

```