### PR TITLE
Solving errors in AvgPool3d and Maxpool3d Implementations

### DIFF
--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -889,6 +889,18 @@ public struct MaxPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
     }
 }
 
+public extension MaxPool3D {
+  /// Creates a MaxPool3D Layer with the specified poolsize and strides. The poolsize
+  /// and strides are square windows.
+  init(poolSize: Int, stride: Int, padding: Padding = .valid)
+  { let poolsize = poolSize
+    let stride = stride
+    self.init(
+      poolsize: (poolsize, poolsize, poolsize), strides: (stride, stride, stride), padding: padding
+    )
+  }
+}
+
 /// An average pooling layer for temporal data.
 @_fixed_layout
 public struct AvgPool1D<Scalar: TensorFlowFloatingPoint>: Layer {
@@ -1013,6 +1025,18 @@ public struct AvgPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
     public func call(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return input.averagePooled(kernelSize: poolSize, strides: strides, padding: padding)
     }
+}
+
+public extension AvgPool3D {
+  /// Creates a AvgPool3D Layer with the specified poolsize and strides. The poolsize
+  /// and strides are square windows.
+  init(poolSize: Int, stride: Int, padding: Padding = .valid)
+  { let poolsize = poolSize
+    let stride = stride
+    self.init(
+      poolsize: (poolsize, poolsize, poolsize), strides: (stride, stride, stride), padding: padding
+    )
+  }
 }
 
 

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -794,7 +794,7 @@ public struct MaxPool1D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Returns: The output.
     @differentiable
     public func call(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.expandingShape(at: 1).maxPooled(
+        return input.expandingShape(at: 1).maxPooled2D(
             kernelSize: (1, 1, poolSize, 1), strides: (1, 1, stride, 1), padding: padding
         ).squeezingShape(at: 1)
     }
@@ -935,7 +935,7 @@ public struct AvgPool1D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Returns: The output.
     @differentiable
     public func call(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.expandingShape(at: 1).averagePooled(
+        return input.expandingShape(at: 1).averagePooled2D(
             kernelSize: (1, 1, poolSize, 1), strides: (1, 1, stride, 1), padding: padding
         ).squeezingShape(at: 1)
     }

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -821,7 +821,7 @@ public struct MaxPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
         self.strides = strides
         self.padding = padding
     }
-    
+
     /// Returns the output obtained from applying the layer to the given input.
     ///
     /// - Parameter input: The input to the layer.
@@ -834,7 +834,7 @@ public struct MaxPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
 }
 
 public extension MaxPool2D {
-  /// Creates a average pooling layer.
+  /// Creates a max pooling layer.
   ///
   /// - Parameters:
   ///   - poolSize: Vertical and horizontal factors by which to downscale.
@@ -974,7 +974,7 @@ public struct AvgPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
 }
 
 public extension AvgPool2D {
-  /// Creates a average pooling layer.
+  /// Creates an average pooling layer.
   ///
   /// - Parameters:
   ///   - poolSize: Vertical and horizontal factors by which to downscale.
@@ -1020,7 +1020,7 @@ public struct AvgPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
 }
 
 public extension AvgPool3D {
-  /// Creates a average pooling layer.
+  /// Creates an average pooling layer.
   ///
   /// - Parameters:
   ///   - poolSize: Vertical and horizontal factors by which to downscale.

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -821,17 +821,7 @@ public struct MaxPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
         self.strides = strides
         self.padding = padding
     }
-
-    /// Creates a max pooling layer.
-    ///
-    /// - Parameters:
-    ///   - poolSize: Vertical and horizontal factors by which to downscale.
-    ///   - strides: The strides.
-    ///   - padding: The padding.
-    self.init(poolSize: (1, poolSize.0, poolSize.1, 1),
-              strides: (1, strides.0, strides.1, 1),
-              padding: padding)
-
+    
     /// Returns the output obtained from applying the layer to the given input.
     ///
     /// - Parameter input: The input to the layer.
@@ -841,6 +831,20 @@ public struct MaxPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
         return input.maxPooled(
             kernelSize: poolSize, strides: strides, padding: padding)
     }
+}
+
+public extension MaxPool2D {
+  /// Creates a average pooling layer.
+  ///
+  /// - Parameters:
+  ///   - poolSize: Vertical and horizontal factors by which to downscale.
+  ///   - strides: The strides.
+  ///   - padding: The padding.
+  init(poolSize: (Int, Int), strides: (Int, Int), padding: Padding = .valid) {
+  self.init(poolSize: (1, poolSize.0, poolSize.1, 1),
+            strides: (1, strides.0, strides.1, 1),
+            padding: padding)
+  }
 }
 
 /// A max pooling layer for spatial or spatio-temporal data.
@@ -865,16 +869,6 @@ public struct MaxPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
         self.padding = padding
     }
 
-    /// Creates a max pooling layer.
-    ///
-    /// - Parameters:
-    ///   - poolSize: Vertical and horizontal factors by which to downscale.
-    ///   - strides: The strides.
-    ///   - padding: The padding.
-    self.init(poolSize: (1, poolSize.0, poolSize.1, poolSize.2, 1),
-              strides: (1, strides.0, strides.1, strides.2, 1),
-              padding: padding)
-
     /// Returns the output obtained from applying the layer to the given input.
     ///
     /// - Parameter input: The input to the layer.
