### PR TITLE
Add two new requirements to TensorGroup and TensorArrayProtocol

### DIFF
--- a/Sources/TensorFlow/Core/TensorGroup.swift
+++ b/Sources/TensorFlow/Core/TensorGroup.swift
@@ -35,7 +35,7 @@ public protocol TensorArrayProtocol {
     var _tensorHandles: [_AnyTensorHandle] { get }
 
     init(_owning tensorHandles: UnsafePointer<CTensorHandle>?, count: Int)
-    init(handles: [_AnyTensorHandle])
+    init<C: RandomAccessCollection>(_handles: C) where C.Element == _AnyTensorHandle
 }
 
 /// A protocol representing types that can be mapped to and from `Array<CTensorHandle>`.
@@ -100,9 +100,10 @@ extension TensorHandle: TensorGroup {
         self.init(_owning: tensorHandles!.pointee)
     }
 
-    public init(handles: [_AnyTensorHandle]) {
-        precondition(handles.count == 1)
-        self.init(handle: handles[0])
+    public init<C: RandomAccessCollection>(
+        _handles: C) where C.Element == _AnyTensorHandle {
+        precondition(_handles.count == 1)
+        self.init(handle: _handles[_handles.startIndex])
     }
 }
 
@@ -127,9 +128,10 @@ extension ResourceHandle: TensorGroup {
         self.init(owning: tensorHandles!.pointee)
     }
 
-    public init(handles: [_AnyTensorHandle]) {
-        precondition(handles.count == 1)
-        self.init(handle: handles[0])
+    public init<C: RandomAccessCollection>(
+        _handles: C) where C.Element == _AnyTensorHandle {
+        precondition(_handles.count == 1)
+        self.init(handle: _handles[_handles.startIndex])
     }
 }
 
@@ -154,9 +156,10 @@ extension VariantHandle: TensorGroup {
         self.init(owning: tensorHandles!.pointee)
     }
 
-    public init(handles: [_AnyTensorHandle]) {
-        precondition(handles.count == 1)
-        self.init(handle: handles[0])
+    public init<C: RandomAccessCollection>(
+        _handles: C) where C.Element == _AnyTensorHandle {
+        precondition(_handles.count == 1)
+        self.init(handle: _handles[_handles.startIndex])
     }
 }
 
@@ -181,9 +184,10 @@ extension Tensor: TensorGroup {
         self.init(handle: TensorHandle(_owning: tensorHandles!.pointee))
     }
 
-    public init(handles: [_AnyTensorHandle]) {
-        precondition(handles.count == 1)
-        self.init(handle: TensorHandle(handle: handles[0]))
+    public init<C: RandomAccessCollection>(
+        _handles: C) where C.Element == _AnyTensorHandle {
+        precondition(_handles.count == 1)
+        self.init(handle: TensorHandle(handle: _handles[_handles.startIndex]))
     }
 }
 
@@ -208,9 +212,10 @@ extension _TensorElementLiteral: TensorGroup {
         self.init(handle: TensorHandle(_owning: tensorHandles!.pointee))
     }
 
-    public init(handles: [_AnyTensorHandle]) {
-        precondition(handles.count == 1)
-        self.init(handle: TensorHandle(handle: handles[0]))
+    public init<C: RandomAccessCollection>(
+        _handles: C) where C.Element == _AnyTensorHandle {
+        precondition(_handles.count == 1)
+        self.init(handle: TensorHandle(handle: _handles[_handles.startIndex]))
     }
 }
 
@@ -235,9 +240,10 @@ extension StringTensor: TensorGroup {
         self.init(handle: TensorHandle(_owning: tensorHandles!.pointee))
     }
 
-    public init(handles: [_AnyTensorHandle]) {
-        precondition(handles.count == 1)
-        self.init(handle: TensorHandle(handle: handles[0]))
+    public init<C: RandomAccessCollection>(
+        _handles: C) where C.Element == _AnyTensorHandle {
+        precondition(_handles.count == 1)
+        self.init(handle: TensorHandle(handle: _handles[_handles.startIndex]))
     }
 }
 
