### PR TITLE
Make layers callable.

### DIFF
--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -40,6 +40,16 @@ public protocol Layer: Differentiable & KeyPathIterable
 }
 
 public extension Layer {
+    /// Returns the output obtained from applying the layer to the given input.
+    ///
+    /// - Parameters:
+    ///   - input: The input to the layer.
+    /// - Returns: The output.
+    @differentiable
+    call func(_ input: Input) -> Output {
+      return applied(to: input)
+    }
+
     /// Returns the inference output obtained from applying the layer to the given input.
     ///
     /// - Parameter input: The input to the layer.

--- a/Tests/DeepLearningTests/TrivialModelTests.swift
+++ b/Tests/DeepLearningTests/TrivialModelTests.swift
@@ -47,7 +47,7 @@ final class TrivialModelTests: XCTestCase {
         Context.local.learningPhase = .training
         for _ in 0..<3000 {
             let 𝛁model = classifier.gradient { classifier -> Tensor<Float> in
-                let ŷ = classifier.applied(to: x)
+                let ŷ = classifier(x)
                 return meanSquaredError(predicted: ŷ, expected: y)
             }
             optimizer.update(&classifier.allDifferentiableVariables, along: 𝛁model)


### PR DESCRIPTION
Add `call func(_ input: Input) -> Output` as an extension method on `Layer`.
The requirement on `Layer` is still named `applied(to:)`.

Depends on https://github.com/apple/swift/pull/24094, please wait to merge.