### PR TITLE
Add logarithm-cosine loss

### DIFF
--- a/Sources/TensorFlow/Loss.swift
+++ b/Sources/TensorFlow/Loss.swift
@@ -87,7 +87,7 @@ public func categoricalHingeLoss<Scalar: TensorFlowFloatingPoint>(
 }
 
 // Helper function for `losCoshLoss(predicted:expected:)`.
-@differentiable(wrt: x)
+@differentiable
 fileprivate func logCosh<Scalar: TensorFlowFloatingPoint>(
     x: Tensor<Scalar>
 ) -> Tensor<Scalar> {

--- a/Sources/TensorFlow/Loss.swift
+++ b/Sources/TensorFlow/Loss.swift
@@ -86,25 +86,24 @@ public func categoricalHingeLoss<Scalar: TensorFlowFloatingPoint>(
     return max(Tensor(0), negative - positive + Tensor(1))
 }
 
-/// Helper function for Logcosh
+// Helper function for Logcosh
 @differentiable(wrt: x)
-internal func logcosh<Scalar: TensorFlowFloatingPoint>(
+fileprivate func logCosh<Scalar: TensorFlowFloatingPoint>(
     x: Tensor<Scalar>
 ) -> Tensor<Scalar> {
-    let y = Tensor<Scalar>([2])
-    return  x + softplus(Tensor(-2) * x) - log(y)
+    return  x + softplus(Tensor(-2) * x) - log(Tensor(y))
 }
 
-/// Returns the Logcosh loss between predictions and expectations.
+/// Returns the logarithm of the hyperbolic cosine of the error between predictions and expectations.
 ///
 /// - Parameters:
 ///   - predicted: Predicted outputs from a neural network.
 ///   - expected: Expected values, i.e. targets, that correspond to the correct output.
 @differentiable(wrt: predicted)
-public func logcoshLoss<Scalar: TensorFlowFloatingPoint>(
+public func logCoshLoss<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>, expected: Tensor<Scalar>
 ) -> Tensor<Scalar> {
-    return (logcosh(x: predicted - expected)).mean()
+    return (logCosh(x: predicted - expected)).mean()
 }
 
 /// Returns the Poisson loss between predictions and expectations.

--- a/Sources/TensorFlow/Loss.swift
+++ b/Sources/TensorFlow/Loss.swift
@@ -86,6 +86,41 @@ public func categoricalHingeLoss<Scalar: TensorFlowFloatingPoint>(
     return max(Tensor(0), negative - positive + Tensor(1))
 }
 
+/// Helper function for Logcosh
+@differentiable(wrt: x)
+internal func logcosh<Scalar: TensorFlowFloatingPoint>(
+    x: Tensor<Scalar>
+) -> Tensor<Scalar> {
+    let y = Tensor<Scalar>([2])
+    return  x + softplus(Tensor(-2) * x) - log(y)
+}
+
+/// Returns the Logcosh loss between predictions and expectations.
+///
+/// - Parameters:
+///   - predicted: Predicted outputs from a neural network.
+///   - expected: Expected values, i.e. targets, that correspond to the correct output.
+@differentiable(wrt: predicted)
+public func logcoshLoss<Scalar: TensorFlowFloatingPoint>(
+    predicted: Tensor<Scalar>, expected: Tensor<Scalar>
+) -> Tensor<Scalar> {
+    return (logcosh(x: predicted - expected)).mean()
+}
+
+
+/// Returns the Poisson loss between predictions and expectations.
+///
+/// - Parameters:
+///   - predicted: Predicted outputs from a neural network.
+///   - expected: Expected values, i.e. targets, that correspond to the correct output.
+@differentiable(wrt: predicted)
+public func poissonLoss<Scalar: TensorFlowFloatingPoint>(
+    predicted: Tensor<Scalar>, expected: Tensor<Scalar>
+) -> Tensor<Scalar> {
+    return (predicted - expected * log(predicted)).mean()
+}
+
+
 /// Returns the Poisson loss between predictions and expectations.
 ///
 /// - Parameters:

--- a/Sources/TensorFlow/Loss.swift
+++ b/Sources/TensorFlow/Loss.swift
@@ -133,7 +133,7 @@ public func categoricalHingeLoss<Scalar: TensorFlowFloatingPoint>(
 fileprivate func logCosh<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>
 ) -> Tensor<Scalar> {
-    x + softplus(Tensor(-2) * x) - log(Tensor(y))
+    x + softplus(Tensor(-2) * x) - log(Tensor(2))
 }
 
 /// Returns the logarithm of the hyperbolic cosine of the error between predictions and expectations.

--- a/Sources/TensorFlow/Loss.swift
+++ b/Sources/TensorFlow/Loss.swift
@@ -107,20 +107,6 @@ public func logcoshLoss<Scalar: TensorFlowFloatingPoint>(
     return (logcosh(x: predicted - expected)).mean()
 }
 
-
-/// Returns the Poisson loss between predictions and expectations.
-///
-/// - Parameters:
-///   - predicted: Predicted outputs from a neural network.
-///   - expected: Expected values, i.e. targets, that correspond to the correct output.
-@differentiable(wrt: predicted)
-public func poissonLoss<Scalar: TensorFlowFloatingPoint>(
-    predicted: Tensor<Scalar>, expected: Tensor<Scalar>
-) -> Tensor<Scalar> {
-    return (predicted - expected * log(predicted)).mean()
-}
-
-
 /// Returns the Poisson loss between predictions and expectations.
 ///
 /// - Parameters:

--- a/Sources/TensorFlow/Loss.swift
+++ b/Sources/TensorFlow/Loss.swift
@@ -86,12 +86,12 @@ public func categoricalHingeLoss<Scalar: TensorFlowFloatingPoint>(
     return max(Tensor(0), negative - positive + Tensor(1))
 }
 
-// Helper function for Logcosh
+// Helper function for `losCoshLoss(predicted:expected:)`.
 @differentiable(wrt: x)
 fileprivate func logCosh<Scalar: TensorFlowFloatingPoint>(
     x: Tensor<Scalar>
 ) -> Tensor<Scalar> {
-    return  x + softplus(Tensor(-2) * x) - log(Tensor(y))
+    x + softplus(Tensor(-2) * x) - log(Tensor(y))
 }
 
 /// Returns the logarithm of the hyperbolic cosine of the error between predictions and expectations.

--- a/Sources/TensorFlow/Loss.swift
+++ b/Sources/TensorFlow/Loss.swift
@@ -131,7 +131,7 @@ public func categoricalHingeLoss<Scalar: TensorFlowFloatingPoint>(
 // Helper function for `losCoshLoss(predicted:expected:)`.
 @differentiable
 fileprivate func logCosh<Scalar: TensorFlowFloatingPoint>(
-    x: Tensor<Scalar>
+    _ x: Tensor<Scalar>
 ) -> Tensor<Scalar> {
     x + softplus(Tensor(-2) * x) - log(Tensor(y))
 }
@@ -145,7 +145,7 @@ fileprivate func logCosh<Scalar: TensorFlowFloatingPoint>(
 public func logCoshLoss<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>, expected: Tensor<Scalar>
 ) -> Tensor<Scalar> {
-    return (logCosh(x: predicted - expected)).mean()
+    (logCosh(predicted - expected)).mean()
 }
 
 /// Returns the Poisson loss between predictions and expectations.

--- a/Tests/TensorFlowTests/LossTests.swift
+++ b/Tests/TensorFlowTests/LossTests.swift
@@ -124,7 +124,7 @@ final class LossTests: XCTestCase {
     func testLogCoshLoss() {
         let predicted = Tensor<Float>([0.2, 0.3, 0.4])
         let expected = Tensor<Float>([1.0, 4.0, 3.0])
-        let loss = logcoshLoss(predicted: predicted, expected: expected)
+        let loss = logCoshLoss(predicted: predicted, expected: expected)
         let expectedLoss: Float = 1.7368573
         assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
     }

--- a/Tests/TensorFlowTests/LossTests.swift
+++ b/Tests/TensorFlowTests/LossTests.swift
@@ -96,6 +96,14 @@ final class LossTests: XCTestCase {
         assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
     }
 
+    func testLogcoshLoss() {
+        let predicted = Tensor<Float>([0.2, 0.3, 0.4])
+        let expected = Tensor<Float>([1.0, 4.0, 3.0])
+        let loss = logcoshLoss(predicted: predicted, expected: expected)
+        let expectedLoss: Float = 1.7368573
+        assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
+    }
+
     func testPoissonLoss() {
         let predicted = Tensor<Float>([0.1, 0.2, 0.3])
         let expected = Tensor<Float>([1, 2, 3])
@@ -202,6 +210,7 @@ final class LossTests: XCTestCase {
         ("testCategoricalHingeLoss", testCategoricalHingeLoss),
         ("testSquaredHingeLoss", testSquaredHingeLoss),
         ("testPoissonLoss",testPoissonLoss),
+        ("testLogcoshLoss", testLogcoshLoss),
         ("testSoftmaxCrossEntropyWithProbabilitiesLoss",
          testSoftmaxCrossEntropyWithProbabilitiesLoss),
         ("testSoftmaxCrossEntropyWithProbabilitiesGrad",

--- a/Tests/TensorFlowTests/LossTests.swift
+++ b/Tests/TensorFlowTests/LossTests.swift
@@ -247,7 +247,7 @@ final class LossTests: XCTestCase {
         ("testCategoricalHingeLoss", testCategoricalHingeLoss),
         ("testSquaredHingeLoss", testSquaredHingeLoss),
         ("testPoissonLoss",testPoissonLoss),
-        ("testLogcoshLoss", testLogcoshLoss),
+        ("testLogCoshLoss", testLogCoshLoss),
         ("testSoftmaxCrossEntropyWithProbabilitiesLoss",
          testSoftmaxCrossEntropyWithProbabilitiesLoss),
         ("testSoftmaxCrossEntropyWithProbabilitiesGrad",

--- a/Tests/TensorFlowTests/LossTests.swift
+++ b/Tests/TensorFlowTests/LossTests.swift
@@ -96,7 +96,7 @@ final class LossTests: XCTestCase {
         assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
     }
 
-    func testLogcoshLoss() {
+    func testLogCoshLoss() {
         let predicted = Tensor<Float>([0.2, 0.3, 0.4])
         let expected = Tensor<Float>([1.0, 4.0, 3.0])
         let loss = logcoshLoss(predicted: predicted, expected: expected)

--- a/Tests/TensorFlowTests/LossTests.swift
+++ b/Tests/TensorFlowTests/LossTests.swift
@@ -246,14 +246,8 @@ final class LossTests: XCTestCase {
         ("testKullbackLeiblerDivergence", testKullbackLeiblerDivergence),
         ("testCategoricalHingeLoss", testCategoricalHingeLoss),
         ("testSquaredHingeLoss", testSquaredHingeLoss),
-<<<<<<< HEAD
         ("testPoissonLoss",testPoissonLoss),
         ("testLogcoshLoss", testLogcoshLoss),
-||||||| merged common ancestors
-        ("testPoissonLoss",testPoissonLoss),
-=======
-        ("testPoissonLoss", testPoissonLoss),
->>>>>>> 20a0923fd8e4dec2aa7e8a856527f66612453c95
         ("testSoftmaxCrossEntropyWithProbabilitiesLoss",
          testSoftmaxCrossEntropyWithProbabilitiesLoss),
         ("testSoftmaxCrossEntropyWithProbabilitiesGrad",


### PR DESCRIPTION
depends on #225.
Otherwise passes locally.

I had a very hacky way of getting the helper logcosh to work.  But I could not figure out how to get around the `error: binary operator '-' cannot be applied to operands of type 'Tensor<Scalar>' and '_'`  that pops up when i do ` x + softplus(Tensor(-2) * x) - log(2)`. If you have suggestions please tell me.

Reference #127