### PR TITLE
Using .sum() rather than .mean() for Poisson loss

### DIFF
--- a/Sources/TensorFlow/Loss.swift
+++ b/Sources/TensorFlow/Loss.swift
@@ -150,7 +150,7 @@ public func categoricalHingeLoss<Scalar: TensorFlowFloatingPoint>(
 public func poissonLoss<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>, expected: Tensor<Scalar>
 ) -> Tensor<Scalar> {
-    return (predicted - expected * log(predicted)).mean()
+    return (predicted - expected * log(predicted)).sum()
 }
 
 /// Returns the Kullback-Leibler divergence between predictions and expectations.

--- a/Tests/TensorFlowTests/LossTests.swift
+++ b/Tests/TensorFlowTests/LossTests.swift
@@ -133,7 +133,7 @@ final class LossTests: XCTestCase {
         let predicted = Tensor<Float>([0.1, 0.2, 0.3])
         let expected = Tensor<Float>([1, 2, 3])
         let loss = poissonLoss(predicted: predicted, expected: expected)
-        let expectedLoss: Float = 3.2444599
+        let expectedLoss: Float = 9.73338
         assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
     }
 


### PR DESCRIPTION
For the Poisson loss, we don't actually need to compute the mean of the loss vector, the sum is enough to characterize the negative log likelihood.