### PR TITLE
Re-implement tensor shape/rank operators using TFE runtime APIs.

### DIFF
--- a/Sources/TensorFlow/Core/Runtime.swift
+++ b/Sources/TensorFlow/Core/Runtime.swift
@@ -551,7 +551,7 @@ public final class _ExecutionContext {
     @usableFromInline let eagerContext: CTFEContext
 
     /// The status for checking TensorFlow errors.
-    private let status: CTFStatus = TF_NewStatus()
+    @usableFromInline let status: CTFStatus = TF_NewStatus()
 
     /// The mutex for preventing potential concurrent access.
     private var mutex: pthread_mutex_t = pthread_mutex_t()


### PR DESCRIPTION
@rxwei Ported from apple/swift#24949.

Gives me about 98% speedup for `Tensor.rank` and 85% speedup for `Tensor.shape` (for a 2x3 tensor) on a MacBook Pro and all tests pass.