### PR TITLE
Fix compilation errors.

### DIFF
--- a/Sources/DeepLearning/Layer.swift
+++ b/Sources/DeepLearning/Layer.swift
@@ -1420,7 +1420,7 @@ public struct SimpleRNNCell<Scalar: TensorFlowFloatingPoint>: RNNCell, VectorNum
 
     // TODO(TF-507): Revert to `typealias State = Tensor<Scalar>` after
     // SR-10697 is fixed.
-    public struct State: Differentiable {
+    public struct State: Equatable, Differentiable, VectorNumeric, KeyPathIterable {
         public let value: Tensor<Scalar>
         public init(_ value: Tensor<Scalar>) {
             self.value = value

--- a/Sources/DeepLearning/Operators.swift
+++ b/Sources/DeepLearning/Operators.swift
@@ -262,12 +262,10 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
                 origInput: self,
                 origOutput: value,
                 grad: v,
-                ksize: Tensor<Int32>([Int32(kernelSize.0), Int32(kernelSize.1),
-                                      Int32(kernelSize.2), Int32(kernelSize.3),
-                                      Int32(kernelSize.4)]),
-                strides: Tensor<Int32>([Int32(strides.0), Int32(strides.1),
-                                        Int32(strides.2), Int32(strides.3),
-                                        Int32(strides.4)]),
+                ksize: [Int32(kernelSize.0), Int32(kernelSize.1), Int32(kernelSize.2),
+                        Int32(kernelSize.3), Int32(kernelSize.4)],
+                strides: [Int32(strides.0), Int32(strides.1), Int32(strides.2), Int32(strides.3),
+                          Int32(strides.4)],
                 padding: padding.raw
             )
         })
@@ -308,12 +306,10 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
             return Raw.avgPool3DGrad(
                 origInputShape: self.shapeTensor,
                 grad: v,
-                ksize: Tensor<Int32>([Int32(kernelSize.0), Int32(kernelSize.1),
-                                      Int32(kernelSize.2), Int32(kernelSize.3),
-                                      Int32(kernelSize.4)]),
-                strides: Tensor<Int32>([Int32(strides.0), Int32(strides.1),
-                                        Int32(strides.2), Int32(strides.3),
-                                        Int32(strides.4)]),
+                ksize: [Int32(kernelSize.0), Int32(kernelSize.1), Int32(kernelSize.2),
+                        Int32(kernelSize.3), Int32(kernelSize.4)],
+                strides: [Int32(strides.0), Int32(strides.1), Int32(strides.2), Int32(strides.3),
+                          Int32(strides.4)],
                 padding: padding.raw
             )
         })


### PR DESCRIPTION
This is a follow-up to https://github.com/tensorflow/swift-apis/pull/119, which I accidentally merged without testing.

---

- Fix VJPs for `maxPooled3D` and `averagePooled3D`.
- Temporarily, fix tests to use `SimpleRNNCell.State`.