### PR TITLE
Add liveness tracking to LazyTensor

### DIFF
--- a/Sources/TensorFlow/LazyTensor/LazyTensorOperation.swift
+++ b/Sources/TensorFlow/LazyTensor/LazyTensorOperation.swift
@@ -64,43 +64,43 @@ class LazyTensor: _AnyTensorHandle {
         ObjectIdentifier: LazyTensorOperationRefCounts] = [:]
 
     static func incrementRefCount(_ op: LazyTensorOperation, isLive: Bool) {
-        let opId = ObjectIdentifier(op)
-        if let counts = operationRefCounts[opId] {
-            operationRefCounts[opId] = LazyTensorOperationRefCounts(
+        let opID = ObjectIdentifier(op)
+        if let counts = operationRefCounts[opID] {
+            operationRefCounts[opID] = LazyTensorOperationRefCounts(
                 op: op,
                 liveRefCount: counts.liveRefCount + (isLive ? 1 : 0),
                 allRefCount: counts.allRefCount + 1)
         } else {
-            operationRefCounts[opId] = LazyTensorOperationRefCounts(
+            operationRefCounts[opID] = LazyTensorOperationRefCounts(
                 op: op, liveRefCount: isLive ? 1 : 0, allRefCount: 1)
         }
     }
 
     static func decrementRefCount(_ op: LazyTensorOperation, isLive: Bool) {
-        let opId = ObjectIdentifier(op)
-        if let counts = operationRefCounts[opId] {
+        let opID = ObjectIdentifier(op)
+        if let counts = operationRefCounts[opID] {
             if counts.allRefCount > 1 {
-                operationRefCounts[opId] = LazyTensorOperationRefCounts(
+                operationRefCounts[opID] = LazyTensorOperationRefCounts(
                     op: op,
                     liveRefCount: counts.liveRefCount - (isLive ? 1 : 0),
                     allRefCount: counts.allRefCount - 1)
             } else {
-                operationRefCounts.removeValue(forKey: opId)
+                operationRefCounts.removeValue(forKey: opID)
             }
         }
     }
 
     static func isLive(_ op: LazyTensorOperation) -> Bool {
-        let opId = ObjectIdentifier(op)
-        if let counts = operationRefCounts[opId] {
+        let opID = ObjectIdentifier(op)
+        if let counts = operationRefCounts[opID] {
             return counts.liveRefCount > 0
         }
         return false
     }
 
     static func onLiveOperations(_ perform: (LazyTensorOperation) -> ()) {
-        for (_, counts) in operationRefCounts {
-            if (counts.liveRefCount > 0) { perform(counts.op) }
+        for (_, counts) in operationRefCounts where counts.liveRefCount > 0 {
+            perform(counts.op)
         }
     }
 

--- a/Sources/TensorFlow/LazyTensor/LazyTensorOperation.swift
+++ b/Sources/TensorFlow/LazyTensor/LazyTensorOperation.swift
@@ -104,13 +104,6 @@ class LazyTensor: _AnyTensorHandle {
         }
     }
 
-    static func printRefCounts() {
-        let live = operationRefCounts.values.reduce(0, { (sum, element) in
-                return sum + (element.liveRefCount > 0 ? 1 : 0)
-            })
-        print("LazyTensorOperations: \(operationRefCounts.count) (\(live) live)")
-    }
-
     static var _materializationCallback: (String) -> () = { _ in }
 }
 
@@ -152,7 +145,7 @@ class LazyTensorOperation: TensorOperation {
         }
     }
 
-    public static var liveOperations: Int = 0
+    static var liveOperations: Int = 0
 
     init(_id id: String?, name: String, outputCount: Int) {
         self.name = name

--- a/Tests/TensorFlowTests/LazyTensorTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTests.swift
@@ -16,6 +16,18 @@ import XCTest
 @testable import TensorFlow
 import CTensorFlow
 
+struct LazyTensorOperationRef : Equatable, Hashable {
+    let value: LazyTensorOperation
+    init(_ value: LazyTensorOperation) { self.value = value }
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(value))
+    }
+}
+
+func ==(lhs: LazyTensorOperationRef, rhs: LazyTensorOperationRef) -> Bool {
+    return lhs.value === rhs.value
+}
+
 final class LazyTensorTests: XCTestCase {
     func testConstructions() {
         let zero = Tensor<Float>(0.0)
@@ -40,8 +52,54 @@ final class LazyTensorTests: XCTestCase {
         XCTAssertEqual("\(liveSymTensor)", "IdentityN_0:0*")
     }
 
+    func testLivenessTracking() {
+        func assertLive(_ expectedLive: [LazyTensorOperation]) {
+            var actualLiveOps: Set<LazyTensorOperationRef> = []
+            LazyTensor.onLiveOperations {
+                actualLiveOps.insert(LazyTensorOperationRef($0))
+            }
+            let expectedLiveOps = Set<LazyTensorOperationRef>(
+                expectedLive.map { LazyTensorOperationRef($0) }
+            )
+            XCTAssertEqual(expectedLiveOps, actualLiveOps)
+        }
+        func isSymbolic(_ t: LazyTensor) -> Bool {
+            if case let .symbolic(_) = t.handle {
+                return true
+            } else {
+                return false
+            }
+        }
+
+        let op0 = LazyTensorOperation(
+            _id: "0", name: "IdentityN", outputCount: 2)
+        let op1 = LazyTensorOperation(
+            _id: "1", name: "IdentityN", outputCount: 2)
+
+        XCTAssertFalse(LazyTensor.isLive(op0))
+        XCTAssertFalse(LazyTensor.isLive(op1))
+
+        let t0 = LazyTensor(_lazyLive: op0, index: 0)
+        let t1 = LazyTensor(_lazy: op1, index: 1)
+        XCTAssertTrue(LazyTensor.isLive(op0))
+        XCTAssertFalse(LazyTensor.isLive(op1))
+        do {
+            let t3 = LazyTensor(_lazyLive: op1, index: 0)
+            XCTAssertTrue(LazyTensor.isLive(op1))
+            assertLive([op0, op1])
+            // The following are here just to ensure t3 is live.
+            XCTAssertTrue(isSymbolic(t3))
+        }
+        XCTAssertFalse(LazyTensor.isLive(op1))
+        assertLive([op0])
+        // The following are here just to ensure t0 and t1 are live.
+        XCTAssertTrue(isSymbolic(t1))
+        XCTAssertTrue(isSymbolic(t0))
+    }
+
     static var allTests = [
         ("testConstructions", testConstructions),
+        ("testLivenessTracking", testLivenessTracking),
     ]
 
 }

--- a/Tests/TensorFlowTests/LazyTensorTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTests.swift
@@ -16,7 +16,7 @@ import XCTest
 @testable import TensorFlow
 import CTensorFlow
 
-struct LazyTensorOperationRef : Equatable, Hashable {
+struct LazyTensorOperationRef: Equatable, Hashable {
     let value: LazyTensorOperation
     init(_ value: LazyTensorOperation) { self.value = value }
     func hash(into hasher: inout Hasher) {

--- a/Tests/TensorFlowTests/LazyTensorTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTests.swift
@@ -87,7 +87,7 @@ final class LazyTensorTests: XCTestCase {
             let t3 = LazyTensor(_lazyLive: op1, index: 0)
             XCTAssertTrue(LazyTensor.isLive(op1))
             assertLive([op0, op1])
-            // The following are here just to ensure t3 is live.
+            // The following is here just to ensure t3 is live.
             XCTAssertTrue(isSymbolic(t3))
         }
         XCTAssertFalse(LazyTensor.isLive(op1))

--- a/Tests/TensorFlowTests/LazyTensorTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTests.swift
@@ -63,6 +63,7 @@ final class LazyTensorTests: XCTestCase {
             )
             XCTAssertEqual(expectedLiveOps, actualLiveOps)
         }
+
         func isSymbolic(_ t: LazyTensor) -> Bool {
             if case let .symbolic(_) = t.handle {
                 return true
@@ -83,6 +84,7 @@ final class LazyTensorTests: XCTestCase {
         let t1 = LazyTensor(_lazy: op1, index: 1)
         XCTAssertTrue(LazyTensor.isLive(op0))
         XCTAssertFalse(LazyTensor.isLive(op1))
+
         do {
             let t3 = LazyTensor(_lazyLive: op1, index: 0)
             XCTAssertTrue(LazyTensor.isLive(op1))
@@ -92,6 +94,7 @@ final class LazyTensorTests: XCTestCase {
         }
         XCTAssertFalse(LazyTensor.isLive(op1))
         assertLive([op0])
+
         // The following are here just to ensure t0 and t1 are live.
         XCTAssertTrue(isSymbolic(t1))
         XCTAssertTrue(isSymbolic(t0))


### PR DESCRIPTION
Tracks list of `LazyTensorOperation` instances held in `LazyTensor` instances. This is required to perform batch materialization of all live tensors during lazy evaluation.