### PR TITLE
Fix implementation of `root(Tensor, Int)`.

### DIFF
--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -876,7 +876,7 @@ public func pow<T: TensorFlowFloatingPoint>(_ x: Tensor<T>, _ n: Int) -> Tensor<
 @inlinable
 // @differentiable
 public func root<T: TensorFlowFloatingPoint>(_ x: Tensor<T>, _ n: Int) -> Tensor<T> {
-    pow(x, Tensor(T(1) / T(n)))
+    sign(x) * pow(abs(x), Tensor(T(1) / T(n)))
 }
 
 /// Computes the element-wise maximum of two tensors.

--- a/Tests/TensorFlowTests/Helpers.swift
+++ b/Tests/TensorFlowTests/Helpers.swift
@@ -21,7 +21,9 @@ internal func assertEqual<T: TensorFlowFloatingPoint>(
 ) {
     for (x, y) in zip(x, y) {
         if x.isNaN || y.isNaN {
-            XCTAssertTrue(x.isNaN && y.isNaN, message, file: file, line: line)
+            XCTAssertTrue(x.isNaN && y.isNaN,
+                          "\(x) is not equal to \(y) - \(message)",
+                          file: file, line: line)
             continue
         }
         XCTAssertEqual(x, y, accuracy: accuracy, message, file: file, line: line)


### PR DESCRIPTION
Fix test failures regarding `root(Tensor, Int)` erroneous returning NaNs.

Inspired by the implementation of `root` for `FloatingPoint` types in
[swift/stdlib/public/core/MathFunctions.swift.gyb](https://github.com/apple/swift/blob/bd9ae78e1fd354f776239c8f19e96329e2dac7d9/stdlib/public/core/MathFunctions.swift.gyb#L94).