### PR TITLE
Gardening.

### DIFF
--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -20,7 +20,7 @@ infix operator .==: ComparisonPrecedence
 // This is a manual definition.
 @inlinable
 func pow<T: BinaryFloatingPoint>(_ x: T, _ y: T) -> T {
-    return T(pow(Double(x), Double(y)))
+    T(pow(Double(x), Double(y)))
 }
 
 // TODO:
@@ -381,7 +381,7 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
 @inlinable
 @differentiable(vjp: _vjpAbs(_:) where T: TensorFlowFloatingPoint)
 public func abs<T: SignedNumeric>(_ x: Tensor<T>) -> Tensor<T> {
-    return Raw.abs(x)
+    Raw.abs(x)
 }
 
 @inlinable
@@ -394,16 +394,16 @@ internal func _vjpAbs<T: TensorFlowFloatingPoint>(
 
 /// Computes the natural logarithm of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpLog(_:) where T: TensorFlowFloatingPoint)
-public func log<T: FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    return Raw.log(x)
+@differentiable(vjp: _vjpLog(_:))
+public func log<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.log(x)
 }
 
 @inlinable
 internal func _vjpLog<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
-    return (log(x), { v in v / x })
+    (log(x), { v in v / x })
 }
 
 /// Computes the logarithm of `1 + x` element-wise.
@@ -422,37 +422,37 @@ func _vjpLog1p<T: TensorFlowFloatingPoint>(
 
 /// Computes `sin` of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpSin(_:) where T: TensorFlowFloatingPoint)
-public func sin<T: FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    return Raw.sin(x)
+@differentiable(vjp: _vjpSin(_:))
+public func sin<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.sin(x)
 }
 
 @inlinable
 internal func _vjpSin<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
-    return (sin(x), { v in v * cos(x) })
+    (sin(x), { v in v * cos(x) })
 }
 
 /// Computes `cos` of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpCos(_:) where T: TensorFlowFloatingPoint)
-public func cos<T: FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    return Raw.cos(x)
+@differentiable(vjp: _vjpCos(_:))
+public func cos<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.cos(x)
 }
 
 @inlinable
 internal func _vjpCos<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
-    return (cos(x), { v in -v * sin(x) })
+    (cos(x), { v in -v * sin(x) })
 }
 
 /// Computes `tan` of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpTan(_:) where T: TensorFlowFloatingPoint)
-public func tan<T: FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    return Raw.tan(x)
+@differentiable(vjp: _vjpTan(_:))
+public func tan<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.tan(x)
 }
 
 @inlinable
@@ -465,37 +465,37 @@ internal func _vjpTan<T: TensorFlowFloatingPoint>(
 
 /// Computes `sinh` of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpSinh(_:) where T: TensorFlowFloatingPoint)
-public func sinh<T: FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    return Raw.sinh(x)
+@differentiable(vjp: _vjpSinh(_:))
+public func sinh<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.sinh(x)
 }
 
 @inlinable
 internal func _vjpSinh<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
-    return (sinh(x), { v in v * cosh(x) })
+    (sinh(x), { v in v * cosh(x) })
 }
 
 /// Computes `cosh` of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpCosh(_:) where T: TensorFlowFloatingPoint)
-public func cosh<T: FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    return Raw.cosh(x)
+@differentiable(vjp: _vjpCosh(_:))
+public func cosh<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.cosh(x)
 }
 
 @inlinable
 internal func _vjpCosh<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
-    return (cosh(x), { v in v * sinh(x) })
+    (cosh(x), { v in v * sinh(x) })
 }
 
 /// Computes `tanh` of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpTanh(_:) where T: TensorFlowFloatingPoint)
-public func tanh<T: FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    return Raw.tanh(x)
+@differentiable(vjp: _vjpTanh(_:))
+public func tanh<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.tanh(x)
 }
 
 @inlinable
