### PR TITLE
Add RNN wrapper for Cells

### DIFF
--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -1449,7 +1449,7 @@ public struct RNN<Cell: RNNCell>: Layer {
         }
         return (timeStepOutputs, { 𝛁outputs in
             assert(𝛁outputs.base.count == timeStepCount,
-                   "The number of output gradients must equal the number of input gradients")
+                   "The number of output gradients must equal the number of time steps")
             var 𝛁cell = Cell.CotangentVector.zero
             var 𝛁state = Cell.State.CotangentVector.zero
             var reversed𝛁inputs: [Cell.TimeStepInput.CotangentVector] = []

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -1448,8 +1448,8 @@ public struct RNN<Cell: RNNCell>: Layer {
             backpropagators.append(backpropagator)
         }
         return (timeStepOutputs, { 𝛁outputs in
-            assert(𝛁outputs.base.count == timeStepCount,
-                   "The number of output gradients must equal the number of time steps")
+            precondition(𝛁outputs.base.count == timeStepCount,
+                         "The number of output gradients must equal the number of time steps")
             var 𝛁cell = Cell.CotangentVector.zero
             var 𝛁state = Cell.State.CotangentVector.zero
             var reversed𝛁inputs: [Cell.TimeStepInput.CotangentVector] = []

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -1397,3 +1397,23 @@ public struct LSTMCell<Scalar: TensorFlowFloatingPoint>: RNNCell {
         return Output(output: newState, state: newState)
     }
 }
+
+public struct RNN<Cell: RNNCell>: Layer {
+    public var cell: Cell
+    
+    init(_ cell: () -> Cell) {
+        self.cell = cell()
+    }
+
+    @differentiable
+    public func applied(to input: [Cell.TimeStepInput]) -> [Cell.Output] {
+        var currentHiddenState = cell.zeroState
+        var outputs: [Cell.Output] = []
+        for timestep in input {
+            let timestepOutput = cell.applied(to: .init(input: timestep, state: currentHiddenState))
+            currentHiddenState = timestepOutput.state
+            outputs.append(timestepOutput)
+        }
+        return outputs
+    }
+}

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -1281,7 +1281,7 @@ public extension RNNCell {
 }
 
 /// A Simple RNN Cell.
-public struct SimpleRNNCell<Scalar: TensorFlowFloatingPoint>: RNNCell {
+public struct SimpleRNNCell<Scalar: TensorFlowFloatingPoint>: RNNCell, VectorNumeric {
     public var weight: Tensor<Scalar>
     public var bias: Tensor<Scalar>
 
@@ -1304,9 +1304,13 @@ public struct SimpleRNNCell<Scalar: TensorFlowFloatingPoint>: RNNCell {
     /// - Parameters:
     ///   - inputSize: The number of features in 2-D input tensors.
     ///   - hiddenSize: The number of features in 2-D hidden states.
-    public init(inputSize: Int, hiddenSize: Int) {
+    ///   - seed: The random seed for initialization. The default value is random.
+    public init(inputSize: Int, hiddenSize: Int,
+                seed: (Int64, Int64) = (Int64.random(in: Int64.min..<Int64.max),
+                                        Int64.random(in: Int64.min..<Int64.max))) {
         let concatenatedInputSize = inputSize + hiddenSize
-        self.weight = Tensor(glorotUniform: [concatenatedInputSize, hiddenSize])
+        self.weight = Tensor(glorotUniform: [concatenatedInputSize, hiddenSize],
+                             seed: seed)
         self.bias = Tensor(zeros: [hiddenSize])
     }
 
@@ -1326,7 +1330,7 @@ public struct SimpleRNNCell<Scalar: TensorFlowFloatingPoint>: RNNCell {
 }
 
 /// An LSTM Cell.
-public struct LSTMCell<Scalar: TensorFlowFloatingPoint>: RNNCell {
+public struct LSTMCell<Scalar: TensorFlowFloatingPoint>: RNNCell, VectorNumeric {
     public var inputWeight, updateWeight, forgetWeight, outputWeight: Tensor<Scalar>
     public var inputBias, updateBias, forgetBias, outputBias: Tensor<Scalar>
 
@@ -1348,17 +1352,19 @@ public struct LSTMCell<Scalar: TensorFlowFloatingPoint>: RNNCell {
     /// - Parameters:
     ///   - inputSize: The number of features in 2-D input tensors.
     ///   - hiddenSize: The number of features in 2-D hidden states.
-    public init(inputSize: Int, hiddenSize: Int) {
+    public init(inputSize: Int, hiddenSize: Int,
+                seed: (Int64, Int64) = (Int64.random(in: Int64.min..<Int64.max),
+                                        Int64.random(in: Int64.min..<Int64.max))) {
         let concatenatedInputSize = inputSize + hiddenSize
         let gateWeightShape = TensorShape([concatenatedInputSize, hiddenSize])
         let gateBiasShape = TensorShape([hiddenSize])
-        self.inputWeight = Tensor(glorotUniform: gateWeightShape)
+        self.inputWeight = Tensor(glorotUniform: gateWeightShape, seed: seed)
         self.inputBias = Tensor(zeros: gateBiasShape)
-        self.updateWeight = Tensor(glorotUniform: gateWeightShape)
+        self.updateWeight = Tensor(glorotUniform: gateWeightShape, seed: seed)
         self.updateBias = Tensor(zeros: gateBiasShape)
-        self.forgetWeight = Tensor(glorotUniform: gateWeightShape)
+        self.forgetWeight = Tensor(glorotUniform: gateWeightShape, seed: seed)
         self.forgetBias = Tensor(ones: gateBiasShape)
-        self.outputWeight = Tensor(glorotUniform: gateWeightShape)
+        self.outputWeight = Tensor(glorotUniform: gateWeightShape, seed: seed)
         self.outputBias = Tensor(zeros: gateBiasShape)
     }
 
@@ -1399,21 +1405,90 @@ public struct LSTMCell<Scalar: TensorFlowFloatingPoint>: RNNCell {
 }
 
 public struct RNN<Cell: RNNCell>: Layer {
+    public typealias Input = [Cell.TimeStepInput]
+    public typealias Output = [Cell.TimeStepOutput]
+
     public var cell: Cell
     
     public init(_ cell: @autoclosure () -> Cell) {
         self.cell = cell()
     }
 
-    @differentiable
-    public func call(_ input: [Cell.TimeStepInput]) -> [Cell.Output] {
-        var currentHiddenState = cell.zeroState
-        var outputs: [Cell.Output] = []
+    @differentiable(wrt: (self, input), vjp: _vjpCall(_:initialState:))
+    public func call(_ input: [Cell.TimeStepInput],
+                     initialState: Cell.State) -> [Cell.TimeStepOutput] {
+        var currentHiddenState = initialState
+        var timeStepOutputs: [Cell.TimeStepOutput] = []
         for timestep in input {
-            let timestepOutput = cell(input: timestep, state: currentHiddenState)
-            currentHiddenState = timestepOutput.state
-            outputs.append(timestepOutput)
+            let output = cell(input: timestep, state: currentHiddenState)
+            currentHiddenState = output.state
+            timeStepOutputs.append(output.output)
         }
-        return outputs
+        return timeStepOutputs
     }
+
+    @usableFromInline
+    internal func _vjpCall(
+        _ inputs: [Cell.TimeStepInput], initialState: Cell.State
+    ) -> ([Cell.TimeStepOutput],
+          (Array<Cell.TimeStepOutput>.CotangentVector)
+              -> (RNN<Cell>.CotangentVector, Array<Cell.TimeStepInput>.CotangentVector)) {
+        let timeStepCount = inputs.count
+        var currentHiddenState = cell.zeroState
+        var timeStepOutputs: [Cell.TimeStepOutput] = []
+        var backpropagators: [Cell.Backpropagator] = []
+        for timestep in inputs {
+            let (output, backpropagator) =
+                cell.appliedForBackpropagation(to: .init(input: timestep,
+                                                         state: currentHiddenState))
+            currentHiddenState = output.state
+            timeStepOutputs.append(output.output)
+            backpropagators.append(backpropagator)
+        }
+        func pullback(𝛁outputs: Array<Cell.TimeStepOutput>.CotangentVector)
+            -> (RNN<Cell>.CotangentVector, Array<Cell.TimeStepInput>.CotangentVector) {
+            assert(𝛁outputs.base.count == timeStepCount,
+                   "The number of output gradients must equal the number of input gradients")
+            var 𝛁cell = Cell.CotangentVector.zero
+            var 𝛁state = Cell.State.CotangentVector.zero
+            var reversed𝛁inputs: [Cell.TimeStepInput.CotangentVector] = []
+            reversed𝛁inputs.reserveCapacity(timeStepCount)
+            for (𝛁output, backpropagator) in zip(𝛁outputs.base, backpropagators).reversed() {
+                let (new𝛁cell, 𝛁input) = backpropagator(.init(output: 𝛁output, state: 𝛁state))
+                𝛁cell = new𝛁cell
+                𝛁state = 𝛁input.state
+                reversed𝛁inputs.append(𝛁input.input)
+            }
+            return (RNN<Cell>.CotangentVector(cell: 𝛁cell),
+                    Array<Cell.TimeStepInput>.CotangentVector(Array(reversed𝛁inputs.reversed())))
+        }
+        return (timeStepOutputs, pullback)
+    }
+
+    @differentiable(wrt: (self, inputs))
+    public func call(_ inputs: [Cell.TimeStepInput]) -> [Cell.TimeStepOutput] {
+        return self(inputs, initialState: cell.zeroState.withoutDerivative())
+    }
+
+    /* TODO: Uncomment once control flow and differentiation through force unwrapping is supported.
+    @differentiable(wrt: (self, inputs))
+    public func lastOutput(from inputs: [Cell.TimeStepInput],
+                           initialState: Cell.State) -> Cell.TimeStepOutput {
+        precondition(!inputs.isEmpty, "inputs cannot be empty")
+        return self(inputs, initialState: initialState).last!
+    }
+
+    @differentiable(wrt: (self, inputs))
+    public func lastOutput(from inputs: [Cell.TimeStepInput]) -> Cell.TimeStepOutput {
+        precondition(!inputs.isEmpty, "inputs cannot be empty")
+        return self(inputs, initialState: cell.zeroState).last!
+    }
+    */
 }
+
+extension RNN: Equatable where Cell: Equatable {}
+extension RNN: AdditiveArithmetic where Cell: AdditiveArithmetic {}
+extension RNN: VectorNumeric where Cell: VectorNumeric {}
+
+public typealias SimpleRNN<Scalar: TensorFlowFloatingPoint> = RNN<SimpleRNNCell<Scalar>>
+public typealias LSTM<Scalar: TensorFlowFloatingPoint> = RNN<LSTMCell<Scalar>>

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -1401,16 +1401,16 @@ public struct LSTMCell<Scalar: TensorFlowFloatingPoint>: RNNCell {
 public struct RNN<Cell: RNNCell>: Layer {
     public var cell: Cell
     
-    init(_ cell: () -> Cell) {
+    public init(_ cell: @autoclosure () -> Cell) {
         self.cell = cell()
     }
 
     @differentiable
-    public func applied(to input: [Cell.TimeStepInput]) -> [Cell.Output] {
+    public func call(_ input: [Cell.TimeStepInput]) -> [Cell.Output] {
         var currentHiddenState = cell.zeroState
         var outputs: [Cell.Output] = []
         for timestep in input {
-            let timestepOutput = cell.applied(to: .init(input: timestep, state: currentHiddenState))
+            let timestepOutput = cell(input: timestep, state: currentHiddenState)
             currentHiddenState = timestepOutput.state
             outputs.append(timestepOutput)
         }

--- a/Tests/DeepLearningTests/LayerTests.swift
+++ b/Tests/DeepLearningTests/LayerTests.swift
@@ -108,7 +108,6 @@ final class LayerTests: XCTestCase {
                                  [[ 0.06621192,    0.009049267,   0.065047316, 0.11534518]],
                                  [[ 0.05612204,    0.00022032857, 0.05407162,  0.09784105]]])
         let (𝛁rnn, 𝛁inputs) = pullback(.init(inputs))
-        print(𝛁rnn, 𝛁inputs)
         XCTAssertEqual(𝛁rnn.cell.weight,
                        [[          0.0,           0.0,           0.0,           0.0],
                         [-0.0051278225,  0.0013102926,    0.00740262,   0.018119661],

--- a/Tests/DeepLearningTests/LayerTests.swift
+++ b/Tests/DeepLearningTests/LayerTests.swift
@@ -95,6 +95,32 @@ final class LayerTests: XCTestCase {
         XCTAssertEqual(output, expected)
     }
 
+    func testRNN() {
+        let x = Tensor<Float>(rangeFrom: 0.0, to: 0.4, stride: 0.1).rankLifted()
+        let inputs: [Tensor<Float>] = Array(repeating: x, count: 4)
+        let rnn = RNN(SimpleRNNCell<Float>(inputSize: 4, hiddenSize: 4,
+                                           seed: (0xFeedBeef, 0xDeadBeef)))
+        let (outputs, pullback) = rnn.valueWithPullback(at: inputs) { rnn, inputs in
+            return rnn(inputs)
+        }
+        XCTAssertEqual(outputs, [[[-0.0026294366, -0.0058668107,  0.04495003,  0.20311214]],
+                                 [[ 0.06788494,    0.050665878,   0.02415526,  0.09249911]],
+                                 [[ 0.06621192,    0.009049267,   0.065047316, 0.11534518]],
+                                 [[ 0.05612204,    0.00022032857, 0.05407162,  0.09784105]]])
+        let (𝛁rnn, 𝛁inputs) = pullback(.init(inputs))
+        print(𝛁rnn, 𝛁inputs)
+        XCTAssertEqual(𝛁rnn.cell.weight,
+                       [[          0.0,           0.0,           0.0,           0.0],
+                        [-0.0051278225,  0.0013102926,    0.00740262,   0.018119661],
+                        [ -0.010255645,  0.0026205853,    0.01480524,   0.036239322],
+                        [ -0.015383467,   0.003930878,    0.02220786,   0.054358985],
+                        [          0.0,           0.0,           0.0,           0.0],
+                        [          0.0,           0.0,           0.0,           0.0],
+                        [          0.0,           0.0,           0.0,           0.0],
+                        [          0.0,           0.0,           0.0,           0.0]])
+        XCTAssertEqual(𝛁rnn.cell.bias, [-0.051278222,  0.013102926,    0.0740262,   0.18119662])
+    }
+
     static var allTests = [
         ("testConv1D", testConv1D),
         ("testMaxPool1D", testMaxPool1D),
@@ -104,6 +130,7 @@ final class LayerTests: XCTestCase {
         ("testGlobalAvgPool3D", testGlobalAvgPool3D),
         ("testReshape", testReshape),
         ("testFlatten", testFlatten),
-        ("testSimpleRNNCell", testSimpleRNNCell)
+        ("testSimpleRNNCell", testSimpleRNNCell),
+        ("testRNN", testRNN)
     ]
 }


### PR DESCRIPTION
Based off of #100 by @tanmayb123. My push to that branch accidentally closed that PR, so I'm starting a new one.

* Add generic structure type `RNN<Cell: RNNCell>` that forms a recurrent layer from a cell. Thanks @tanmayb123 for starting this!
* Define a custom efficient derivative for `RNN.call(_:)`.
* Make RNN structures (`SimpleRNNCell`, `LSTMCell`, `RNN`) conditionally conform to `VectorNumeric` and `VectorNumeric` for easier integration with more efficient optimizers in the future.
* Make RNN cell initializers take a random seed, passing them through `Tensor.init(glorotUniform:seed:)`.
* Add a test for `RNN` using `SimpleRNNCell`.

Related to #52. Resolves #91.