### PR TITLE
Add top-level versions of `ElementaryFunctions` operators for `Tensor`.

### DIFF
--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -406,6 +406,20 @@ internal func _vjpLog<T: TensorFlowFloatingPoint>(
     (log(x), { v in v / x })
 }
 
+/// Computes the base-two logarithm of the specified tensor element-wise.
+@inlinable
+@differentiable
+public func log2<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    log(x) / T.log(2)
+}
+
+/// Computes the base-ten logarithm of the specified tensor element-wise.
+@inlinable
+@differentiable
+public func log10<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    log(x) / T.log(10)
+}
+
 /// Computes the logarithm of `1 + x` element-wise.
 @inlinable
 @differentiable(vjp: _vjpLog1p)
@@ -506,6 +520,90 @@ internal func _vjpTanh<T: TensorFlowFloatingPoint>(
     return (value, { v in v * (1 - value.squared()) })
 }
 
+/// Computes `acos` of the specified tensor element-wise.
+@inlinable
+@differentiable(vjp: _vjpAcos(_:))
+public func acos<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.acos(x)
+}
+
+@inlinable
+internal func _vjpAcos<T: TensorFlowFloatingPoint>(
+    _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+    (acos(x), { v in -v / sqrt(1 - x.squared()) })
+}
+
+/// Computes `asin` of the specified tensor element-wise.
+@inlinable
+@differentiable(vjp: _vjpAsin(_:))
+public func asin<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.asin(x)
+}
+
+@inlinable
+internal func _vjpAsin<T: TensorFlowFloatingPoint>(
+    _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+    (asin(x), { v in v / sqrt(1 - x.squared()) })
+}
+
+/// Computes `atan` of the specified tensor element-wise.
+@inlinable
+@differentiable(vjp: _vjpAtan(_:))
+public func atan<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.atan(x)
+}
+
+@inlinable
+internal func _vjpAtan<T: TensorFlowFloatingPoint>(
+    _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+    (atan(x), { v in v / (1 + x.squared()) })
+}
+
+/// Computes `acosh` of the specified tensor element-wise.
+@inlinable
+@differentiable(vjp: _vjpAcosh(_:))
+public func acosh<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.acosh(x)
+}
+
+@inlinable
+internal func _vjpAcosh<T: TensorFlowFloatingPoint>(
+    _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+    (acosh(x), { v in v / asinh(x) })
+}
+
+/// Computes `asinh` of the specified tensor element-wise.
+@inlinable
+@differentiable(vjp: _vjpAsinh(_:))
+public func asinh<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.asinh(x)
+}
+
+@inlinable
+internal func _vjpAsinh<T: TensorFlowFloatingPoint>(
+    _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+    (asinh(x), { v in v / acosh(x) })
+}
+
+/// Computes `atanh` of the specified tensor element-wise.
+@inlinable
+@differentiable(vjp: _vjpAtanh(_:))
+public func atanh<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.atanh(x)
+}
+
+@inlinable
+internal func _vjpAtanh<T: TensorFlowFloatingPoint>(
+    _ x: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+    (atanh(x), { v in v / (1 - x.squared()) })
+}
+
 /// Computes the square of the tensor.
 public extension Tensor where Scalar: Numeric {
     @inlinable
@@ -565,6 +663,20 @@ internal func _vjpExp<T: TensorFlowFloatingPoint>(
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
     let value = exp(x)
     return (value, { v in value * v })
+}
+
+/// Computes two raised to the power of the specified tensor element-wise.
+@inlinable
+// @differentiable
+public func exp2<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    pow(2, x)
+}
+
+/// Computes ten raised to the power of the specified tensor element-wise.
+@inlinable
+// @differentiable
+public func exp10<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    pow(10, x)
 }
 
 /// Computes the exponential of `x - 1` element-wise.
@@ -749,6 +861,20 @@ public func pow<T: TensorFlowFloatingPoint>(_ lhs: T, _ rhs: Tensor<T>) -> Tenso
 // @differentiable
 public func pow<T: TensorFlowFloatingPoint>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T> {
     pow(lhs, Tensor(rhs))
+}
+
+/// Computes the power of the tensor to the scalar, broadcasting the scalar.
+@inlinable
+// @differentiable
+public func pow<T: TensorFlowFloatingPoint>(_ x: Tensor<T>, _ n: Int) -> Tensor<T> {
+    pow(x, Tensor(T(n)))
+}
+
+/// Computes the element-wise `n`th root of the tensor.
+@inlinable
+// @differentiable
+public func root<T: TensorFlowFloatingPoint>(_ x: Tensor<T>, _ n: Int) -> Tensor<T> {
+    pow(x, Tensor(T(1) / T(n)))
 }
 
 /// Computes the element-wise maximum of two tensors.

