### PR TITLE
Fix "unable to type-check this expression in reasonable time" errors.

### DIFF
--- a/Sources/DeepLearning/Operators.swift
+++ b/Sources/DeepLearning/Operators.swift
@@ -47,14 +47,16 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
             let squaredDiff: Tensor = Raw.squaredDifference(self, mean)
             let variance = squaredDiff.mean(alongAxes: axis)
 
-             let diff = self - mean
+            let diff = self - mean
             let inv = rsqrt(variance + epsilon)
             let norm = diff * inv
 
-             let dNorm = v * scale
+            let dNorm = v * scale
             let dVariance = -(dNorm * diff).sum(alongAxes: axis) / 2 * pow(inv, -3)
-            let dMean = (-dNorm * inv).sum(alongAxes: axis) +
-                dVariance * (-diff * 2).mean(alongAxes: axis)
+            // Note: `dMean` is split into two lines to avoid the "compiler is unable to type-check
+            // this expression in reasonable time" error.
+            var dMean = (-dNorm * inv).sum(alongAxes: axis)
+            dMean = dMean + dVariance * (-diff * 2).mean(alongAxes: axis)
             let dOffset = v.sum(alongAxes: axis)
             let dScale = (norm * v).sum(alongAxes: axis)
             let dim = Tensor(Tensor<Int32>(self.shapeTensor[axis]))

--- a/Sources/DeepLearning/Optimizer.swift
+++ b/Sources/DeepLearning/Optimizer.swift
@@ -105,8 +105,10 @@ public class Adam<Model: Layer>: Optimizer
                        along direction: Model.AllDifferentiableVariables) {
         step += 1
         let learningRate = self.learningRate * 1 / (1 + decay * Float(step))
-        let stepSize = learningRate * (sqrt(1 - pow(beta2, Float(step))) /
-            (1 - pow(beta1, Float(step))))
+        // Note: `stepSize` is split into two lines to avoid the "compiler is unable to type-check
+        // this expression in reasonable time" error.
+        var stepSize = learningRate * sqrt(1 - pow(beta2, Float(step)))
+        stepSize = stepSize / (1 - pow(beta1, Float(step)))
         // Update Float & Double Tensor variables.
         for kp in model.recursivelyAllWritableKeyPaths(to: Tensor<Float>.self) {
             firstMoments[keyPath: kp] =


### PR DESCRIPTION
Fix compilation via `swift build` using a post-merge toolchain
(`swift-DEVELOPMENT-SNAPSHOT-2019-05-02-a`).