@@ -883,6 +877,20 @@ public struct MaxPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
     public func call(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return input.maxPooled(kernelSize: poolSize, strides: strides, padding: padding)
     }
+}
+
+public extension MaxPool3D {
+  /// Creates a max pooling layer.
+  ///
+  /// - Parameters:
+  ///   - poolSize: Vertical and horizontal factors by which to downscale.
+  ///   - strides: The strides.
+  ///   - padding: The padding.
+  init(poolSize: (Int, Int, Int), strides: (Int, Int, Int), padding: Padding = .valid) {
+  self.init(poolSize: (1, poolSize.0, poolSize.1, poolSize.2, 1),
+            strides: (1, strides.0, strides.1, strides.2, 1),
+            padding: padding)
+  }
 }
 
 public extension MaxPool3D {
@@ -955,16 +963,6 @@ public struct AvgPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
         self.padding = padding
     }
 
-    /// Creates an average pooling layer.
-    ///
-    /// - Parameters:
-    ///   - poolSize: Vertical and horizontal factors by which to downscale.
-    ///   - strides: The strides.
-    ///   - padding: The padding.
-    self.init(poolSize: (1, poolSize.0, poolSize.1, 1),
-              strides: (1, strides.0, strides.1, 1),
-              padding: padding)
-
     /// Returns the output obtained from applying the layer to the given input.
     ///
     /// - Parameter input: The input to the layer.
@@ -973,6 +971,20 @@ public struct AvgPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
     public func call(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return input.averagePooled(kernelSize: poolSize, strides: strides, padding: padding)
     }
+}
+
+public extension AvgPool2D {
+  /// Creates a average pooling layer.
+  ///
+  /// - Parameters:
+  ///   - poolSize: Vertical and horizontal factors by which to downscale.
+  ///   - strides: The strides.
+  ///   - padding: The padding.
+  init(poolSize: (Int, Int), strides: (Int, Int), padding: Padding = .valid) {
+  self.init(poolSize: (1, poolSize.0, poolSize.1, 1),
+            strides: (1, strides.0, strides.1, 1),
+            padding: padding)
+  }
 }
 
 /// An average pooling layer for spatial or spatio-temporal data.
@@ -997,16 +1009,6 @@ public struct AvgPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
         self.padding = padding
     }
 
-    /// Creates an average pooling layer.
-    ///
-    /// - Parameters:
-    ///   - poolSize: Vertical and horizontal factors by which to downscale.
-    ///   - strides: The strides.
-    ///   - padding: The padding.
-    self.init(poolSize: (1, poolSize.0, poolSize.1, poolSize.2, 1),
-              strides: (1, strides.0, strides.1, strides.2, 1),
-              padding: padding)
-
     /// Returns the output obtained from applying the layer to the given input.
     ///
     /// - Parameter input: The input to the layer.
@@ -1015,6 +1017,20 @@ public struct AvgPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
     public func call(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return input.averagePooled(kernelSize: poolSize, strides: strides, padding: padding)
     }
+}
+
+public extension AvgPool3D {
+  /// Creates a average pooling layer.
+  ///
+  /// - Parameters:
+  ///   - poolSize: Vertical and horizontal factors by which to downscale.
+  ///   - strides: The strides.
+  ///   - padding: The padding.
+  init(poolSize: (Int, Int, Int), strides: (Int, Int, Int), padding: Padding = .valid) {
+  self.init(poolSize: (1, poolSize.0, poolSize.1, poolSize.2, 1),
+            strides: (1, strides.0, strides.1, strides.2, 1),
+            padding: padding)
+  }
 }
 
 public extension AvgPool3D {

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -897,7 +897,7 @@ public extension MaxPool3D {
   /// Creates a max pooling layer with the specified pooling window size and stride. All
   /// pooling sizes and strides are the same.
   init(poolSize: Int, stride: Int, padding: Padding = .valid) {
-       self.init(poolsize: (poolSize, poolSize, poolSize),
+       self.init(poolSize: (poolSize, poolSize, poolSize),
                  strides: (stride, stride, stride),
                  padding: padding)
   }

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -828,7 +828,7 @@ public struct MaxPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Returns: The output.
     @differentiable
     public func call(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.maxPooled(
+        return input.maxPooled2D(
             kernelSize: poolSize, strides: strides, padding: padding)
     }
 }
@@ -875,7 +875,7 @@ public struct MaxPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Returns: The output.
     @differentiable
     public func call(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.maxPooled(kernelSize: poolSize, strides: strides, padding: padding)
+        return input.maxPooled3D(kernelSize: poolSize, strides: strides, padding: padding)
     }
 }
 
@@ -969,7 +969,7 @@ public struct AvgPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Returns: The output.
     @differentiable
     public func call(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.averagePooled(kernelSize: poolSize, strides: strides, padding: padding)
+        return input.averagePooled2D(kernelSize: poolSize, strides: strides, padding: padding)
     }
 }
 
@@ -1015,7 +1015,7 @@ public struct AvgPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Returns: The output.
     @differentiable
     public func call(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.averagePooled(kernelSize: poolSize, strides: strides, padding: padding)
+        return input.averagePooled3D(kernelSize: poolSize, strides: strides, padding: padding)
     }
 }
 

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -845,6 +845,50 @@ public struct MaxPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
     }
 }
 