@@ -511,22 +511,22 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpSquared() where Scalar: TensorFlowFloatingPoint)
     func squared() -> Tensor {
-        return Raw.square(self)
+        Raw.square(self)
     }
 }
 
 internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
     func _vjpSquared() -> (Tensor, (Tensor) -> Tensor) {
-        return (squared(), { 2 * self * $0 })
+        (squared(), { 2 * self * $0 })
     }
 }
 
 /// Computes the square root of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpSqrt(_:) where T: TensorFlowFloatingPoint)
-public func sqrt<T: FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    return Raw.sqrt(x)
+@differentiable(vjp: _vjpSqrt(_:))
+public func sqrt<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.sqrt(x)
 }
 
 @inlinable
@@ -539,9 +539,9 @@ internal func _vjpSqrt<T: TensorFlowFloatingPoint>(
 
 /// Computes the inverse square root of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpRsqrt(_:) where T: TensorFlowFloatingPoint)
-public func rsqrt<T: FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    return Raw.rsqrt(x)
+@differentiable(vjp: _vjpRsqrt(_:))
+public func rsqrt<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.rsqrt(x)
 }
 
 @inlinable
@@ -554,9 +554,9 @@ internal func _vjpRsqrt<T: TensorFlowFloatingPoint>(
 
 /// Computes `exp` of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpExp(_:) where T: TensorFlowFloatingPoint)
-public func exp<T: FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    return Raw.exp(x)
+@differentiable(vjp: _vjpExp(_:))
+public func exp<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.exp(x)
 }
 
 @inlinable
@@ -586,55 +586,55 @@ internal func _vjpExpm1<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpRound)
 public func round<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-  return Raw.round(x)
+    Raw.round(x)
 }
 
 @inlinable
 internal func _vjpRound<T: TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
-  return (round(x), { v in Tensor<T>(zerosLike: v) })
+    (round(x), { v in Tensor<T>(zerosLike: v) })
 }
 
 /// Computes the ceiling of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpCeil(_:) where T: TensorFlowFloatingPoint)
-public func ceil<T: FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    return Raw.ceil(x)
+@differentiable(vjp: _vjpCeil(_:))
+public func ceil<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.ceil(x)
 }
 
 @inlinable
 internal func _vjpCeil<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
-    return (ceil(x), { _ in Tensor(0).broadcasted(like: x) })
+    (ceil(x), { _ in Tensor(0).broadcasted(like: x) })
 }
 
 /// Computes the floor of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpFloor(_:) where T: TensorFlowFloatingPoint)
-public func floor<T: FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    return Raw.floor(x)
+@differentiable(vjp: _vjpFloor(_:))
+public func floor<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.floor(x)
 }
 
 @inlinable
 internal func _vjpFloor<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
-    return (floor(x), { _ in Tensor(0).broadcasted(like: x) })
+    (floor(x), { _ in Tensor(0).broadcasted(like: x) })
 }
 
 @inlinable
 @differentiable(vjp: _vjpSign(_:) where T: TensorFlowFloatingPoint)
 public func sign<T: Numeric>(_ x: Tensor<T>) -> Tensor<T> {
-    return Raw.sign(x)
+    Raw.sign(x)
 }
 
 @inlinable
 internal func _vjpSign<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
-    return (sign(x), { v in Tensor<T>(zerosLike: x) })
+    (sign(x), { v in Tensor<T>(zerosLike: x) })
 }
 
 /// Computes the sigmoid of the specified tensor element-wise.
@@ -642,28 +642,28 @@ internal func _vjpSign<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpSigmoid)
 public func sigmoid<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    return Raw.sigmoid(x)
+    Raw.sigmoid(x)
 }
 
 @inlinable
 internal func _vjpSigmoid<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
-    return (sigmoid(x), { v in Raw.sigmoidGrad(x, dy: v) })
+    (sigmoid(x), { v in Raw.sigmoidGrad(x, dy: v) })
 }
 
 /// Computes the softmax of the specified tensor along the last axis.
 /// Specifically, computes `exp(x) / exp(x).sum(alongAxes: -1)`.
 @inlinable
