### PR TITLE
Temporarily add back 'func call' to unblock CI.

### DIFF
--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -32,9 +32,6 @@ public protocol Layer: Differentiable & KeyPathIterable
     /// - Returns: The output.
     @differentiable
     func callAsFunction(_ input: Input) -> Output
-
-    @differentiable
-    func call(_  input: Input) -> Output
 }
 
 public extension Layer {

--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -32,6 +32,16 @@ public protocol Layer: Differentiable & KeyPathIterable
     /// - Returns: The output.
     @differentiable
     func callAsFunction(_ input: Input) -> Output
+
+    @differentiable
+    func call(_  input: Input) -> Output
+}
+
+public extension Layer {
+    @differentiable
+    func call(_  input: Input) -> Output {
+        return callAsFunction(input)
+    }
 }
 
 public extension Layer {

--- a/Sources/TensorFlow/Layers/Recurrent.swift
+++ b/Sources/TensorFlow/Layers/Recurrent.swift
@@ -65,6 +65,11 @@ public extension RNNCell {
     func callAsFunction(input: TimeStepInput, state: State) -> RNNCellOutput<TimeStepOutput, State> {
         return self(RNNCellInput(input: input, state: state))
     }
+
+    @differentiable
+    func call(input: TimeStepInput, state: State) -> RNNCellOutput<TimeStepOutput, State> {
+        return self(RNNCellInput(input: input, state: state))
+    }
 }
 
 /// A simple RNN cell.
@@ -213,6 +218,11 @@ public struct RNN<Cell: RNNCell>: Layer {
             timeStepOutputs.append(output.output)
         }
         return timeStepOutputs
+    }
+
+    @differentiable(wrt: (self, input))
+    public func call(_ input: [Cell.TimeStepInput], initialState: Cell.State) -> [Cell.TimeStepOutput] {
+        return callAsFunction(input, initialState: initialState)
     }
 
     @usableFromInline


### PR DESCRIPTION
This allows toolchains built with call or callAsFunction to work on swift-apis. This is to smooth over the transition period.