### PR TITLE
Fix compilation errors.

### DIFF
--- a/Sources/TensorFlow/Bindings/EagerExecution.swift
+++ b/Sources/TensorFlow/Bindings/EagerExecution.swift
@@ -266,6 +266,7 @@ internal struct TFE_Op: TFTensorOperation {
         }
     }
 
+    @inlinable @inline(__always)
     internal func updateAttribute<In: TensorGroup, Out: TensorGroup>(
         _ name: String,
         _ value: (In) -> Out
@@ -273,6 +274,7 @@ internal struct TFE_Op: TFTensorOperation {
         updateAttribute(name, _TensorFunctionPointer(name: _tffunc(value)))
     }
 
+    @inlinable @inline(__always)
     internal func updateAttribute(_ name: String, _ value: _TensorFunctionPointer) {
         value.name.utf8CString.withUnsafeBufferPointer { buffer in
             // utf8CString is null-terminated; TFE_OpSetAttrFunctionName wants

--- a/Sources/TensorFlow/Bindings/TFTensorOperation.swift
+++ b/Sources/TensorFlow/Bindings/TFTensorOperation.swift
@@ -15,7 +15,10 @@
 /// Opaque reference to a function that has been made callable by loading it
 /// into the runtime.
 public struct _TensorFunctionPointer {
-    var name: String
+    public var name: String
+    public init(name: String) {
+        self.name = name
+    }
 }
 
 // A protocol for a tensor operation.

--- a/Sources/TensorFlow/Core/LazyTensorOperation.swift
+++ b/Sources/TensorFlow/Core/LazyTensorOperation.swift
@@ -33,7 +33,7 @@ class LazyTensor: _AnyTensorHandle {
         switch handle {
         case .concrete(let h, _):
             return h
-        case .symbolic(let op, let index, _):
+        case .symbolic(_, _, _):
             assert(false, "TODO: to be send out in a separate PR.")
             // return op.materialized(index: index)
         }


### PR DESCRIPTION
Fix `apple/swift` compilation errors.

```
/Users/danielzheng/swift-dev/tensorflow-swift-apis/Sources/TensorFlow/Bindings/EagerExecution.swift:274:31: error: initializer 'init(name:)' is internal and cannot be referenced from an '@inlinable' function
        updateAttribute(name, _TensorFunctionPointer(name: _tffunc(value)))
                              ^
/Users/danielzheng/swift-dev/tensorflow-swift-apis/Sources/TensorFlow/Bindings/TFTensorOperation.swift:17:15: note: initializer 'init(name:)' is not '@usableFromInline' or public
public struct _TensorFunctionPointer {
              ^
/Users/danielzheng/swift-dev/tensorflow-swift-apis/Sources/TensorFlow/Bindings/EagerExecution.swift:279:15: error: property 'name' is internal and cannot be referenced from an '@inlinable' function
        value.name.utf8CString.withUnsafeBufferPointer { buffer in
              ^
/Users/danielzheng/swift-dev/tensorflow-swift-apis/Sources/TensorFlow/Bindings/TFTensorOperation.swift:18:9: note: property 'name' is not '@usableFromInline' or public
    var name: String
        ^
```