-@differentiable(vjp: _vjpSoftmax(_:) where T: TensorFlowFloatingPoint)
-public func softmax<T: FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    return Raw.softmax(logits: x)
+@differentiable(vjp: _vjpSoftmax(_:))
+public func softmax<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.softmax(logits: x)
 }
 
 /// Computes the softmax of the specified tensor along the specified axis.
 /// Specifically, computes `exp(x) / exp(x).sum(alongAxes: axis)`.
 @inlinable
-// TODO: [AD].
+@differentiable
 public func softmax<T: TensorFlowFloatingPoint>(_ x: Tensor<T>, alongAxis axis: Int) -> Tensor<T> {
     let xExp = exp(x)
     return xExp / xExp.sum(alongAxes: Tensor<Int32>(Int32(axis)))
@@ -682,9 +682,9 @@ func _vjpSoftmax<T: TensorFlowFloatingPoint>(
 
 /// Computes the log-softmax of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpLogSoftmax(_:) where T: TensorFlowFloatingPoint)
-public func logSoftmax<T: FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    return Raw.logSoftmax(logits: x)
+@differentiable(vjp: _vjpLogSoftmax(_:))
+public func logSoftmax<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    Raw.logSoftmax(logits: x)
 }
 
 @inlinable
@@ -698,16 +698,16 @@ func _vjpLogSoftmax<T: TensorFlowFloatingPoint>(
 /// Computes `relu` of the specified tensor element-wise.
 /// Specifically, computes `max(0, x)`.
 @inlinable
-@differentiable(vjp: _vjpRelu(_:) where T: TensorFlowFloatingPoint)
-public func relu<T: FloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    return max(0, x)
+@differentiable(vjp: _vjpRelu(_:))
+public func relu<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+    max(0, x)
 }
 
 @inlinable
 func _vjpRelu<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
-    return (relu(x), { v in Tensor(x .> 0) * v })
+    (relu(x), { v in Tensor(x .> 0) * v })
 }
 
 //===------------------------------------------------------------------------------------------===//
