### PR TITLE
Make `TensorFlowFloatingPoint` refine `ElementaryFunctions`.

### DIFF
--- a/Sources/TensorFlow/Core/DataTypes.swift
+++ b/Sources/TensorFlow/Core/DataTypes.swift
@@ -74,7 +74,8 @@ public typealias TensorFlowInteger = TensorFlowScalar & BinaryInteger
 ///
 /// - Note: `Tensor` conditionally conforms to `Differentiable` when the `Scalar` associated type
 ///   conforms `TensorFlowFloatingPoint`.
-public protocol TensorFlowFloatingPoint: TensorFlowScalar & BinaryFloatingPoint & Differentiable
+public protocol TensorFlowFloatingPoint:
+    TensorFlowScalar & BinaryFloatingPoint & Differentiable & ElementaryFunctions
     where Self.RawSignificand: FixedWidthInteger,
           Self == Self.TangentVector,
           Self == Self.AllDifferentiableVariables {}


### PR DESCRIPTION
Enables use of `ElementaryFunctions` requirements on `TensorFlowFloatingPoint`-constrained types, e.g. `T.log(2)` where `T: TensorFlowFloatingPoint`.