### PR TITLE
Add support for calling functions directly by name.

### DIFF
--- a/Sources/TensorFlow/Bindings/EagerExecution.swift
+++ b/Sources/TensorFlow/Bindings/EagerExecution.swift
@@ -266,12 +266,15 @@ internal struct TFE_Op: TFTensorOperation {
         }
     }
 
-    @inlinable @inline(__always)
     internal func updateAttribute<In: TensorGroup, Out: TensorGroup>(
         _ name: String,
         _ value: (In) -> Out
     ) {
-        _tffunc(value).utf8CString.withUnsafeBufferPointer { buffer in
+        updateAttribute(name, _TensorFunctionPointer(name: _tffunc(value)))
+    }
+
+    internal func updateAttribute(_ name: String, _ value: _TensorFunctionPointer) {
+        value.name.utf8CString.withUnsafeBufferPointer { buffer in
             // utf8CString is null-terminated; TFE_OpSetAttrFunctionName wants
             // non-null-terminated.
             TFE_OpSetAttrFunctionName(op, name, buffer.baseAddress, buffer.count - 1)

--- a/Sources/TensorFlow/Bindings/TFTensorOperation.swift
+++ b/Sources/TensorFlow/Bindings/TFTensorOperation.swift
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// Opaque reference to a function that has been made callable by loading it
+/// into the runtime.
+public struct _TensorFunctionPointer {
+    var name: String
+}
+
 // A protocol for a tensor operation.
 public protocol TensorOperation {
     // We use functions instead of fields to give freedom in the representation for the conforming
@@ -59,6 +65,7 @@ public protocol TFTensorOperation: TensorOperation {
     func updateAttribute(_ name: String, _ value: [TensorShape])
     func updateAttribute(_ name: String, _ value: [TensorShape?])
     func updateAttribute<In: TensorGroup, Out: TensorGroup>(_ name: String, _ value: (In) -> Out)
+    func updateAttribute(_ name: String, _ value: _TensorFunctionPointer)
 
     func execute()
 

--- a/Sources/TensorFlow/Core/LazyTensorOperation.swift
+++ b/Sources/TensorFlow/Core/LazyTensorOperation.swift
@@ -152,6 +152,7 @@ class LazyTensorOperation: TensorOperation {
         case StringArray([String])
         case ConstTensor(TFETensorHandle)
         case TensorDataTypeValue(TensorDataType)
+        case TensorFunctionPointer(_TensorFunctionPointer)
     }
 
     let name: String
@@ -264,6 +265,9 @@ class LazyTensorOperation: TensorOperation {
     }
     func updateAttribute(_ name: String, _ value: [String]) {
         attrs[name] = Attribute.StringArray(value)
+    }
+    func updateAttribute(_ name: String, _ value: _TensorFunctionPointer) {
+        attrs[name] = Attribute.TensorFunctionPointer(value)
     }
 }
 
@@ -654,6 +658,7 @@ extension LazyTensorOperation.Attribute: CustomStringConvertible {
         case .StringArray(let values): return arrayAsString("String", values)
         case .ConstTensor(let v): return v.valueDescription
         case .TensorDataTypeValue(let v): return dataTypeAsString(v)
+        case .TensorFunctionPointer(let v): return "TFFunction(\(v.name))"
         }
     }
 

--- a/Tests/TensorFlowTests/LazyTensorOperationTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorOperationTests.swift
@@ -172,6 +172,12 @@ final class LazyTensorOperationTests: XCTestCase {
         )
     }
 
+    func testFunctionAttribute() {
+        let op0 = LazyTensorOperation(_id: "0", name: "Nop", outputCount: 1)
+        op0.updateAttribute("fn", _TensorFunctionPointer(name: "ExampleFunction"))
+        XCTAssertEqual(op0.description, "%0 = Nop[fn: TFFunction(ExampleFunction)]()")
+    }
+
     static var allTests = [
         ("testNoInput", testNoInput),
         ("testSingleInput", testSingleInput),
@@ -184,6 +190,7 @@ final class LazyTensorOperationTests: XCTestCase {
         ("testStringAttribute", testStringAttribute),
         ("testTensorDataTypeAttribute", testTensorDataTypeAttribute),
         ("testArrayAttributes", testArrayAttributes),
-        ("testMultipleAttributes", testMultipleAttributes)
+        ("testMultipleAttributes", testMultipleAttributes),
+        ("testFunctionAttribute", testFunctionAttribute)
     ]
 }


### PR DESCRIPTION
This should allow using the TFE_Op code directly when dispatching traced code. This will make tracing and lazy-tensor more symmetric.