@@ -716,9 +716,9 @@ func _vjpRelu<T: TensorFlowFloatingPoint>(
 
 /// Computes the power of the first tensor to the second tensor.
 @inlinable
-@differentiable(vjp: _vjpPow(_:_:) where T: TensorFlowFloatingPoint)
-public func pow<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T> where T: FloatingPoint {
-    return Raw.pow(lhs, rhs)
+@differentiable(vjp: _vjpPow(_:_:))
+public func pow<T: TensorFlowFloatingPoint>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T> {
+    Raw.pow(lhs, rhs)
 }
 
 @inlinable
@@ -739,16 +739,16 @@ internal func _vjpPow<T: TensorFlowFloatingPoint>(
 
 /// Computes the power of the scalar to the tensor, broadcasting the scalar.
 @inlinable
-// @differentiable(where T: TensorFlowFloatingPoint)
-public func pow<T>(_ lhs: T, _ rhs: Tensor<T>) -> Tensor<T> where T: FloatingPoint {
-    return pow(Tensor(lhs), rhs)
+// @differentiable
+public func pow<T: TensorFlowFloatingPoint>(_ lhs: T, _ rhs: Tensor<T>) -> Tensor<T> {
+    pow(Tensor(lhs), rhs)
 }
 
 /// Computes the power of the tensor to the scalar, broadcasting the scalar.
 @inlinable
-// @differentiable(where T: TensorFlowFloatingPoint)
-public func pow<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T> where T: FloatingPoint {
-    return pow(lhs, Tensor(rhs))
+// @differentiable
+public func pow<T: TensorFlowFloatingPoint>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T> {
+    pow(lhs, Tensor(rhs))
 }
 
 /// Computes the element-wise maximum of two tensors.
@@ -756,7 +756,7 @@ public func pow<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T> where T: FloatingPoi
 @inlinable
 @differentiable(vjp: _vjpMax(_:_:) where T: TensorFlowFloatingPoint)
 public func max<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T> where T: Numeric & Comparable {
-    return Raw.maximum(lhs, rhs)
+    Raw.maximum(lhs, rhs)
 }
 
 @inlinable
@@ -771,14 +771,14 @@ internal func _vjpMax<T: TensorFlowFloatingPoint>(
 @inlinable
 // @differentiable(where T: TensorFlowFloatingPoint)
 public func max<T>(_ lhs: T, _ rhs: Tensor<T>) -> Tensor<T> where T: Numeric & Comparable {
-    return max(Tensor(lhs), rhs)
+    max(Tensor(lhs), rhs)
 }
 
 /// Computes the element-wise maximum of the scalar and the tensor, broadcasting the scalar.
 @inlinable
 // @differentiable(where T: TensorFlowFloatingPoint)
 public func max<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T> where T: Numeric & Comparable {
-    return max(lhs, Tensor(rhs))
+    max(lhs, Tensor(rhs))
 }
 
 /// Computes the element-wise minimum of two tensors.
@@ -786,7 +786,7 @@ public func max<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T> where T: Numeric & C
 @inlinable
 @differentiable(vjp: _vjpMin(_:_:) where T: TensorFlowFloatingPoint)
 public func min<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T> where T: Numeric & Comparable {
-    return Raw.minimum(lhs, rhs)
+    Raw.minimum(lhs, rhs)
 }
 
 @inlinable
@@ -801,14 +801,14 @@ internal func _vjpMin<T: TensorFlowFloatingPoint>(
 @inlinable
 // @differentiable(where T: TensorFlowFloatingPoint)
 public func min<T>(_ lhs: T, _ rhs: Tensor<T>) -> Tensor<T> where T: Numeric & Comparable {
-    return min(Tensor(lhs), rhs)
+    min(Tensor(lhs), rhs)
 }
 
 /// Computes the element-wise minimum of the scalar and the tensor, broadcasting the scalar.
 @inlinable
 // @differentiable(where T: TensorFlowFloatingPoint)
 public func min<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T> where T: Numeric & Comparable {
-    return min(lhs, Tensor(rhs))
+    min(lhs, Tensor(rhs))
 }
 
 @inlinable
@@ -843,7 +843,7 @@ public extension Tensor {
     @inlinable
     @differentiable(wrt: (self, other), vjp: _vjpReplacing where Scalar: TensorFlowFloatingPoint)
     func replacing(with other: Tensor, where mask: Tensor<Bool>) -> Tensor {
-        return Raw.select(condition: mask, t: other, e: self)
+        Raw.select(condition: mask, t: other, e: self)
     }
 }
 
@@ -971,7 +971,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
     @inlinable
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func max(squeezingAxes axes: Int...) -> Tensor {
-        return max(squeezingAxes: axes)
+        max(squeezingAxes: axes)
     }
 
     /// Returns the minimum values along the specified axes. The reduced dimensions are removed.
@@ -982,7 +982,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
         wrt: self,
         vjp: _vjpMinOrMax(squeezingAxes:) where Scalar: TensorFlowFloatingPoint)
     func min(squeezingAxes axes: Tensor<Int32>) -> Tensor {
-        return Raw.min(self, reductionIndices: axes, keepDims: false)
+        Raw.min(self, reductionIndices: axes, keepDims: false)
     }
 
     /// Returns the minimum values along the specified axes. The reduced dimensions are removed.
@@ -1002,7 +1002,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
     @inlinable
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func min(squeezingAxes axes: Int...) -> Tensor {
-        return min(squeezingAxes: axes)
+        min(squeezingAxes: axes)
     }
 
     /// Returns the indices of the maximum values along the specified axes. The reduced dimensions
@@ -1011,7 +1011,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
     func argmax(squeezingAxis axis: Int) -> Tensor<Int32> {
-        return Raw.argMax(self, dimension: Tensor<Int32>(Int32(axis)))
+        Raw.argMax(self, dimension: Tensor<Int32>(Int32(axis)))
     }
 
     /// Returns the indices of the minimum values along the specified axes. The reduced dimensions
@@ -1020,7 +1020,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
     func argmin(squeezingAxis axis: Int) -> Tensor<Int32> {
-        return Raw.argMin(self, dimension: Tensor<Int32>(Int32(axis)))
+        Raw.argMin(self, dimension: Tensor<Int32>(Int32(axis)))
     }
 
     /// Returns the minimum along the specified axes. The reduced dimensions are retained with
@@ -1030,7 +1030,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpMinOrMax(alongAxes:) where Scalar: TensorFlowFloatingPoint)
     func min(alongAxes axes: Tensor<Int32>) -> Tensor {
-        return Raw.min(self, reductionIndices: axes, keepDims: true)
+        Raw.min(self, reductionIndices: axes, keepDims: true)
     }
 
     /// Returns the minimum along the specified axes. The reduced dimensions are retained with
@@ -1049,7 +1049,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
     func min(alongAxes axes: Int...) -> Tensor {
-        return min(alongAxes: axes)
+        min(alongAxes: axes)
     }
 
     /// Returns the minimum along the specified axes. The reduced dimensions are retained with
@@ -1059,7 +1059,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpMinOrMax(alongAxes:) where Scalar: TensorFlowFloatingPoint)
     func max(alongAxes axes: Tensor<Int32>) -> Tensor {
-        return Raw.max(self, reductionIndices: axes, keepDims: true)
+        Raw.max(self, reductionIndices: axes, keepDims: true)
     }
 
     /// Returns the minimum along the specified axes. The reduced dimensions are retained with
@@ -1078,19 +1078,19 @@ public extension Tensor where Scalar: Numeric & Comparable {
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
     func max(alongAxes axes: Int...) -> Tensor {
-        return max(alongAxes: axes)
+        max(alongAxes: axes)
     }
 
     /// Returns the index of the maximum value of the flattened scalars.
     @inlinable
     func argmax() -> Tensor<Int32> {
-        return flattened().argmax(squeezingAxis: 0)
+        flattened().argmax(squeezingAxis: 0)
     }
 
     /// Returns the index of the minimum value of the flattened scalars.
     @inlinable
     func argmin() -> Tensor<Int32> {
-        return flattened().argmin(squeezingAxis: 0)
+        flattened().argmin(squeezingAxis: 0)
     }
 }
 
@@ -1137,7 +1137,7 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpSum(squeezingAxes:) where Scalar: TensorFlowFloatingPoint)
     func sum(squeezingAxes axes: Tensor<Int32>) -> Tensor {
-        return Raw.sum(self, reductionIndices: axes, keepDims: false)
+        Raw.sum(self, reductionIndices: axes, keepDims: false)
     }
 
     /// Returns the sum along the specified axes. The reduced dimensions are removed.
@@ -1157,13 +1157,13 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func sum(squeezingAxes axes: Int...) -> Tensor {
-        return sum(squeezingAxes: axes)
+        sum(squeezingAxes: axes)
     }
 
     @inlinable
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func sum() -> Tensor {
-        return flattened().sum(squeezingAxes: 0)
+        flattened().sum(squeezingAxes: 0)
     }
 
     /// Returns the sum along the specified axes. The reduced dimensions are retained with value 1.
@@ -1172,7 +1172,7 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpSum(alongAxes:) where Scalar: TensorFlowFloatingPoint)
     func sum(alongAxes axes: Tensor<Int32>) -> Tensor {
-        return Raw.sum(self, reductionIndices: axes, keepDims: true)
+        Raw.sum(self, reductionIndices: axes, keepDims: true)
     }
 
     /// Returns the sum along the specified axes. The reduced dimensions are retained with value 1.
@@ -1192,7 +1192,7 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func sum(alongAxes axes: Int...) -> Tensor {
-        return sum(alongAxes: axes)
+        sum(alongAxes: axes)
     }
 
     // MARK: - Product
@@ -1204,7 +1204,7 @@ public extension Tensor where Scalar: Numeric {
     // TODO: Make this @differentiable.
     @inlinable
     func product(squeezingAxes axes: Tensor<Int32>) -> Tensor {
-        return Raw.prod(self, reductionIndices: axes, keepDims: false)
+        Raw.prod(self, reductionIndices: axes, keepDims: false)
     }
 
     /// Returns the product along the specified axes. The reduced dimensions are removed.
@@ -1224,12 +1224,12 @@ public extension Tensor where Scalar: Numeric {
     /// - Precondition: Each value in `axes` must be in the range `-rank...rank`.
     @inlinable
     func product(squeezingAxes axes: Int...) -> Tensor {
-        return product(squeezingAxes: axes)
+        product(squeezingAxes: axes)
     }
 
     @inlinable
     func product() -> Tensor {
-        return flattened().product(squeezingAxes: 0)
+        flattened().product(squeezingAxes: 0)
     }
 
     /// Returns the product along the specified axes. The reduced dimensions are retained with
@@ -1238,7 +1238,7 @@ public extension Tensor where Scalar: Numeric {
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
     func product(alongAxes axes: Tensor<Int32>) -> Tensor {
-        return Raw.prod(self, reductionIndices: axes, keepDims: true)
+        Raw.prod(self, reductionIndices: axes, keepDims: true)
     }
 
     /// Returns the product along the specified axes. The reduced dimensions are retained with
@@ -1258,7 +1258,7 @@ public extension Tensor where Scalar: Numeric {
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
     func product(alongAxes axes: Int...) -> Tensor {
-        return product(alongAxes: axes)
+        product(alongAxes: axes)
     }
 
     // MARK: - Mean
@@ -1269,7 +1269,7 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpMean(squeezingAxes:) where Scalar: TensorFlowFloatingPoint)
     func mean(squeezingAxes axes: Tensor<Int32>) -> Tensor {
-        return Raw.mean(self, reductionIndices: axes, keepDims: false)
+        Raw.mean(self, reductionIndices: axes, keepDims: false)
     }
 
     /// Returns the arithmetic mean along the specified axes. The reduced dimensions are removed.
@@ -1289,13 +1289,13 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func mean(squeezingAxes axes: Int...) -> Tensor {
-        return mean(squeezingAxes: axes)
+        mean(squeezingAxes: axes)
     }
 
     @inlinable
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func mean() -> Tensor {
-        return flattened().mean(squeezingAxes: [0])
+        flattened().mean(squeezingAxes: [0])
     }
 
     /// Returns the arithmetic mean along the specified axes. The reduced dimensions are retained
@@ -1305,7 +1305,7 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpMean(alongAxes:) where Scalar: TensorFlowFloatingPoint)
     func mean(alongAxes axes: Tensor<Int32>) -> Tensor {
-        return Raw.mean(self, reductionIndices: axes, keepDims: true)
+        Raw.mean(self, reductionIndices: axes, keepDims: true)
     }
 
     /// Returns the arithmetic mean along the specified axes. The reduced dimensions are retained
@@ -1327,7 +1327,7 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func mean(alongAxes axes: Int...) -> Tensor {
-        return mean(alongAxes: axes)
+        mean(alongAxes: axes)
     }
 
     // MARK: - Variance
@@ -1362,7 +1362,7 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func variance(squeezingAxes axes: Int...) -> Tensor {
-        return variance(squeezingAxes: axes)
+        variance(squeezingAxes: axes)
     }
 
     @inlinable
@@ -1403,7 +1403,7 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func variance(alongAxes axes: Int...) -> Tensor {
-        return variance(alongAxes: axes)
+        variance(alongAxes: axes)
     }
 }
 
@@ -1452,7 +1452,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
     @differentiable(wrt: self)
     func standardDeviation(squeezingAxes axes: Tensor<Int32>) -> Tensor {
-        return sqrt(variance(squeezingAxes: axes))
+        sqrt(variance(squeezingAxes: axes))
     }
 
     /// Returns the standard deviation of the elements along the specified axes. The reduced
@@ -1463,7 +1463,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
     @differentiable(wrt: self)
     func standardDeviation(squeezingAxes axes: [Int]) -> Tensor {
-        return sqrt(variance(squeezingAxes: axes))
+        sqrt(variance(squeezingAxes: axes))
     }
 
     /// Returns the standard deviation of the elements along the specified axes. The reduced
@@ -1474,7 +1474,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
     @differentiable(wrt: self)
     func standardDeviation(squeezingAxes axes: Int...) -> Tensor {
-        return standardDeviation(squeezingAxes: axes)
+        standardDeviation(squeezingAxes: axes)
     }
 
     /// Returns the standard deviation of the elements along the specified axes. The reduced
@@ -1486,7 +1486,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     @differentiable(wrt: self)
     func standardDeviation() -> Tensor {
         // Reduce along all dimensions.
-        return standardDeviation(squeezingAxes: Array(0..<shape.rank))
+        standardDeviation(squeezingAxes: Array(0..<shape.rank))
     }
 
     /// Returns the standard deviation of the elements along the specified axes. The reduced
@@ -1497,7 +1497,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
     @differentiable(wrt: self)
     func standardDeviation(alongAxes axes: Tensor<Int32>) -> Tensor {
-        return sqrt(variance(alongAxes: axes))
+        sqrt(variance(alongAxes: axes))
     }
 
     /// Returns the standard deviation of the elements along the specified axes. The reduced
@@ -1521,7 +1521,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
     @differentiable(wrt: self)
     func standardDeviation(alongAxes axes: Int...) -> Tensor {
-        return sqrt(variance(alongAxes: axes))
+        sqrt(variance(alongAxes: axes))
     }
 }
 
@@ -1592,7 +1592,7 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(vjp: _vjpMatmulOperator(lhs:rhs:) where Scalar: TensorFlowFloatingPoint)
     static func • (lhs: Tensor, rhs: Tensor) -> Tensor {
-        return matmul(lhs, rhs)
+        matmul(lhs, rhs)
     }
 }
 
@@ -1605,6 +1605,6 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
         lhs: Tensor,
         rhs: Tensor
     ) -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
