### PR TITLE
Update optimizers.

### DIFF
--- a/Tests/DeepLearningTests/SequentialTests.swift
+++ b/Tests/DeepLearningTests/SequentialTests.swift
@@ -29,7 +29,7 @@ final class SequentialTests: XCTestCase {
             }
         }
         var model = Model()
-        let optimizer = SGD(for: model, learningRate: 0.02, scalarType: Float.self)
+        let optimizer = SGD(for: model, learningRate: 0.02)
         let x: Tensor<Float> = [[0, 0], [0, 1], [1, 0], [1, 1]]
         let y: Tensor<Float> = [0, 1, 1, 0]
         Context.local.learningPhase = .training

--- a/Tests/DeepLearningTests/TrivialModelTests.swift
+++ b/Tests/DeepLearningTests/TrivialModelTests.swift
@@ -40,7 +40,7 @@ final class TrivialModelTests: XCTestCase {
             }
         }
         var classifier = Classifier(hiddenSize: 4)
-        let optimizer = SGD(for: classifier, learningRate: 0.02, scalarType: Float.self)
+        let optimizer = SGD(for: classifier, learningRate: 0.02)
         let x: Tensor<Float> = [[0, 0], [0, 1], [1, 0], [1, 1]]
         let y: Tensor<Float> = [[0], [1], [1], [0]]
 


### PR DESCRIPTION
Previously, optimizers were incompatible with
[LayerList](https://github.com/fastai/fastai_docs/commit/a6dc98490fbc2f97cc5f4bac7c1a5d0170ebc5b1)
due to an interaction between KeyPath iterables and the instantiation of
`AllDifferentiableVariables.zero` (which naturally is `[]`). Concretely, when
running the optimizers, you would encounter array out-of-bounds errors. This
change updates the optimizers to take an instance of the model, and instantiate
all the "optimizer slots" (in TensorFlow optimizer parlance) as copies of the
Model's AllDifferentiableVariable's, just with their Tensor values set to zero.

Additionally, this change simplifies Optimizers to remove the Scalar type. For
now, this is handled by iterating over the 2 valid Scalar types (`Float`, and
`Double`), but in the future, support for generic math, the ability to leverage
`VectorNumeric`, and maybe a couple other features should allow for fully
general mixed-precision optimizers without requiring KeyPath iteration over the
respective scalar types.

Finally, this change makes a number of optimizer variables public to allow for
experimentation.