+/// A max pooling layer for spatial or spatio-temporal data.
+@_fixed_layout
+public struct MaxPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
+    /// The size of the sliding reduction window for pooling.
+    @noDerivative let poolSize: (Int, Int, Int, Int, Int)
+    /// The strides of the sliding window for each dimension of a 5-D input.
+    /// Strides in non-spatial dimensions must be `1`.
+    @noDerivative let strides: (Int, Int, Int, Int, Int)
+    /// The padding algorithm for pooling.
+    @noDerivative let padding: Padding
+
+    /// Creates a max pooling layer.
+    public init(
+        poolSize: (Int, Int, Int, Int, Int),
+        strides: (Int, Int, Int, Int, Int),
+        padding: Padding
+    ) {
+        self.poolSize = poolSize
+        self.strides = strides
+        self.padding = padding
+    }
+
+    /// Creates a max pooling layer.
+    ///
+    /// - Parameters:
+    ///   - poolSize: Vertical and horizontal factors by which to downscale.
+    ///   - strides: The strides.
+    ///   - padding: The padding.
+    public init(poolSize: (Int, Int, Int), strides: (Int, Int, Int), padding: Padding = .valid) {
+        self.poolSize = (1, poolSize.0, poolSize.1, poolSize.2, 1)
+        self.strides = (1, strides.0, strides.1, strides.2, 1)
+        self.padding = padding
+    }
+
+    /// Returns the output obtained from applying the layer to the given input.
+    ///
+    /// - Parameter input: The input to the layer.
+    /// - Returns: The output.
+    @differentiable
+    public func call(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
+        return input.maxPooled(kernelSize: poolSize, strides: strides, padding: padding)
+    }
+}
+
 /// An average pooling layer for temporal data.
 @_fixed_layout
 public struct AvgPool1D<Scalar: TensorFlowFloatingPoint>: Layer {
@@ -894,7 +938,7 @@ public struct AvgPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// The padding algorithm for pooling.
     @noDerivative let padding: Padding
 
-    /// Creates a average pooling layer.
+    /// Creates an average pooling layer.
     public init(
         poolSize: (Int, Int, Int, Int),
         strides: (Int, Int, Int, Int),
@@ -905,7 +949,7 @@ public struct AvgPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
         self.padding = padding
     }
 
-    /// Creates a average pooling layer.
+    /// Creates an average pooling layer.
     ///
     /// - Parameters:
     ///   - poolSize: Vertical and horizontal factors by which to downscale.
@@ -914,6 +958,50 @@ public struct AvgPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
     public init(poolSize: (Int, Int), strides: (Int, Int), padding: Padding = .valid) {
         self.poolSize = (1, poolSize.0, poolSize.1, 1)
         self.strides = (1, strides.0, strides.1, 1)
+        self.padding = padding
+    }
+
+    /// Returns the output obtained from applying the layer to the given input.
+    ///
+    /// - Parameter input: The input to the layer.
+    /// - Returns: The output.
+    @differentiable
+    public func call(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
+        return input.averagePooled(kernelSize: poolSize, strides: strides, padding: padding)
+    }
+}
+
+/// An average pooling layer for spatial or spatio-temporal data.
+@_fixed_layout
+public struct AvgPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
+    /// The size of the sliding reduction window for pooling.
+    @noDerivative let poolSize: (Int, Int, Int, Int, Int)
+    /// The strides of the sliding window for each dimension of a 5-D input.
+    /// Strides in non-spatial dimensions must be `1`.
+    @noDerivative let strides: (Int, Int, Int, Int, Int)
+    /// The padding algorithm for pooling.
+    @noDerivative let padding: Padding
+
+    /// Creates an average pooling layer.
+    public init(
+        poolSize: (Int, Int, Int, Int, Int),
+        strides: (Int, Int, Int, Int, Int),
+        padding: Padding
+    ) {
+        self.poolSize = poolSize
+        self.strides = strides
+        self.padding = padding
+    }
+
+    /// Creates an average pooling layer.
+    ///
+    /// - Parameters:
+    ///   - poolSize: Vertical and horizontal factors by which to downscale.
+    ///   - strides: The strides.
+    ///   - padding: The padding.
+    public init(poolSize: (Int, Int, Int), strides: (Int, Int, Int), padding: Padding = .valid) {
+        self.poolSize = (1, poolSize.0, poolSize.1, poolSize.2, 1)
+        self.strides = (1, strides.0, strides.1, strides.2, 1)
         self.padding = padding
     }
 

--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -828,11 +828,9 @@ public struct MaxPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   - poolSize: Vertical and horizontal factors by which to downscale.
     ///   - strides: The strides.
     ///   - padding: The padding.
-    public init(poolSize: (Int, Int), strides: (Int, Int), padding: Padding = .valid) {
-        self.poolSize = (1, poolSize.0, poolSize.1, 1)
-        self.strides = (1, strides.0, strides.1, 1)
-        self.padding = padding
-    }
+    self.init(poolSize: (1, poolSize.0, poolSize.1, 1),
+              strides: (1, strides.0, strides.1, 1),
+              padding: padding)
 
     /// Returns the output obtained from applying the layer to the given input.
     ///
