### PR TITLE
Add softplus and softsign

### DIFF
--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -896,6 +896,38 @@ internal func _vjpSigmoid<T: TensorFlowFloatingPoint>(
     (sigmoid(x), { v in Raw.sigmoidGrad(x, dy: v) })
 }
 
+/// Computes the softplus of the specified tensor.
+// Specifically, computes `log(exp(features) + 1)`.
+@inlinable
+@differentiable(vjp: _vjpSoftplus)
+public func softplus<T: TensorFlowFloatingPoint>(_ features: Tensor<T>) -> Tensor<T> {
+    Raw.softplus(features: features)
+}
+
+@inlinable
+internal func _vjpSoftplus<T: TensorFlowFloatingPoint>(
+    _ features: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+    (softplus(features), { v in Raw.softplusGrad(gradients: v, features: features)})
+}
+
+/// Computes the softsign of the specified tensor.
+/// Specifically, computes `features/ (abs(features) + 1)`.
+/// Computes the softplus of the specified tensor.
+// Specifically, computes `log(exp(features) + 1)`.
+@inlinable
+@differentiable(vjp: _vjpSoftsign)
+public func softsign<T: TensorFlowFloatingPoint>(_ features: Tensor<T>) -> Tensor<T> {
+    Raw.softsign(features: features)
+}
+
+@inlinable
+internal func _vjpSoftsign<T: TensorFlowFloatingPoint>(
+    _ features: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+    (softsign(features), { v in Raw.softsignGrad(gradients: v, features: features)})
+}
+
 /// Computes the softmax of the specified tensor along the last axis.
 /// Specifically, computes `exp(x) / exp(x).sum(alongAxes: -1)`.
 @inlinable

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -896,7 +896,7 @@ internal func _vjpSigmoid<T: TensorFlowFloatingPoint>(
     (sigmoid(x), { v in Raw.sigmoidGrad(x, dy: v) })
 }
 
-/// Computes the softplus of the specified tensor element-wise.
+/// Returns the softplus of the specified tensor element-wise.
 /// Specifically, computes `log(exp(features) + 1)`.
 @inlinable
 @differentiable(vjp: _vjpSoftplus)
@@ -911,7 +911,7 @@ internal func _vjpSoftplus<T: TensorFlowFloatingPoint>(
     (softplus(features), { v in Raw.softplusGrad(gradients: v, features: features)})
 }
 
-/// Computes the softsign of the specified tensor element-wise.
+/// Returns the softsign of the specified tensor element-wise.
 /// Specifically, computes `features/ (abs(features) + 1)`.
 @inlinable
 @differentiable(vjp: _vjpSoftsign)

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -896,8 +896,8 @@ internal func _vjpSigmoid<T: TensorFlowFloatingPoint>(
     (sigmoid(x), { v in Raw.sigmoidGrad(x, dy: v) })
 }
 
