### PR TITLE
Add a 'clipped(min:max:)' method.

### DIFF
--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -213,6 +213,13 @@ public extension Tensor {
     func squeezingShape(at axes: [Int]) -> Tensor {
         return Raw.squeeze(self, squeezeDims: axes.map(Int32.init))
     }
+
+    /// Returns a `Tensor` by clipping tensor values to a specified min and max.
+    @inlinable
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
+    func clipped(min minimum: Tensor<Int32>, max maximum: Tensor<Int32>) -> Tensor{
+      return Raw.clipByValye(self, clipValueMin: minimum, clipValueMax: maximum)
+    }
 }
 
 internal extension Tensor where Scalar: TensorFlowFloatingPoint {

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -217,7 +217,7 @@ public extension Tensor {
     /// Returns a `Tensor` by clipping tensor values to a specified min and max.
     @inlinable
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
-    func clipped(min minimum: Tensor<Int32>, max maximum: Tensor<Int32>) -> Tensor{
+    func clipped<T>(min minimum: Tensor<T>, max maximum: Tensor<T>) -> Tensor{
       return Raw.clipByValue(t: self, clipValueMin: minimum, clipValueMax: maximum)
     }
 }

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -576,11 +576,11 @@ public extension Tensor {
 }
 
 public extension Tensor where Scalar: Numeric {
-    /// Returns a `Tensor` by clipping tensor values to a specified min and max.
+    /// Returns a tensor by clipping scalars to a specified minimum and maximum.
+    // FIXME: Define a derivative function.
     @inlinable
-    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
-    func clipped(min minimum: Tensor, max maximum: Tensor) -> Tensor{
-      return Raw.clipByValue(t: self, clipValueMin: minimum, clipValueMax: maximum)
+    func clipped(min: Tensor, max: Tensor) -> Tensor {
+      return Raw.clipByValue(t: self, clipValueMin: min, clipValueMax: max)
     }
 }
 

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -218,7 +218,7 @@ public extension Tensor {
     @inlinable
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func clipped(min minimum: Tensor<Int32>, max maximum: Tensor<Int32>) -> Tensor{
-      return Raw.clipByValue(self, clipValueMin: minimum, clipValueMax: maximum)
+      return Raw.clipByValue(t: self, clipValueMin: minimum, clipValueMax: maximum)
     }
 }
 

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -218,7 +218,7 @@ public extension Tensor {
     @inlinable
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func clipped(min minimum: Tensor<Int32>, max maximum: Tensor<Int32>) -> Tensor{
-      return Raw.clipByValye(self, clipValueMin: minimum, clipValueMax: maximum)
+      return Raw.clipByValue(self, clipValueMin: minimum, clipValueMax: maximum)
     }
 }
 

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -214,12 +214,6 @@ public extension Tensor {
         return Raw.squeeze(self, squeezeDims: axes.map(Int32.init))
     }
 
-    /// Returns a `Tensor` by clipping tensor values to a specified min and max.
-    @inlinable
-    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
-    func clipped<T>(min minimum: Tensor<T>, max maximum: Tensor<T>) -> Tensor{
-      return Raw.clipByValue(t: self, clipValueMin: minimum, clipValueMax: maximum)
-    }
 }
 
 internal extension Tensor where Scalar: TensorFlowFloatingPoint {
@@ -617,6 +611,14 @@ public extension Tensor {
 }
 
 public extension Tensor where Scalar: Numeric {
+
+    /// Returns a `Tensor` by clipping tensor values to a specified min and max.
+    @inlinable
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
+    func clipped(min minimum: Tensor, max maximum: Tensor) -> Tensor{
+      return Raw.clipByValue(t: self, clipValueMin: minimum, clipValueMax: maximum)
+    }
+
     @inlinable
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func unbroadcasted(toShape otherShape: Tensor<Int32>) -> Tensor {

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -213,7 +213,6 @@ public extension Tensor {
     func squeezingShape(at axes: [Int]) -> Tensor {
         return Raw.squeeze(self, squeezeDims: axes.map(Int32.init))
     }
-
 }
 
 internal extension Tensor where Scalar: TensorFlowFloatingPoint {
@@ -577,12 +576,12 @@ public extension Tensor {
 }
 
 public extension Tensor where Scalar: Numeric {
-  /// Returns a `Tensor` by clipping tensor values to a specified min and max.
-  @inlinable
-  @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
-  func clipped(min minimum: Tensor, max maximum: Tensor) -> Tensor{
-    return Raw.clipByValue(t: self, clipValueMin: minimum, clipValueMax: maximum)
-  }
+    /// Returns a `Tensor` by clipping tensor values to a specified min and max.
+    @inlinable
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
+    func clipped(min minimum: Tensor, max maximum: Tensor) -> Tensor{
+      return Raw.clipByValue(t: self, clipValueMin: minimum, clipValueMax: maximum)
+    }
 }
 
 //===------------------------------------------------------------------------------------------===//

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -581,7 +581,7 @@ public extension Tensor where Scalar: Numeric {
     // @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     @inlinable
     func clipped(min: Tensor, max: Tensor) -> Tensor {
-      return Raw.clipByValue(t: self, clipValueMin: min, clipValueMax: max)
+        Raw.clipByValue(t: self, clipValueMin: min, clipValueMax: max)
     }
 }
 

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -576,6 +576,15 @@ public extension Tensor {
     }
 }
 
+public extension Tensor where Scalar: Numeric {
+  /// Returns a `Tensor` by clipping tensor values to a specified min and max.
+  @inlinable
+  @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
+  func clipped(min minimum: Tensor, max maximum: Tensor) -> Tensor{
+    return Raw.clipByValue(t: self, clipValueMin: minimum, clipValueMax: maximum)
+  }
+}
+
 //===------------------------------------------------------------------------------------------===//
 // Broadcasting
 //===------------------------------------------------------------------------------------------===//
@@ -611,14 +620,6 @@ public extension Tensor {
 }
 
 public extension Tensor where Scalar: Numeric {
-
-    /// Returns a `Tensor` by clipping tensor values to a specified min and max.
-    @inlinable
-    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
-    func clipped(min minimum: Tensor, max maximum: Tensor) -> Tensor{
-      return Raw.clipByValue(t: self, clipValueMin: minimum, clipValueMax: maximum)
-    }
-
     @inlinable
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func unbroadcasted(toShape otherShape: Tensor<Int32>) -> Tensor {

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -578,6 +578,7 @@ public extension Tensor {
 public extension Tensor where Scalar: Numeric {
     /// Returns a tensor by clipping scalars to a specified minimum and maximum.
     // FIXME: Define a derivative function.
+    // @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     @inlinable
     func clipped(min: Tensor, max: Tensor) -> Tensor {
       return Raw.clipByValue(t: self, clipValueMin: min, clipValueMax: max)


### PR DESCRIPTION
Refer discussion [here](https://github.com/tensorflow/swift-apis/pull/187#issuecomment-500205653).

I need some help here though, I'm sure this needs a vjp as well but what would a vjp for this look like? 

Currently getting this error from the build : 
```
      error: cannot convert value of type 'Tensor<Scalar>' to expected argument type 'Tensor<_>'

      return Raw.clipByValue(t: self, clipValueMin: minimum, clipValueMax: maximum)
                                ^~~~
                                     as! Tensor<_>
```


FInally, min and max have a default value of -infinity and +infinity, do we have those identifiers in swift?