@@ -873,11 +871,9 @@ public struct MaxPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   - poolSize: Vertical and horizontal factors by which to downscale.
     ///   - strides: The strides.
     ///   - padding: The padding.
-    public init(poolSize: (Int, Int, Int), strides: (Int, Int, Int), padding: Padding = .valid) {
-        self.poolSize = (1, poolSize.0, poolSize.1, poolSize.2, 1)
-        self.strides = (1, strides.0, strides.1, strides.2, 1)
-        self.padding = padding
-    }
+    self.init(poolSize: (1, poolSize.0, poolSize.1, poolSize.2, 1),
+              strides: (1, strides.0, strides.1, strides.2, 1),
+              padding: padding)
 
     /// Returns the output obtained from applying the layer to the given input.
     ///
@@ -890,14 +886,12 @@ public struct MaxPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
 }
 
 public extension MaxPool3D {
-  /// Creates a MaxPool3D Layer with the specified poolsize and strides. The poolsize
-  /// and strides are square windows.
-  init(poolSize: Int, stride: Int, padding: Padding = .valid)
-  { let poolsize = poolSize
-    let stride = stride
-    self.init(
-      poolsize: (poolsize, poolsize, poolsize), strides: (stride, stride, stride), padding: padding
-    )
+  /// Creates a max pooling layer with the specified pooling window size and stride. All
+  /// pooling sizes and strides are the same.
+  init(poolSize: Int, stride: Int, padding: Padding = .valid) {
+       self.init(poolsize: (poolSize, poolSize, poolSize),
+                 strides: (stride, stride, stride),
+                 padding: padding)
   }
 }
 
@@ -967,11 +961,9 @@ public struct AvgPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   - poolSize: Vertical and horizontal factors by which to downscale.
     ///   - strides: The strides.
     ///   - padding: The padding.
-    public init(poolSize: (Int, Int), strides: (Int, Int), padding: Padding = .valid) {
-        self.poolSize = (1, poolSize.0, poolSize.1, 1)
-        self.strides = (1, strides.0, strides.1, 1)
-        self.padding = padding
-    }
+    self.init(poolSize: (1, poolSize.0, poolSize.1, 1),
+              strides: (1, strides.0, strides.1, 1),
+              padding: padding)
 
     /// Returns the output obtained from applying the layer to the given input.
     ///
@@ -1011,11 +1003,9 @@ public struct AvgPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   - poolSize: Vertical and horizontal factors by which to downscale.
     ///   - strides: The strides.
     ///   - padding: The padding.
-    public init(poolSize: (Int, Int, Int), strides: (Int, Int, Int), padding: Padding = .valid) {
-        self.poolSize = (1, poolSize.0, poolSize.1, poolSize.2, 1)
-        self.strides = (1, strides.0, strides.1, strides.2, 1)
-        self.padding = padding
-    }
+    self.init(poolSize: (1, poolSize.0, poolSize.1, poolSize.2, 1),
+              strides: (1, strides.0, strides.1, strides.2, 1),
+              padding: padding)
 
     /// Returns the output obtained from applying the layer to the given input.
     ///
@@ -1028,17 +1018,14 @@ public struct AvgPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
 }
 
 public extension AvgPool3D {
-  /// Creates a AvgPool3D Layer with the specified poolsize and strides. The poolsize
-  /// and strides are square windows.
-  init(poolSize: Int, stride: Int, padding: Padding = .valid)
-  { let poolsize = poolSize
-    let stride = stride
-    self.init(
-      poolsize: (poolsize, poolsize, poolsize), strides: (stride, stride, stride), padding: padding
-    )
-  }
+    /// Creates an average pooling layer with the specified pooling window size and stride. All
+    /// pooling sizes and strides are the same.
+    init(poolSize: Int, strides: Int, padding: Padding = .valid) {
+        self.init(poolSize: (poolSize, poolSize, poolSize),
+                  strides: (strides, strides, strides),
+                  padding: padding)
+    }
 }
-
 
 /// A global average pooling layer for temporal data.
 @_fixed_layout

