### PR TITLE
Add a `LazyTensor.forEachOperation` method.

### DIFF
--- a/Sources/TensorFlow/LazyTensor/LazyTensorOperation.swift
+++ b/Sources/TensorFlow/LazyTensor/LazyTensorOperation.swift
@@ -105,6 +105,10 @@ class LazyTensor: _AnyTensorHandle {
         }
     }
 
+    static func onAllOperations(_ perform: (LazyTensorOperation) -> ()) {
+        for (_, counts) in operationRefCounts { perform(counts.op) }
+    }
+
     @usableFromInline
     static var _materializationCallback: (String) -> () = { _ in }
 }

--- a/Sources/TensorFlow/LazyTensor/LazyTensorOperation.swift
+++ b/Sources/TensorFlow/LazyTensor/LazyTensorOperation.swift
@@ -99,14 +99,18 @@ class LazyTensor: _AnyTensorHandle {
         return false
     }
 
-    static func onLiveOperations(_ perform: (LazyTensorOperation) -> ()) {
+    static func forEachLiveOperation(
+        _ perform: (LazyTensorOperation) throws -> Void
+    ) rethrows -> Void {
         for (_, counts) in operationRefCounts where counts.liveRefCount > 0 {
-            perform(counts.op)
+            try perform(counts.op)
         }
     }
 
-    static func onAllOperations(_ perform: (LazyTensorOperation) -> ()) {
-        for (_, counts) in operationRefCounts { perform(counts.op) }
+    static func forEachOperation(
+        _ perform: (LazyTensorOperation) throws -> Void
+    ) rethrows -> Void {
+        for (_, counts) in operationRefCounts { try perform(counts.op) }
     }
 
     @usableFromInline

--- a/Tests/TensorFlowTests/LazyTensorTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTests.swift
@@ -55,7 +55,7 @@ final class LazyTensorTests: XCTestCase {
     func testLivenessTracking() {
         func assertLive(_ expectedLive: [LazyTensorOperation]) {
             var actualLiveOps: Set<LazyTensorOperationRef> = []
-            LazyTensor.onLiveOperations {
+            LazyTensor.forEachLiveOperation {
                 actualLiveOps.insert(LazyTensorOperationRef($0))
             }
             let expectedLiveOps = Set<LazyTensorOperationRef>(
@@ -66,7 +66,7 @@ final class LazyTensorTests: XCTestCase {
 
         func assertAll(_ expectedAll: [LazyTensorOperation]) {
             var actualAllOps: Set<LazyTensorOperationRef> = []
-            LazyTensor.onAllOperations {
+            LazyTensor.forEachOperation {
                 actualAllOps.insert(LazyTensorOperationRef($0))
             }
             let expectedAllOps = Set<LazyTensorOperationRef>(

--- a/Tests/TensorFlowTests/LazyTensorTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTests.swift
@@ -64,6 +64,17 @@ final class LazyTensorTests: XCTestCase {
             XCTAssertEqual(expectedLiveOps, actualLiveOps)
         }
 
+        func assertAll(_ expectedAll: [LazyTensorOperation]) {
+            var actualAllOps: Set<LazyTensorOperationRef> = []
+            LazyTensor.onAllOperations {
+                actualAllOps.insert(LazyTensorOperationRef($0))
+            }
+            let expectedAllOps = Set<LazyTensorOperationRef>(
+                expectedAll.map { LazyTensorOperationRef($0) }
+            )
+            XCTAssertEqual(expectedAllOps, actualAllOps)
+        }
+
         func isSymbolic(_ t: LazyTensor) -> Bool {
             if case let .symbolic(_) = t.handle {
                 return true
@@ -89,11 +100,13 @@ final class LazyTensorTests: XCTestCase {
             let t3 = LazyTensor(_lazyLive: op1, index: 0)
             XCTAssertTrue(LazyTensor.isLive(op1))
             assertLive([op0, op1])
+            assertAll([op0, op1])
             // The following is here just to ensure t3 is live.
             XCTAssertTrue(isSymbolic(t3))
         }
         XCTAssertFalse(LazyTensor.isLive(op1))
         assertLive([op0])
+        assertAll([op0, op1])
 
         // The following are here just to ensure t0 and t1 are live.
         XCTAssertTrue(isSymbolic(t1))


### PR DESCRIPTION
The function is useful to iterate over all the `LazyTensorOperation` instances that have been created.