-        return _vjpMatmul(lhs, rhs)
+        _vjpMatmul(lhs, rhs)
     }
 }

--- a/Sources/TensorFlow/Operators/NN.swift
+++ b/Sources/TensorFlow/Operators/NN.swift
@@ -76,36 +76,6 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     }
 }
 
-public extension Tensor where Scalar: BinaryFloatingPoint {
-    /// Computes the batch normalized tensor along the specified axis.
-    ///
-    /// Specifically, returns `(self - mu)/(var + epsilon) * gamma + beta` where
-    /// `mu` and `var` are respectively the mean and variance of `self` along
-    /// `axis`.
-    ///
-    /// - Parameters:
-    ///     - axis: The batch dimension.
-    ///     - offset: The offset, also known as beta.
-    ///     - scale: The scale, also known as gamma.
-    ///     - epsilon: A small value added to the denominator for numerical stability.
-    @inlinable
-    @differentiable(
-        wrt: (self, offset, scale),
-        vjp: _vjpBatchNormalized where Scalar: TensorFlowFloatingPoint)
-    func batchNormalized(
-        alongAxis axis: Int,
-        offset: Tensor = Tensor(0),
-        scale: Tensor = Tensor(1),
-        epsilon: Scalar = 0.001
-    ) -> Tensor {
-        let mean = self.mean(alongAxes: axis)
-        let squaredDiff: Tensor = Raw.squaredDifference(self, mean)
-        let variance = squaredDiff.mean(alongAxes: axis)
-        let inv = rsqrt(variance + epsilon) * scale
-        return self * inv + offset - mean * inv
-    }
-}
-
 //===------------------------------------------------------------------------------------------===//
 // Convolution and Pooling
 //===------------------------------------------------------------------------------------------===//


### PR DESCRIPTION
- Change all `@differentiable` operators constrained on `T: FloatingPoint`
  to be constrained on `T: TensorFlowFloatingPoint` for consistency.
- Omit return for single expression functions in Sources/TensorFlow/Operators/Math.swift for consistency.