--- a/Sources/DeepLearning/Operators.swift
+++ b/Sources/DeepLearning/Operators.swift
@@ -233,8 +233,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     ) -> (Tensor, (Tensor) -> Tensor) {
         // TODO: Currently this is not higher order differentiable. Redefine in
         // closed form.
-        let value = maxPooled2D(kernelSize: kernelSize, strides: strides,
-                              padding: padding)
+        let value = maxPooled2D(kernelSize: kernelSize, strides: strides, padding: padding)
         return (value, { v in
             return Raw.maxPoolGradV2(
                 origInput: self,
@@ -257,8 +256,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     ) -> (Tensor, (Tensor) -> Tensor) {
         // TODO: Currently this is not higher order differentiable. Redefine in
         // closed form.
-        let value = maxPooled3D(kernelSize: kernelSize, strides: strides,
-                              padding: padding)
+        let value = maxPooled3D(kernelSize: kernelSize, strides: strides, padding: padding)
         return (value, { v in
             return Raw.maxPool3DGrad(
                 origInput: self,
@@ -283,8 +281,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     ) -> (Tensor, (Tensor) -> Tensor) {
         // TODO: Currently this is not higher order differentiable. Redefine in
         // closed form.
-        let value = averagePooled2D(kernelSize: kernelSize, strides: strides,
-                                  padding: padding)
+        let value = averagePooled2D(kernelSize: kernelSize, strides: strides, padding: padding)
         return (value, { v in
             return Raw.avgPoolGrad(
                 origInputShape: self.shapeTensor,
@@ -306,8 +303,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     ) -> (Tensor, (Tensor) -> Tensor) {
         // TODO: Currently this is not higher order differentiable. Redefine in
         // closed form.
-        let value = averagePooled3D(kernelSize: kernelSize, strides: strides,
-                              padding: padding)
+        let value = averagePooled3D(kernelSize: kernelSize, strides: strides, padding: padding)
         return (value, { v in
             return Raw.avgPool3DGrad(
                 origInputShape: self.shapeTensor,
@@ -363,10 +359,10 @@ public extension Tensor where Scalar: FloatingPoint {
     ///     - padding: The padding for the operation.
     @inlinable @inline(__always)
     @differentiable(
-        wrt: self, vjp: _vjpMaxPooled(kernelSize:strides:padding:)
+        wrt: self, vjp: _vjpMaxPooled2D(kernelSize:strides:padding:)
         where Scalar : TensorFlowFloatingPoint
     )
-    func maxPooled(
+    func maxPooled2D(
         kernelSize: (Int, Int, Int, Int),
         strides: (Int, Int, Int, Int),
         padding: Padding
@@ -380,6 +376,33 @@ public extension Tensor where Scalar: FloatingPoint {
             padding: padding.raw)
     }
 
+    /// Computes a 3-D max pooling, with the specified kernel sizes, strides, and
+    /// padding.
+    ///
+    /// - Parameters:
+    ///     - kernelSize: The dimensions of the pooling kernel.
+    ///     - strides: The strides of the sliding filter for each dimension of the
+    ///         input.
+    ///     - padding: The padding for the operation.
+    @inlinable @inline(__always)
+    @differentiable(
+        wrt: self, vjp: _vjpMaxPooled3D(kernelSize:strides:padding:)
+        where Scalar : TensorFlowFloatingPoint
+    )
+    func maxPooled3D(
+        kernelSize: (Int, Int, Int, Int),
+        strides: (Int, Int, Int, Int),
+        padding: Padding
+    ) -> Tensor {
+        return Raw.maxPool3D(
+            self,
+            ksize: Tensor<Int32>([Int32(kernelSize.0), Int32(kernelSize.1),
+                                  Int32(kernelSize.2), Int32(kernelSize.3), Int32(kernelSize.4)]),
+            strides: Tensor<Int32>([Int32(strides.0), Int32(strides.1),
+                                    Int32(strides.2), Int32(strides.3), Int32(strides.4)]),
+            padding: padding.raw)
+    }
+
     /// Computes a 2-D average pooling, with the specified kernel sizes, strides,
     /// and padding.
     ///
@@ -390,10 +413,10 @@ public extension Tensor where Scalar: FloatingPoint {
     ///     - padding: The padding for the operation.
     @inlinable @inline(__always)
     @differentiable(
-        wrt: self, vjp: _vjpAveragePooled(kernelSize:strides:padding:)
+        wrt: self, vjp: _vjpAveragePooled2D(kernelSize:strides:padding:)
         where Scalar : TensorFlowFloatingPoint
     )
-    func averagePooled(
+    func averagePooled2D(
         kernelSize: (Int, Int, Int, Int),
         strides: (Int, Int, Int, Int),
         padding: Padding
@@ -403,6 +426,33 @@ public extension Tensor where Scalar: FloatingPoint {
             ksize: [Int32(kernelSize.0), Int32(kernelSize.1),
                     Int32(kernelSize.2), Int32(kernelSize.3)],
             strides: [Int32(strides.0), Int32(strides.1), Int32(strides.2), Int32(strides.3)],
+            padding: padding.raw)
+    }
+
+    /// Computes a 3-D average pooling, with the specified kernel sizes, strides,
+    /// and padding.
+    ///
+    /// - Parameters:
+    ///     - kernelSize: The dimensions of the pooling kernel.
+    ///     - strides: The strides of the sliding filter for each dimension of the
+    ///         input.
+    ///     - padding: The padding for the operation.
+    @inlinable @inline(__always)
+    @differentiable(
+        wrt: self, vjp: _vjpAveragePooled3D(kernelSize:strides:padding:)
+        where Scalar : TensorFlowFloatingPoint
+    )
+    func averagePooled3D(
+        kernelSize: (Int, Int, Int, Int, Int),
+        strides: (Int, Int, Int, Int, Int),
+        padding: Padding
+    ) -> Tensor {
+        return Raw.avgPool3D(
+            value: self,
+            ksize: [Int32(kernelSize.0), Int32(kernelSize.1),
+                    Int32(kernelSize.2), Int32(kernelSize.3), Int32(kernelSize.4)],
+            strides: [Int32(strides.0), Int32(strides.1), Int32(strides.2), Int32(strides.3),
+                      Int32(strides.4)],
             padding: padding.raw)
     }
 }

--- a/Sources/DeepLearning/Operators.swift
+++ b/Sources/DeepLearning/Operators.swift
@@ -226,14 +226,14 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     }
 
     @inlinable
-    internal func _vjpMaxPooled(
+    internal func _vjpMaxPooled2D(
         kernelSize: (Int, Int, Int, Int),
         strides: (Int, Int, Int, Int),
         padding: Padding
     ) -> (Tensor, (Tensor) -> Tensor) {
         // TODO: Currently this is not higher order differentiable. Redefine in
         // closed form.
-        let value = maxPooled(kernelSize: kernelSize, strides: strides,
+        let value = maxPooled2D(kernelSize: kernelSize, strides: strides,
                               padding: padding)
         return (value, { v in
             return Raw.maxPoolGradV2(
@@ -250,14 +250,40 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     }
 
     @inlinable
-    internal func _vjpAveragePooled(
+    internal func _vjpMaxPooled3D(
+        kernelSize: (Int, Int, Int, Int, Int),
+        strides: (Int, Int, Int, Int, Int),
+        padding: Padding
+    ) -> (Tensor, (Tensor) -> Tensor) {
+        // TODO: Currently this is not higher order differentiable. Redefine in
+        // closed form.
+        let value = maxPooled3D(kernelSize: kernelSize, strides: strides,
+                              padding: padding)
+        return (value, { v in
+            return Raw.maxPool3DGrad(
+                origInput: self,
+                origOutput: value,
+                grad: v,
+                ksize: Tensor<Int32>([Int32(kernelSize.0), Int32(kernelSize.1),
+                                      Int32(kernelSize.2), Int32(kernelSize.3),
+                                      Int32(kernelSize.4)]),
+                strides: Tensor<Int32>([Int32(strides.0), Int32(strides.1),
+                                        Int32(strides.2), Int32(strides.3),
+                                        Int32(strides.4)]),
+                padding: padding.raw
+            )
+        })
+    }
+
+    @inlinable
+    internal func _vjpAveragePooled2D(
         kernelSize: (Int, Int, Int, Int),
         strides: (Int, Int, Int, Int),
         padding: Padding
     ) -> (Tensor, (Tensor) -> Tensor) {
         // TODO: Currently this is not higher order differentiable. Redefine in
         // closed form.
-        let value = averagePooled(kernelSize: kernelSize, strides: strides,
+        let value = averagePooled2D(kernelSize: kernelSize, strides: strides,
                                   padding: padding)
         return (value, { v in
             return Raw.avgPoolGrad(
@@ -265,7 +291,33 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
                 grad: v,
                 ksize: [Int32(kernelSize.0), Int32(kernelSize.1),
                         Int32(kernelSize.2), Int32(kernelSize.3)],
-                strides: [Int32(strides.0), Int32(strides.1), Int32(strides.2), Int32(strides.3)],
+                strides: [Int32(strides.0), Int32(strides.1),
+                          Int32(strides.2), Int32(strides.3)],
+                padding: padding.raw
+            )
+        })
+    }
+
+    @inlinable
+    internal func _vjpAveragePooled3D(
+        kernelSize: (Int, Int, Int, Int, Int),
+        strides: (Int, Int, Int, Int, Int),
+        padding: Padding
+    ) -> (Tensor, (Tensor) -> Tensor) {
+        // TODO: Currently this is not higher order differentiable. Redefine in
+        // closed form.
+        let value = averagePooled3D(kernelSize: kernelSize, strides: strides,
+                              padding: padding)
+        return (value, { v in
+            return Raw.avgPool3DGrad(
+                origInputShape: self.shapeTensor,
+                grad: v,
+                ksize: Tensor<Int32>([Int32(kernelSize.0), Int32(kernelSize.1),
+                                      Int32(kernelSize.2), Int32(kernelSize.3),
+                                      Int32(kernelSize.4)]),
+                strides: Tensor<Int32>([Int32(strides.0), Int32(strides.1),
+                                        Int32(strides.2), Int32(strides.3),
+                                        Int32(strides.4)]),
                 padding: padding.raw
             )
         })

--- a/Sources/DeepLearning/Operators.swift
+++ b/Sources/DeepLearning/Operators.swift
@@ -390,16 +390,16 @@ public extension Tensor where Scalar: FloatingPoint {
         where Scalar : TensorFlowFloatingPoint
     )
     func maxPooled3D(
-        kernelSize: (Int, Int, Int, Int),
-        strides: (Int, Int, Int, Int),
+        kernelSize: (Int, Int, Int, Int, Int),
+        strides: (Int, Int, Int, Int, Int),
         padding: Padding
     ) -> Tensor {
         return Raw.maxPool3D(
             self,
-            ksize: Tensor<Int32>([Int32(kernelSize.0), Int32(kernelSize.1),
-                                  Int32(kernelSize.2), Int32(kernelSize.3), Int32(kernelSize.4)]),
-            strides: Tensor<Int32>([Int32(strides.0), Int32(strides.1),
-                                    Int32(strides.2), Int32(strides.3), Int32(strides.4)]),
+            ksize: [Int32(kernelSize.0), Int32(kernelSize.1),
+                    Int32(kernelSize.2), Int32(kernelSize.3), Int32(kernelSize.4)],
+            strides: [Int32(strides.0), Int32(strides.1),
+                      Int32(strides.2), Int32(strides.3), Int32(strides.4)],
             padding: padding.raw)
     }
 
@@ -448,7 +448,7 @@ public extension Tensor where Scalar: FloatingPoint {
         padding: Padding
     ) -> Tensor {
         return Raw.avgPool3D(
-            value: self,
+	    self,
             ksize: [Int32(kernelSize.0), Int32(kernelSize.1),
                     Int32(kernelSize.2), Int32(kernelSize.3), Int32(kernelSize.4)],
             strides: [Int32(strides.0), Int32(strides.1), Int32(strides.2), Int32(strides.3),

--- a/Tests/DeepLearningTests/LayerTests.swift
+++ b/Tests/DeepLearningTests/LayerTests.swift
@@ -34,12 +34,44 @@ final class LayerTests: XCTestCase {
         XCTAssertEqual(round(output), expected)
     }
 
+    func testMaxPool2D() {
+        let layer = MaxPool2D<Float>(poolSize:(2, 2), strides:(1, 1), padding:.valid)
+        let input = Tensor(shape: [1, 2, 2, 1], scalars: (0..<4).map(Float.init))
+        let output = layer.inferring(from: input)
+        let expected = Tensor<Float>([[[[3]]]])
+        XCTAssertEqual(round(output), expected)
+    }
+
+    func testMaxPool3D() {
+        let layer = MaxPool3D<Float>(poolSize:(2 ,2, 2), strides:(1, 1, 1), padding:.valid)
+        let input = Tensor(shape: [1, 2, 2, 2, 1], scalars: (0..<8).map(Float.init))
+        let output = layer.inferring(from: input)
+        let expected = Tensor<Float>([[[[[7]]]]])
+        XCTAssertEqual(round(output), expected)
+    }
+
     func testAvgPool1D() {
         let layer = AvgPool1D<Float>(poolSize: 3, stride: 1, padding: .valid)
         let input = Tensor<Float>([[0, 1, 2, 3, 4], [10, 11, 12, 13, 14]]).expandingShape(at: 2)
         let output = layer.inferring(from: input)
         let expected = Tensor<Float>([[[1], [2], [3]], [[11], [12], [13]]])
         XCTAssertEqual(round(output), expected)
+    }
+
+    func testAvgPool2D() {
+        let layer = AvgPool2D<Float>(poolSize:(2, 5), strides:(1, 1), padding:.valid)
+        let input = Tensor(shape: [1, 2, 5, 1], scalars: (0..<10).map(Float.init))
+        let output = layer.inferring(from: input)
+        let expected = Tensor<Float>([[[[4.5]]]])
+        XCTAssertEqual(output, expected)
+    }
+
+    func testAvgPool3D() {
+        let layer = AvgPool3D<Float>(poolSize: (2, 4, 5), stride: (1, 1, 1), padding: .valid)
+        let input = Tensor(shape: [1, 2, 4, 5, 1], scalars: (0..<20).map(Float.init))
+        let output = layer.inferring(from: input)
+        let expected = Tensor<Float>([[[[[9.5]]]]])
+        XCTAssertEqual(output, expected)
     }
 
     func testGlobalAvgPool1D() {

--- a/Tests/DeepLearningTests/LayerTests.swift
+++ b/Tests/DeepLearningTests/LayerTests.swift
@@ -35,7 +35,7 @@ final class LayerTests: XCTestCase {
     }
 
     func testMaxPool2D() {
-        let layer = MaxPool2D<Float>(poolSize:(2, 2), strides:(1, 1), padding:.valid)
+        let layer = MaxPool2D<Float>(poolSize: (2, 2), strides: (1, 1), padding:.valid)
         let input = Tensor(shape: [1, 2, 2, 1], scalars: (0..<4).map(Float.init))
         let output = layer.inferring(from: input)
         let expected = Tensor<Float>([[[[3]]]])
@@ -43,7 +43,7 @@ final class LayerTests: XCTestCase {
     }
 
     func testMaxPool3D() {
-        let layer = MaxPool3D<Float>(poolSize:(2 ,2, 2), strides:(1, 1, 1), padding:.valid)
+        let layer = MaxPool3D<Float>(poolSize: (2 ,2, 2), strides: (1, 1, 1), padding:.valid)
         let input = Tensor(shape: [1, 2, 2, 2, 1], scalars: (0..<8).map(Float.init))
         let output = layer.inferring(from: input)
         let expected = Tensor<Float>([[[[[7]]]]])
@@ -59,7 +59,7 @@ final class LayerTests: XCTestCase {
     }
 
     func testAvgPool2D() {
-        let layer = AvgPool2D<Float>(poolSize:(2, 5), strides:(1, 1), padding:.valid)
+        let layer = AvgPool2D<Float>(poolSize: (2, 5), strides: (1, 1), padding:.valid)
         let input = Tensor(shape: [1, 2, 5, 1], scalars: (0..<10).map(Float.init))
         let output = layer.inferring(from: input)
         let expected = Tensor<Float>([[[[4.5]]]])

--- a/Tests/DeepLearningTests/LayerTests.swift
+++ b/Tests/DeepLearningTests/LayerTests.swift
@@ -35,7 +35,7 @@ final class LayerTests: XCTestCase {
     }
 
     func testMaxPool2D() {
-        let layer = MaxPool2D<Float>(poolSize: (2, 2), strides: (1, 1), padding:.valid)
+        let layer = MaxPool2D<Float>(poolSize: (2, 2), strides: (1, 1), padding: .valid)
         let input = Tensor(shape: [1, 2, 2, 1], scalars: (0..<4).map(Float.init))
         let output = layer.inferring(from: input)
         let expected = Tensor<Float>([[[[3]]]])
@@ -43,7 +43,7 @@ final class LayerTests: XCTestCase {
     }
 
     func testMaxPool3D() {
-        let layer = MaxPool3D<Float>(poolSize: (2 ,2, 2), strides: (1, 1, 1), padding:.valid)
+        let layer = MaxPool3D<Float>(poolSize: (2, 2, 2), strides: (1, 1, 1), padding: .valid)
         let input = Tensor(shape: [1, 2, 2, 2, 1], scalars: (0..<8).map(Float.init))
         let output = layer.inferring(from: input)
         let expected = Tensor<Float>([[[[[7]]]]])
@@ -59,7 +59,7 @@ final class LayerTests: XCTestCase {
     }
 
     func testAvgPool2D() {
-        let layer = AvgPool2D<Float>(poolSize: (2, 5), strides: (1, 1), padding:.valid)
+        let layer = AvgPool2D<Float>(poolSize: (2, 5), strides: (1, 1), padding: .valid)
         let input = Tensor(shape: [1, 2, 5, 1], scalars: (0..<10).map(Float.init))
         let output = layer.inferring(from: input)
         let expected = Tensor<Float>([[[[4.5]]]])

--- a/Tests/DeepLearningTests/LayerTests.swift
+++ b/Tests/DeepLearningTests/LayerTests.swift
@@ -182,7 +182,11 @@ final class LayerTests: XCTestCase {
     static var allTests = [
         ("testConv1D", testConv1D),
         ("testMaxPool1D", testMaxPool1D),
+        ("testMaxPool2D", testMaxPool2D),
+        ("testMaxPool3D", testMaxPool3D),
         ("testAvgPool1D", testAvgPool1D),
+        ("testAvgPool2D", testAvgPool2D),
+        ("testAvgPool3D", testAvgPool3D),
         ("testGlobalAvgPool1D", testGlobalAvgPool1D),
         ("testGlobalAvgPool2D", testGlobalAvgPool2D),
         ("testGlobalAvgPool3D", testGlobalAvgPool3D),

--- a/Tests/DeepLearningTests/LayerTests.swift
+++ b/Tests/DeepLearningTests/LayerTests.swift
@@ -31,7 +31,7 @@ final class LayerTests: XCTestCase {
         let input = Tensor<Float>([[0, 1, 2, 3, 4], [10, 11, 12, 13, 14]]).expandingShape(at: 2)
         let output = layer.inferring(from: input)
         let expected = Tensor<Float>([[[2], [3], [4]], [[12], [13], [14]]])
-        XCTAssertEqual(round(output), expected)
+        XCTAssertEqual(output, expected)
     }
 
     func testMaxPool2D() {
@@ -39,7 +39,7 @@ final class LayerTests: XCTestCase {
         let input = Tensor(shape: [1, 2, 2, 1], scalars: (0..<4).map(Float.init))
         let output = layer.inferring(from: input)
         let expected = Tensor<Float>([[[[3]]]])
-        XCTAssertEqual(round(output), expected)
+        XCTAssertEqual(output, expected)
     }
 
     func testMaxPool3D() {
@@ -47,7 +47,7 @@ final class LayerTests: XCTestCase {
         let input = Tensor(shape: [1, 2, 2, 2, 1], scalars: (0..<8).map(Float.init))
         let output = layer.inferring(from: input)
         let expected = Tensor<Float>([[[[[7]]]]])
-        XCTAssertEqual(round(output), expected)
+        XCTAssertEqual(output, expected)
     }
 
     func testAvgPool1D() {
@@ -55,7 +55,7 @@ final class LayerTests: XCTestCase {
         let input = Tensor<Float>([[0, 1, 2, 3, 4], [10, 11, 12, 13, 14]]).expandingShape(at: 2)
         let output = layer.inferring(from: input)
         let expected = Tensor<Float>([[[1], [2], [3]], [[11], [12], [13]]])
-        XCTAssertEqual(round(output), expected)
+        XCTAssertEqual(output, expected)
     }
 
     func testAvgPool2D() {


### PR DESCRIPTION
the error inherently is :
```
error: cannot convert value of type '(Int, Int, Int, Int, Int)' to expected argument type '(Int, Int, Int, Int)'
        return input.maxPooled(kernelSize: poolSize, strides: strides, padding: padding)
```
I'm still working on how to solve it, Any suggestions are welcome :).