--- a/Tests/TensorFlowTests/Helpers.swift
+++ b/Tests/TensorFlowTests/Helpers.swift
@@ -15,8 +15,22 @@
 import XCTest
 @testable import TensorFlow
 
-internal func assertEqual<T: TensorFlowFloatingPoint>(_ x: Tensor<T>, _ y: Tensor<T>, accuracy: T) {
-    zip(x.scalars, y.scalars).forEach { (x, y) in
-        XCTAssertEqual(x, y, accuracy: accuracy)
+internal func assertEqual<T: TensorFlowFloatingPoint>(
+    _ x: [T], _ y: [T], accuracy: T, _ message: String = "",
+    file: StaticString = #file, line: UInt = #line
+) {
+    for (x, y) in zip(x, y) {
+        if x.isNaN || y.isNaN {
+            XCTAssertTrue(x.isNaN && y.isNaN, message, file: file, line: line)
+            continue
+        }
+        XCTAssertEqual(x, y, accuracy: accuracy, message, file: file, line: line)
     }
+}
+
+internal func assertEqual<T: TensorFlowFloatingPoint>(
+    _ x: Tensor<T>, _ y: Tensor<T>, accuracy: T, _ message: String = "",
+    file: StaticString = #file, line: UInt = #line
+) {
+    assertEqual(x.scalars, y.scalars, accuracy: accuracy, message, file: file, line: line)
 }

--- a/Tests/TensorFlowTests/OperatorTests/MathTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/MathTests.swift
@@ -16,6 +16,49 @@ import XCTest
 @testable import TensorFlow
 
 final class MathOperatorTests: XCTestCase {
+    func testElementaryFunction(
+        name: String,
+        _ tensorOperator: (Tensor<Float>) -> Tensor<Float>,
+        _ scalarOperator: (Float) -> Float,
+        accuracy: Float = 1e-4,
+        file: StaticString = #file, line: UInt = #line
+    ) {
+        let x = Tensor<Float>(randomNormal: [20], seed: (0, 0))
+        let actual = tensorOperator(x).scalars
+        let expected = x.scalars.map(scalarOperator)
+        assertEqual(actual, expected, accuracy: accuracy, name, file: file, line: line)
+    }
+
+    func testElementaryFunctions() {
+        testElementaryFunction(name: "sqrt", sqrt, Float.sqrt)
+        testElementaryFunction(name: "cos", cos, Float.cos)
+        testElementaryFunction(name: "sin", sin, Float.sin)
+        testElementaryFunction(name: "tan", tan, Float.tan)
+        testElementaryFunction(name: "cosh", cosh, Float.cosh)
+        testElementaryFunction(name: "sinh", sinh, Float.sinh)
+        testElementaryFunction(name: "tanh", tanh, Float.tanh)
+        testElementaryFunction(name: "acos", acos, Float.acos)
+        testElementaryFunction(name: "asin", asin, Float.asin)
+        testElementaryFunction(name: "atan", atan, Float.atan)
+        testElementaryFunction(name: "acosh", acosh, Float.acosh)
+        testElementaryFunction(name: "asinh", asinh, Float.asinh)
+        testElementaryFunction(name: "atanh", atanh, Float.atanh)
+        testElementaryFunction(name: "exp", exp, Float.exp)
+        testElementaryFunction(name: "exp2", exp2, Float.exp2)
+        testElementaryFunction(name: "exp10", exp10, Float.exp10)
+        testElementaryFunction(name: "expm1", expm1, Float.expm1)
+        testElementaryFunction(name: "log", log, Float.log)
+        testElementaryFunction(name: "log2", log2, Float.log2)
+        testElementaryFunction(name: "log10", log10, Float.log10)
+        testElementaryFunction(name: "log1p", log1p, Float.log1p)
+        testElementaryFunction(name: "pow",
+                               { x in pow(x, x) }, { x in Float.pow(x, x) })
+        testElementaryFunction(name: "pow",
+                               { x in pow(x, 3) }, { x in Float.pow(x, 3) })
+        testElementaryFunction(name: "root",
+                               { x in root(x, 3) }, { x in Float.root(x, 3) })
+    }
+
     func testLog1p() {
         let x = Tensor<Float>([[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]])
         let y = log1p(x)


### PR DESCRIPTION
Add `Tensor` operators:
- `acos`, `asin`, `atan`,  `acosh`, `asinh`, `atanh`,
  `log2`, `log10`, `exp2`, `exp10`, `pow(Tensor, Int)`, `root(Tensor, Int)`

Todos:
- Add operator tests.
- Mark all operators as `@differentiable`. Blocked by some bugs.
- Add derivative tests.