### PR TITLE
Make `Padding.raw` public.

### DIFF
--- a/Sources/DeepLearning/Operators.swift
+++ b/Sources/DeepLearning/Operators.swift
@@ -114,7 +114,7 @@ public enum Padding {
 
 public extension Padding {
     @inlinable
-    internal var raw: Raw.Padding {
+    var raw: Raw.Padding {
         switch self {
         case .same: return .same
         case .valid: return .valid


### PR DESCRIPTION
Required for passing `Padding` to `Raw` functions.