### PR TITLE
Supress compiler warnings in  LazyTensorTests.swift.

### DIFF
--- a/Tests/TensorFlowTests/LazyTensorTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTests.swift
@@ -76,10 +76,9 @@ final class LazyTensorTests: XCTestCase {
         }
 
         func isSymbolic(_ t: LazyTensor) -> Bool {
-            if case let .symbolic(_) = t.handle {
-                return true
-            } else {
-                return false
+            switch t.handle {
+            case .symbolic(_): return true
+            case .concrete(_): return false
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/tensorflow/swift-apis/issues/247