-/// Computes the softplus of the specified tensor.
-// Specifically, computes `log(exp(features) + 1)`.
+/// Computes the softplus of the specified tensor element-wise.
+/// Specifically, computes `log(exp(features) + 1)`.
 @inlinable
 @differentiable(vjp: _vjpSoftplus)
 public func softplus<T: TensorFlowFloatingPoint>(_ features: Tensor<T>) -> Tensor<T> {
@@ -911,10 +911,8 @@ internal func _vjpSoftplus<T: TensorFlowFloatingPoint>(
     (softplus(features), { v in Raw.softplusGrad(gradients: v, features: features)})
 }
 
-/// Computes the softsign of the specified tensor.
+/// Computes the softsign of the specified tensor element-wise.
 /// Specifically, computes `features/ (abs(features) + 1)`.
-/// Computes the softplus of the specified tensor.
-// Specifically, computes `log(exp(features) + 1)`.
 @inlinable
 @differentiable(vjp: _vjpSoftsign)
 public func softsign<T: TensorFlowFloatingPoint>(_ features: Tensor<T>) -> Tensor<T> {

--- a/Tests/TensorFlowTests/OperatorTests/MathTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/MathTests.swift
@@ -118,7 +118,7 @@ final class MathOperatorTests: XCTestCase {
             x.variance(squeezingAxes: 0),
             Tensor(shape: [5], scalars: [0, 0, 0, 0, 0]))
         XCTAssertEqual(
-            x.variance(alongAxes: 0), 
+            x.variance(alongAxes: 0),
             Tensor(shape: [5], scalars: [0, 0, 0, 0, 0]))
         XCTAssertEqual(
             x.variance(squeezingAxes: 1),
@@ -214,6 +214,24 @@ final class MathOperatorTests: XCTestCase {
         XCTAssertEqual(result.scalars, [12.5, 6.5])
     }
 
+    func testSoftplus() {
+      let x = Tensor<Float>([1.0, 2.0, 3.0])
+      let y = softplus(x)
+      let expected = Tensor<Float>([[1.3132616,  2.126928, 3.0485873]])
+      XCTAssertEqual(x, expected)
+    }
+
+    func testSoftsign() {
+      let x = Tensor<Float>([1.0, 4.0, 3.0])
+      let y = softsign(x)
+      let expected = Tensor<Float>([0.5 , 0.8 , 0.75]])
+      XCTAssertEqual(x, expected)
+    }
+
+    func testSoftsign() {
+
+    }
+
     func testXORInference() {
         func xor(_ x: Float, _ y: Float) -> Float {
             let x = Tensor<Float>([x, y]).reshaped(to: [1, 2])
@@ -281,6 +299,8 @@ final class MathOperatorTests: XCTestCase {
         ("testSign", testSign),
         ("testReduction", testReduction),
         ("testArgmax", testArgmax),
+        ("testSoftplus", testSoftplus),
+        ("testSoftsign", testSoftsign),
         ("testCeilAndFloor", testCeilAndFloor),
         ("testSimpleMath", testSimpleMath),
         ("testStandardDeviation", testStandardDeviation),

--- a/Tests/TensorFlowTests/OperatorTests/MathTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/MathTests.swift
@@ -228,10 +228,6 @@ final class MathOperatorTests: XCTestCase {
       XCTAssertEqual(x, expected)
     }
 
-    func testSoftsign() {
-
-    }
-
     func testXORInference() {
         func xor(_ x: Float, _ y: Float) -> Float {
             let x = Tensor<Float>([x, y]).reshaped(to: [1, 2])

--- a/Tests/TensorFlowTests/OperatorTests/MathTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/MathTests.swift
@@ -218,14 +218,14 @@ final class MathOperatorTests: XCTestCase {
       let x = Tensor<Float>([1.0, 2.0, 3.0])
       let y = softplus(x)
       let expected = Tensor<Float>([1.3132616,  2.126928, 3.0485873])
-      XCTAssertEqual(x, expected)
+      XCTAssertEqual(y, expected)
     }
 
     func testSoftsign() {
       let x = Tensor<Float>([1.0, 4.0, 3.0])
       let y = softsign(x)
       let expected = Tensor<Float>([0.5 , 0.8 , 0.75])
-      XCTAssertEqual(x, expected)
+      XCTAssertEqual(y, expected)
     }
 
     func testXORInference() {

--- a/Tests/TensorFlowTests/OperatorTests/MathTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/MathTests.swift
@@ -217,14 +217,14 @@ final class MathOperatorTests: XCTestCase {
     func testSoftplus() {
       let x = Tensor<Float>([1.0, 2.0, 3.0])
       let y = softplus(x)
-      let expected = Tensor<Float>([[1.3132616,  2.126928, 3.0485873]])
+      let expected = Tensor<Float>([1.3132616,  2.126928, 3.0485873])
       XCTAssertEqual(x, expected)
     }
 
     func testSoftsign() {
       let x = Tensor<Float>([1.0, 4.0, 3.0])
       let y = softsign(x)
-      let expected = Tensor<Float>([0.5 , 0.8 , 0.75]])
+      let expected = Tensor<Float>([0.5 , 0.8 , 0.75])
       XCTAssertEqual(x, expected)
     }
 


### PR DESCRIPTION
We need these operators for other loss functions like kullback-leibler divergence and logcosh.

One small doubt, The comments for softplus and softsign both mention gradients as 
`  gradients: The backpropagated gradients to the corresponding softplus operation.`

So am i getting the logic right by passing `gradients: v`?

Tests pass.