@@ -276,13 +282,15 @@ extension Array: TensorArrayProtocol where Element: TensorGroup {
         })
     }
 
-    public init(handles: [_AnyTensorHandle]) {
-        let size = handles.count / Int(Element._tensorHandleCount)
-        self = Array((0..<size).map {
-                let start = $0 * Int(Element._tensorHandleCount)
-                let end = start + Int(Element._tensorHandleCount)
-                let elemHandles = Array<_AnyTensorHandle>(handles[start..<end])
-                return Element.init(handles: elemHandles)
-            })
+    public init<C: RandomAccessCollection>(
+        _handles: C) where C.Element == _AnyTensorHandle {
+        let size = _handles.count / Int(Element._tensorHandleCount)
+        self = (0..<size).map {
+            let start = _handles.index(
+                _handles.startIndex, offsetBy: $0 * Int(Element._tensorHandleCount))
+            let end = _handles.index(
+                start, offsetBy: Int(Element._tensorHandleCount))
+            return Element.init(_handles: _handles[start..<end])
+        }
     }
 }

--- a/Sources/TensorFlow/Core/TensorGroup.swift
+++ b/Sources/TensorFlow/Core/TensorGroup.swift
@@ -53,8 +53,6 @@ public protocol TensorGroup: TensorArrayProtocol {
     /// Initializes a value of this type, taking ownership of the `_tensorHandleCount` tensors
     /// starting at address `tensorHandles`.
     init(_owning tensorHandles: UnsafePointer<CTensorHandle>?)
-
-    init(handles: [_AnyTensorHandle])
 }
 
 public extension TensorGroup {

--- a/Sources/TensorFlow/Core/TensorHandle.swift
+++ b/Sources/TensorFlow/Core/TensorHandle.swift
@@ -62,6 +62,10 @@ public struct TensorHandle<Scalar> where Scalar: _TensorFlowDataTypeCompatible {
         self.handle = TFETensorHandle(_owning: cTensorHandle)
     }
 
+    public init(handle: _AnyTensorHandle) {
+        self.handle = handle
+    }
+
     @usableFromInline
     init(copyingFromCTensor cTensor: CTensor) {
         let status = TF_NewStatus()
@@ -105,7 +109,7 @@ public struct TensorHandle<Scalar> where Scalar: _TensorFlowDataTypeCompatible {
 extension TensorHandle where Scalar: TensorFlowScalar {
     /// Create a `TensorHandle` with a closure that initializes the underlying buffer.
     ///
-    /// `scalarsInitializer` receives a buffer with exactly enough capacity to hold the scalars in a 
+    /// `scalarsInitializer` receives a buffer with exactly enough capacity to hold the scalars in a
     /// tensor with shape `shape`. `scalarsInitializer` must initialize the entire buffer, with
     /// contiguous scalars in row-major order.
     @inlinable
@@ -145,6 +149,11 @@ public struct ResourceHandle {
     init(owning cTensorHandle: CTensorHandle) {
         self.handle = TFETensorHandle(_owning: cTensorHandle)
     }
+
+    @usableFromInline
+    init(handle: _AnyTensorHandle) {
+        self.handle = handle
+    }
 }
 
 public struct VariantHandle {
@@ -156,5 +165,10 @@ public struct VariantHandle {
     @usableFromInline
     init(owning cTensorHandle: CTensorHandle) {
         self.handle = TFETensorHandle(_owning: cTensorHandle)
+    }
+
+    @usableFromInline
+    init(handle: _AnyTensorHandle) {
+        self.handle = handle
     }
 }

--- a/Sources/TensorFlow/Operators/Dataset.swift
+++ b/Sources/TensorFlow/Operators/Dataset.swift
@@ -220,10 +220,13 @@ public struct Zip2TensorGroup<T: TensorGroup, U: TensorGroup>: TensorGroup {
         first._tensorHandles + second._tensorHandles
     }
 
-    public init(handles: [_AnyTensorHandle]) {
-        let firstEnd = Int(T._tensorHandleCount)
-        self.first = T.init(handles: Array(handles[0..<firstEnd]))
-        self.second = U.init(handles: Array(handles[firstEnd..<handles.count]))
+    public init<C: RandomAccessCollection>(
+        _handles: C) where C.Element == _AnyTensorHandle {
+        let firstStart = _handles.startIndex
+        let firstEnd = _handles.index(
+            firstStart, offsetBy: Int(T._tensorHandleCount))
+        self.first = T.init(_handles: _handles[firstStart..<firstEnd])
+        self.second = U.init(_handles: _handles[firstEnd..<_handles.endIndex])
     }
 }
 

--- a/Sources/TensorFlow/Operators/Dataset.swift
+++ b/Sources/TensorFlow/Operators/Dataset.swift
@@ -215,6 +215,16 @@ public struct Zip2TensorGroup<T: TensorGroup, U: TensorGroup>: TensorGroup {
         self.first = first
         self.second = second
     }
+
+    public var  _tensorHandles: [_AnyTensorHandle] {
+        first._tensorHandles + second._tensorHandles
+    }
+
+    public init(handles: [_AnyTensorHandle]) {
+        let firstEnd = Int(T._tensorHandleCount)
+        self.first = T.init(handles: Array(handles[0..<firstEnd]))
+        self.second = U.init(handles: Array(handles[firstEnd..<handles.count]))
+    }
 }
 
 // TODO(SR-9156): This does not work in graph mode.

--- a/Tests/TensorFlowTests/OperatorTests/DatasetTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/DatasetTests.swift
@@ -18,6 +18,14 @@ import XCTest
 struct SimpleOutput: TensorGroup {
     let a: TensorHandle<Int32>
     let b: TensorHandle<Int32>
+
+    init(handles: [_AnyTensorHandle]) {
+        precondition(handles.count == 2)
+        a = TensorHandle<Int32>(handle: handles[0])
+        b = TensorHandle<Int32>(handle: handles[1])
+    }
+
+    public var _tensorHandles: [_AnyTensorHandle] { [a.handle, b.handle] }
 }
 
 final class DatasetTests: XCTestCase {

--- a/Tests/TensorFlowTests/OperatorTests/DatasetTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/DatasetTests.swift
@@ -19,10 +19,13 @@ struct SimpleOutput: TensorGroup {
     let a: TensorHandle<Int32>
     let b: TensorHandle<Int32>
 
-    init(handles: [_AnyTensorHandle]) {
-        precondition(handles.count == 2)
-        a = TensorHandle<Int32>(handle: handles[0])
-        b = TensorHandle<Int32>(handle: handles[1])
+    public init<C: RandomAccessCollection>(
+        _handles: C) where C.Element == _AnyTensorHandle {
+        precondition(_handles.count == 2)
+        let aIndex = _handles.startIndex
+        let bIndex = _handles.index(aIndex, offsetBy: 1)
+        a = TensorHandle<Int32>(handle: _handles[aIndex])
+        b = TensorHandle<Int32>(handle: _handles[bIndex])
     }
 
     public var _tensorHandles: [_AnyTensorHandle] { [a.handle, b.handle] }

--- a/Tests/TensorFlowTests/TensorGroupTests.swift
+++ b/Tests/TensorFlowTests/TensorGroupTests.swift
@@ -147,7 +147,7 @@ struct UltraNested<T: TensorGroup & Equatable, V: TensorGroup & Equatable>
     }
 }
 
-func copyOf<T>(handle: TensorHandle<T>) -> _AnyTensorHandle {
+func copy<T>(of handle: TensorHandle<T>) -> _AnyTensorHandle {
     let status = TF_NewStatus()
     let result = TFETensorHandle(_owning: TFE_TensorHandleCopySharingTensor(
             handle._cTensorHandle, status)!)
@@ -172,8 +172,8 @@ final class TensorGroupTests: XCTestCase {
         let b = Tensor<Float>(0.1)
         let simple = Simple(w: w, b: b)
 
-        let wHandle = copyOf(handle: w.handle)
-        let bHandle = copyOf(handle: b.handle)
+        let wHandle = copy(of: w.handle)
+        let bHandle = copy(of: b.handle)
 
         let expectedSimple = Simple(_handles: [wHandle, bHandle])
 
@@ -191,8 +191,8 @@ final class TensorGroupTests: XCTestCase {
         let int = Tensor<Int32>(1)
         let mixed = Mixed(float: float, int: int)
 
-        let floatHandle = copyOf(handle: float.handle)
-        let intHandle = copyOf(handle: int.handle)
+        let floatHandle = copy(of: float.handle)
+        let intHandle = copy(of: int.handle)
 
         let expectedMixed = Mixed(_handles: [floatHandle, intHandle])
 
@@ -214,10 +214,10 @@ final class TensorGroupTests: XCTestCase {
         let mixed = Mixed(float: float, int: int)
         let nested = Nested(simple: simple, mixed: mixed)
 
-        let wHandle = copyOf(handle: w.handle)
-        let bHandle = copyOf(handle: b.handle)
-        let floatHandle = copyOf(handle: float.handle)
-        let intHandle = copyOf(handle: int.handle)
+        let wHandle = copy(of: w.handle)
+        let bHandle = copy(of: b.handle)
+        let floatHandle = copy(of: float.handle)
+        let intHandle = copy(of: int.handle)
 
         let expectedNested = Nested(
             _handles: [wHandle, bHandle, floatHandle, intHandle])
@@ -241,10 +241,10 @@ final class TensorGroupTests: XCTestCase {
         let mixed = Mixed(float: float, int: int)
         let generic = Generic(t: simple, u: mixed)
 
-        let wHandle = copyOf(handle: w.handle)
-        let bHandle = copyOf(handle: b.handle)
-        let floatHandle = copyOf(handle: float.handle)
-        let intHandle = copyOf(handle: int.handle)
+        let wHandle = copy(of: w.handle)
+        let bHandle = copy(of: b.handle)
+        let floatHandle = copy(of: float.handle)
+        let intHandle = copy(of: int.handle)
 
         let expectedGeneric = Generic<Simple, Mixed>(
             _handles: [wHandle, bHandle, floatHandle, intHandle])
@@ -278,14 +278,14 @@ final class TensorGroupTests: XCTestCase {
                 let genericMS = Generic<Mixed, Simple>(t: mixed, u: simple)
                 let generic = UltraNested(a: genericSM, b: genericMS)
 
-                let wHandle1 = copyOf(handle: w.handle)
-                let wHandle2 = copyOf(handle: w.handle)
-                let bHandle1 = copyOf(handle: b.handle)
-                let bHandle2 = copyOf(handle: b.handle)
-                let floatHandle1 = copyOf(handle: float.handle)
-                let floatHandle2 = copyOf(handle: float.handle)
-                let intHandle1 = copyOf(handle: int.handle)
-                let intHandle2 = copyOf(handle: int.handle)
+                let wHandle1 = copy(of: w.handle)
+                let wHandle2 = copy(of: w.handle)
+                let bHandle1 = copy(of: b.handle)
+                let bHandle2 = copy(of: b.handle)
+                let floatHandle1 = copy(of: float.handle)
+                let floatHandle2 = copy(of: float.handle)
+                let intHandle1 = copy(of: int.handle)
+                let intHandle2 = copy(of: int.handle)
 
                 let expectedGeneric = UltraNested<Simple, Mixed>(
                     _handles: [wHandle1, bHandle1, floatHandle1,  intHandle1,


### PR DESCRIPTION
This is one of the first steps in addressing https://bugs.swift.org/browse/TF-542. Specifically, this PR introduces two new requirements to `TensorArrayProtocol` and `TensorGroup`:
 - `init(handles: [_AnyTensorHandle])`
 - `var _tensorHandles: [_AnyTensorHandle] { get }`

This is also necessary for the implementation of LazyTensor. 

The Derived conformances for `TensorGroup` does not address these requirements yet. Therefore, the tests have been changed to conform with `TensorGroup` explicitly.