### PR TITLE
Convert a LazyTensorTrace into a TFFunction.

### DIFF
--- a/Sources/TensorFlow/Core/LazyTensorTFFunctionBuilder.swift
+++ b/Sources/TensorFlow/Core/LazyTensorTFFunctionBuilder.swift
@@ -1,0 +1,294 @@
+import CTensorFlow
+
+class TFGraph {
+    /// The `TF_Operation *` type.
+    typealias CTFOperation = OpaquePointer
+    
+    enum Input {
+        case single(TF_Output)
+        case list([TF_Output])
+    }
+
+    /// The pointer to the underlying TF Graph.
+    let cTFGraph: CTFGraph = TF_NewGraph()
+    var inputs: [TF_Output] = []
+    var nodes: [CTFOperation?] = []
+    var outputs: [TF_Output] = []
+    var outputGroups: [Int] = []
+    var name: String { "lazyTrace_\(nodeCounter)" }
+
+    /// A status object to pass to TF graph building operations.
+    private let status: CTFStatus = TF_NewStatus()
+
+    /// Counter that is used for number the generated graph nodes. 
+    private var nodeCounter: Int = 0
+
+    init(_ lazyTrace: LazyTensorTrace) {
+        var nodesCache: [ObjectIdentifier: CTFOperation?] = [:]
+        for op in lazyTrace.operations {
+            let opInputs = op.inputs.map { input -> TFGraph.Input in
+                switch input {
+                case LazyTensorOperation.Input.single(let h):
+                    return TFGraph.Input.single(makeTFOutput(h, nodesCache))
+                case LazyTensorOperation.Input.list(let elements):
+                    let tfInputs = elements.map { makeTFOutput($0, nodesCache) }
+                    return TFGraph.Input.list(tfInputs)
+                }
+            }
+            let graphNode = makeTFGraphNode(
+                name: op.name,
+                attrs: op.attributes,
+                inputs: opInputs,
+                device: op.deviceName)
+            nodesCache[ObjectIdentifier(op)] = graphNode
+            if op.name != "Placeholder" { nodes.append(graphNode) }
+        }
+        self.inputs = lazyTrace.inputs.map {
+            TF_Output(oper: nodesCache[ObjectIdentifier($0)]!, index: 0)
+        }
+        for output in lazyTrace.outputs {
+            let graphNode = nodesCache[ObjectIdentifier(output)]!
+            outputGroups.append(output.outputCount)
+            outputs += Array((0..<output.outputCount).map {
+                    TF_Output(oper: graphNode, index: Int32($0)) })
+        }
+    }
+
+    deinit {
+        TF_DeleteGraph(cTFGraph)
+        TF_DeleteStatus(status)
+    }
+
+    private func newNodeName(base: String) -> String {
+        let name = "\(base)_\(nodeCounter)"
+        nodeCounter += 1
+        return name
+    }
+
+    private func updateAttribute(
+        _ desc: CTFOperationDescription,
+        _ name: String,
+        _ attrValue: LazyTensorOperation.Attribute
+    ) {
+        switch attrValue {
+        case LazyTensorOperation.Attribute.tensorDataTypeValue(let value):
+            TF_SetAttrType(desc, name, value._cDataType)
+        case LazyTensorOperation.Attribute.boolValue(let value):
+            TF_SetAttrBool(desc, name, value ? 1 : 0)
+        case LazyTensorOperation.Attribute.intValue(let value):
+            TF_SetAttrInt(desc, name, Int64(value))
+        case LazyTensorOperation.Attribute.floatValue(let value):
+            TF_SetAttrFloat(desc, name, value)
+        case LazyTensorOperation.Attribute.stringValue(let value): do {
+                value.utf8CString.withUnsafeBufferPointer { buffer in
+                    // utf8CString is null-terminated; TF_SetAttrString wants
+                    // non-null-terminated.
+                    TF_SetAttrString(
+                        desc, name, buffer.baseAddress, buffer.count - 1)
+                }
+            }
+        case LazyTensorOperation.Attribute.intArray(let values): do {
+                let values64 = values.map { Int64($0) }
+                values64.withUnsafeBufferPointer { buffer in
+                    TF_SetAttrIntList(
+                        desc, name, buffer.baseAddress, Int32(buffer.count))
+                }
+            }
+        case LazyTensorOperation.Attribute.constTensor(let value): do {
+                let cTensor = TFE_TensorHandleResolve(
+                    value._cTensorHandle, status)
+                checkOk(status)
+                TF_SetAttrTensor(desc, name, cTensor!, status)
+            }
+        case LazyTensorOperation.Attribute.tensorDataTypeArray(let values): do {
+                values.withUnsafeBufferPointer { buffer in
+                    buffer.withMemoryRebound(to: TF_DataType.self) {
+                        reboundBuffer in
+                        TF_SetAttrTypeList(
+                            desc, name,
+                            reboundBuffer.baseAddress,
+                            Int32(reboundBuffer.count))
+                    }
+                }
+            }
+        case LazyTensorOperation.Attribute.optionalTensorShapeArray(let values): do {
+                let flattenedDims = values.flatMap { (tensorShapeOpt) -> [Int64] in
+                    if let tensorShape = tensorShapeOpt {
+                        return tensorShape.dimensions.map(Int64.init)
+                    }
+                    return []
+                }
+                let ranks = values.map { shape in (shape?.rank).map(Int32.init) ?? -1 }
+                flattenedDims.withUnsafeBufferPointer { flattenedDimsBuffer in
+                    var dimsPtr: UnsafePointer<Int64>? = flattenedDimsBuffer.baseAddress
+                    var dims: [UnsafePointer<Int64>?] = []
+                    for rank in ranks {
+                        dims.append(dimsPtr)
+                        if rank >= 0 {
+                            dimsPtr = dimsPtr.map { $0.advanced(by: Int(rank)) }
+                        }
+                    }
+                    dims.withUnsafeMutableBufferPointer { dimsBuffer in
+                        ranks.withUnsafeBufferPointer { ranksBuffer in
+                            TF_SetAttrShapeList(
+                                desc, name,
+                                dimsBuffer.baseAddress,
+                                ranksBuffer.baseAddress,
+                                Int32(ranksBuffer.count))
+                        }
+                    }
+                }
+            }
+        default:
+            assert(false, "Unhandled attribute \(name):\(attrValue)")
+        }
+    }
+
+    private func makeTFGraphNode(
+        name: String,
+        attrs: [String: LazyTensorOperation.Attribute],
+        inputs: [Input],
+        device: String?
+    ) -> CTFOperation? {
+        // Create a new graph node now.
+        let desc: CTFOperationDescription! = TF_NewOperation(
+            cTFGraph, name, newNodeName(base: name))
+
+        // Set Attributes
+        for (name, value) in attrs {
+            updateAttribute(desc, name, value)
+        }
+
+        // Add Inputs
+        for input in inputs {
+            switch input {
+            case Input.single(let singleInput):
+                TF_AddInput(desc, singleInput)
+            case Input.list(let inputList):
+                inputList.withUnsafeBufferPointer { buffer in
+                    TF_AddInputList(desc, buffer.baseAddress, Int32(buffer.count))
+                }
+            }
+        }
+        
+        if let device = device { TF_SetDevice(desc, device) }
+        
+        // Finalize operation.
+        let graphNode = TF_FinishOperation(desc, status)
+        checkOk(status)
+        return graphNode!
+    }
+
+    private func makeTFConstNode(_ handle: TFETensorHandle) -> TF_Output {
+        let cTensorHandle = handle._cTensorHandle
+        let cTensor = TFE_TensorHandleResolve(cTensorHandle, status)
+        checkOk(status)
+        let desc = TF_NewOperation(cTFGraph, "Const", newNodeName(base: "Const"))
+        checkOk(status)
+        TF_SetAttrType(desc, "dtype", TFE_TensorHandleDataType(cTensorHandle))
+        TF_SetAttrTensor(desc, "value", cTensor, status)
+        checkOk(status)
+        let constNode = TF_FinishOperation(desc, status)
+        return TF_Output(oper: constNode, index: 0)
+    }
+
+    private func makeTFOutput(
+        _ lazyHandle: LazyTensor,
+        _ nodesCache: [ObjectIdentifier: CTFOperation?]) -> TF_Output {
+        if case let LazyTensor.Handle.symbolic(
+            lazyOp, index, _) = lazyHandle.handle {
+            let id = ObjectIdentifier(lazyOp)
+            return TF_Output(oper: nodesCache[id]!, index: Int32(index))
+        }
+        assert(false, "Should only have symbolic inputs.")
+    }
+}
+
+class TFFunction {
+    let cTFFunction: CTFFunction
+    let outputCount: Int
+    let outputGroups: [Int]
+    
+    init(_ lazyTrace: LazyTensorTrace) {
+        let status: CTFStatus = TF_NewStatus()
+        defer { TF_DeleteStatus(status) }
+        let graph = TFGraph(lazyTrace)
+        let cTFGraph = graph.cTFGraph
+        let inputs = graph.inputs
+        let outputs = graph.outputs
+        self.outputCount = outputs.count
+        self.outputGroups = graph.outputGroups
+        self.cTFFunction = graph.nodes.withUnsafeBufferPointer {
+            operations -> CTFFunction in
+            let base = operations.baseAddress
+            let tracedGraphFn = TF_GraphToFunction(cTFGraph, graph.name,
+                /*append_hash_to_fn_name*/ 1,
+                /*num_opers*/ Int32(operations.count),
+                /*opers*/ base,
+                /*numinputs*/ Int32(inputs.count),
+                /*inputs*/ inputs,
+                /*noutputs*/ Int32(outputs.count),
+                /*outputs*/ outputs,
+                /*outputnames*/ nil,
+                /*functionoptions*/ nil, "",
+                status)
+            checkOk(status)
+            if _RuntimeConfig.printsDebugLog {
+                var len: Int = 0
+                let funcDebugStr = TF_FunctionDebugString(tracedGraphFn, &len)!
+                debugLog("The traced function is:\n\(String(cString: funcDebugStr))")
+                free(funcDebugStr)
+                debugLog("Corresponding lazy tensor operations:\n")
+                for output in graph.outputs {
+                    debugLog("  \(output)")
+                }
+            }
+            return tracedGraphFn!
+        }
+        
+        let eagerContext = _TFCGetGlobalEagerContext()
+        TFE_ContextAddFunction(eagerContext, self.cTFFunction, status)
+        checkOk(status)
+    }
+
+    func execute(_ inputs: [TFETensorHandle]) -> [TFETensorHandle] {
+        let status: CTFStatus = TF_NewStatus()
+        defer { TF_DeleteStatus(status) }
+        
+        let eagerContext = _TFCGetGlobalEagerContext()
+        let fname = TF_FunctionName(cTFFunction)!
+        let eagerOp: CTFEOp! = TFE_NewOp(eagerContext, fname, status)
+        defer { TFE_DeleteOp(eagerOp) }
+        checkOk(status)
+
+        let deviceName = _ExecutionContext.global.currentDeviceName
+        if let deviceName = deviceName {
+            debugLog("Placing the trace func on device \(deviceName).")
+            TFE_OpSetDevice(eagerOp, deviceName, status)
+            checkOk(status)
+        }
+
+        for input in inputs {
+            TFE_OpAddInput(eagerOp, input._cTensorHandle, status)
+            checkOk(status)
+        }
+
+        var returnValues = [CTensorHandle?](repeating: nil, count: outputCount)
+        var outputReturnValueCount = Int32(outputCount)
+        TFE_Execute(eagerOp, &returnValues, &outputReturnValueCount, status)
+        checkOk(status)
+
+        return returnValues.map  { TFETensorHandle(_owning: $0!) }
+    }
+}
+
+extension TFFunction: CustomStringConvertible {
+    public var description: String {
+        var len: Int = 0
+        let funcDebugStr = TF_FunctionDebugString(cTFFunction, &len)!
+        let result = String(cString: funcDebugStr)
+        free(funcDebugStr)
+        return result
+    }
+}
+

--- a/Sources/TensorFlow/Core/LazyTensorTFFunctionBuilder.swift
+++ b/Sources/TensorFlow/Core/LazyTensorTFFunctionBuilder.swift
@@ -1,3 +1,17 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import CTensorFlow
 
 class TFGraph {

--- a/Sources/TensorFlow/Core/LazyTensorTFFunctionBuilder.swift
+++ b/Sources/TensorFlow/Core/LazyTensorTFFunctionBuilder.swift
@@ -14,8 +14,9 @@
 
 import CTensorFlow
 
-/// Swift-side convenience wrapper for a `TF_Graph*`. It holds a pointer to the underlying
-/// TF_Graph and also exposes the some aspects of the TF_Graph as properties.
+/// Swift-side convenience wrapper for a `TF_Graph`. It holds a pointer to the
+/// underlying TF_Graph and also exposes some aspects of the TF_Graph as
+/// properties.
 class TFGraph {
     /// The `TF_Operation *` type.
     typealias CTFOperation = OpaquePointer
@@ -67,9 +68,9 @@ class TFGraph {
         for output in lazyTrace.outputs {
             let graphNode = nodesCache[ObjectIdentifier(output)]!
             outputGroupCounts.append(output.outputCount)
-            outputs += Array((0..<output.outputCount).map {
-                    TF_Output(oper: graphNode, index: Int32($0))
-                })
+            outputs += (0..<output.outputCount).map {
+                TF_Output(oper: graphNode, index: Int32($0))
+            }
         }
     }
 
@@ -228,8 +229,7 @@ class TFGraph {
     }
 }
 
-
-/// Swift-side convenience wrapper for a `TF_Function*`.
+/// Swift-side convenience wrapper for a `TF_Function`.
 class TFFunction {
     let cTFFunction: CTFFunction
     let outputCount: Int

--- a/Sources/TensorFlow/Core/LazyTensorTFFunctionBuilder.swift
+++ b/Sources/TensorFlow/Core/LazyTensorTFFunctionBuilder.swift
@@ -34,13 +34,13 @@ class TFGraph {
     /// An array representing how the outputs are grouped. The grouping
     /// corresponds to a higher-level notion like TensorGroup.
     var outputGroupCounts: [Int] = []
-    var name: String { "lazyTrace_\(nodeCounter)" }
+    var name: String { "lazyTrace_\(nodeCount)" }
 
     /// A status object to pass to TF graph building operations.
     private let status: CTFStatus = TF_NewStatus()
 
     /// Counter that is used for number the generated graph nodes.
-    private var nodeCounter: Int = 0
+    private var nodeCount: Int = 0
 
     init(trace: LazyTensorTrace) {
         var nodesCache: [ObjectIdentifier: CTFOperation?] = [:]
@@ -80,8 +80,8 @@ class TFGraph {
     }
 
     private func newNodeName(base: String) -> String {
-        let name = "\(base)_\(nodeCounter)"
-        nodeCounter += 1
+        let name = "\(base)_\(nodeCount)"
+        nodeCount += 1
         return name
     }
 

--- a/Tests/TensorFlowTests/LazyTensorTFFunctionBuilderTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTFFunctionBuilderTests.swift
@@ -1,0 +1,227 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+@testable import TensorFlow
+import CTensorFlow
+
+final class LazyTensorTFFunctionBuilderTests : XCTestCase {
+    override class func setUp() {
+        super.setUp()
+        _RuntimeConfig.useLazyTensor = true
+    }
+
+    func testSingletonInputs() {
+        let a = materializedLazyTensor(Tensor<Float>(10.0))
+        let w = Raw.identity(a)
+        XCTAssertEqual(tfFunction(w, "testSingletonInputs")!.description,
+            """
+
+            testSingletonInputs(placeholder_0:float) -> (identity_1:float) {
+              Identity_1 = Identity[T=float](placeholder_0)
+              return identity_1 = Identity_1:output:0
+            }
+
+            """)
+    }
+
+    func testListInputs() {
+        let a = materializedLazyTensor(Tensor<Float>(10.0))
+        let b = materializedLazyTensor(Tensor<Float>(2.0))
+        let w = Raw.addN(inputs: [a, b])
+        XCTAssertEqual(tfFunction(w, "testListInputs")!.description,
+            """
+
+            testListInputs(placeholder_0:float, placeholder_1:float) -> (addn_2:float) {
+              AddN_2 = AddN[N=2, T=float](placeholder_0, placeholder_1)
+              return addn_2 = AddN_2:sum:0
+            }
+
+            """)
+    }
+
+    func testSequence() {
+        let a = materializedLazyTensor(Tensor<Float>(10.0))
+        let b = materializedLazyTensor(Tensor<Float>(2.0))
+        let c = materializedLazyTensor(Tensor<Float>(3.0))
+        let w = a + b * c
+        XCTAssertEqual(tfFunction(w, "sequence")!.description,
+            """
+
+            sequence(placeholder_0:float, placeholder_1:float, placeholder_2:float) -> (add_4:float) {
+              Mul_3 = Mul[T=float](placeholder_1, placeholder_2)
+              Add_4 = Add[T=float](placeholder_0, Mul_3:z:0)
+              return add_4 = Add_4:z:0
+            }
+
+            """)
+    }
+
+    func testAttributes() {
+        // If tests ops such as "AttrBool" are available, testing the handing of
+        // attributes would be very simple. However, tests ops are not
+        // registered into the runtime by default (which is reasonable). If it
+        // is possible to get a test-only libtensorflow.so, we should simplify
+        // this test usinge the test ops.
+
+        let a = materializedLazyTensor(Tensor<Float>(10.0))
+        let b = materializedLazyTensor(Tensor<Float>(20.0))
+
+        // Bool attribute
+        let boolAttr = LazyTensorOperation("MatrixInverse", 1)
+        boolAttr.updateAttribute("adjoint", true)
+        boolAttr.addInput(a)
+        XCTAssertEqual(tfFunction(boolAttr, "boolAttr").description,
+            """
+
+            boolAttr(placeholder_0:float) -> () {
+              MatrixInverse_1 = MatrixInverse[T=float, adjoint=true](placeholder_0)
+            }
+
+            """)
+
+        // Int attribute
+        let intAttr = LazyTensorOperation("Unpack", 1)
+        intAttr.updateAttribute("axis", 0)
+        intAttr.updateAttribute("num", 1)
+        intAttr.updateAttribute("T", Float.tensorFlowDataType)
+        intAttr.addInput(a)
+        XCTAssertEqual(tfFunction(intAttr, "intAttr").description,
+            """
+
+            intAttr(placeholder_0:float) -> () {
+              Unpack_1 = Unpack[T=float, axis=0, num=1](placeholder_0)
+            }
+
+            """)
+
+        // Float attribute
+        let floatAttr = LazyTensorOperation("ApproximateEqual", 1)
+        floatAttr.updateAttribute("T", Float.tensorFlowDataType)
+        floatAttr.updateAttribute("tolerance", 0.01)
+        floatAttr.addInput(a)
+        floatAttr.addInput(b)
+        XCTAssertEqual(tfFunction(floatAttr, "floatAttr").description,
+            """
+
+            floatAttr(placeholder_0:float, placeholder_1:float) -> () {
+              ApproximateEqual_2 = ApproximateEqual[T=float, tolerance=0.01](placeholder_0, placeholder_1)
+            }
+
+            """)
+
+        // String attribute
+        let stringAttr = LazyTensorOperation("PrintV2", 0)
+        let tag = StringTensor("Hello!")
+        stringAttr.updateAttribute("output_stream", "stream")
+        stringAttr.addInput(tag)
+        XCTAssertEqual(tfFunction(stringAttr, "stringAttr").description,
+            """
+
+            stringAttr() -> () {
+              Const_0 = Const[dtype=string, value=Tensor<type: string shape: [] values: Hello!>]()
+              PrintV2_1 = PrintV2[end=\"\\n\", output_stream=\"stream\"](Const_0:output:0)
+            }
+
+            """)
+
+
+        // TensorShape attr
+        let shapeAttr = LazyTensorOperation("EnsureShape", 1)
+        shapeAttr.updateAttribute("shape", TensorShape([5, 6]))
+        shapeAttr.updateAttribute("T", Float.tensorFlowDataType)
+        shapeAttr.addInput(a)
+        XCTAssertEqual(tfFunction(shapeAttr, "shapeAttr").description,
+            """
+
+            shapeAttr(placeholder_0:float) -> () {
+              EnsureShape_1 = EnsureShape[T=float, shape=[5,6]](placeholder_0)
+            }
+
+            """)
+
+
+        // [Int], [TensorShape?] & [TensorDataType] attribute.
+        let arrayAttr1 = LazyTensorOperation("PrelinearizeTuple", 0)
+        arrayAttr1.updateAttribute("dtypes",
+            [Float.tensorFlowDataType, Float.tensorFlowDataType]) // [TensorDataType]
+        arrayAttr1.updateAttribute("shapes", [[1, 2], nil]) // [TensorShape?]
+        arrayAttr1.updateAttribute("layouts", [3, 4]) // [Int]
+        arrayAttr1.addInputList([a,b])
+
+        XCTAssertEqual(tfFunction(arrayAttr1, "arrayAttr1").description,
+            """
+
+            arrayAttr1(placeholder_0:float, placeholder_1:float) -> () {
+              PrelinearizeTuple_2 = PrelinearizeTuple[dtypes={float, float}, layouts=[3, 4], shapes=[[1,2], <unknown>]](placeholder_0, placeholder_1)
+            }
+
+            """)
+
+        // Const Tensor attribute.
+        let constTensorAttr = LazyTensorOperation("Const", 0)
+        let x = Tensor<Float>(5.5)
+        constTensorAttr.updateAttribute("dtype", Float.tensorFlowDataType)
+        constTensorAttr.updateAttribute("value", x.handle.handle._tfeTensorHandle)
+        XCTAssertEqual(tfFunction(constTensorAttr, "constTensorAttr").description,
+            """
+
+            constTensorAttr() -> () {
+              Const_0 = Const[dtype=float, value=Tensor<type: float shape: [] values: 5.5>]()
+            }
+
+            """)
+
+    }
+
+    private func tfFunction(
+        _ lazyOp: LazyTensorOperation,
+        _ name: String? = nil
+    ) -> TFFunction {
+        let trace = LazyTensorTrace(lazyOp)
+        return TFFunction(trace, name: name)
+    }
+
+    private func materializedLazyTensor<T: TensorFlowScalar>(
+        _ input: Tensor<T>
+    ) -> Tensor<T> {
+        let concreteHandle = input.handle.handle._tfeTensorHandle
+        let materializedHandle = LazyTensor(_materialized: concreteHandle)
+        return Tensor(handle: TensorHandle<T>(handle: materializedHandle))
+    }
+
+    private func tfFunction<T: TensorFlowScalar>(
+        _ input: Tensor<T>,
+        _ name: String? = nil
+    ) -> TFFunction? {
+        let tensor = input.handle.handle
+        guard let lazyTensor = tensor as? LazyTensor else {
+            XCTFail("Trying to get TFFunction for a non-lazy tensor.")
+            return nil
+        }
+        guard case let .symbolic(lazyOp, _, _)  = lazyTensor.handle else {
+            XCTFail("Cannot get TFFunction for a concrete tensor.")
+            return nil
+        }
+        let trace =  LazyTensorTrace(lazyOp)
+        return TFFunction(trace, name: name)
+    }
+
+    static var allTests = [
+        ("testSingletonInputs", testSingletonInputs),
+        ("testListInputs", testListInputs),
+        ("testSequence", testSequence),
+        ("testAttributes", testAttributes),
+    ]
+}

--- a/Tests/TensorFlowTests/LazyTensorTFFunctionBuilderTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTFFunctionBuilderTests.swift
@@ -25,7 +25,8 @@ final class LazyTensorTFFunctionBuilderTests : XCTestCase {
     func testSingletonInputs() {
         let a = materializedLazyTensor(Tensor<Float>(10.0))
         let w = Raw.identity(a)
-        XCTAssertEqual(tfFunction(w, "testSingletonInputs")!.description,
+        XCTAssertEqual(
+            tfFunction(w, "testSingletonInputs")!.description,
             """
 
             testSingletonInputs(placeholder_0:float) -> (identity_1:float) {
@@ -40,7 +41,8 @@ final class LazyTensorTFFunctionBuilderTests : XCTestCase {
         let a = materializedLazyTensor(Tensor<Float>(10.0))
         let b = materializedLazyTensor(Tensor<Float>(2.0))
         let w = Raw.addN(inputs: [a, b])
-        XCTAssertEqual(tfFunction(w, "testListInputs")!.description,
+        XCTAssertEqual(
+            tfFunction(w, "testListInputs")!.description,
             """
 
             testListInputs(placeholder_0:float, placeholder_1:float) -> (addn_2:float) {
@@ -56,7 +58,8 @@ final class LazyTensorTFFunctionBuilderTests : XCTestCase {
         let b = materializedLazyTensor(Tensor<Float>(2.0))
         let c = materializedLazyTensor(Tensor<Float>(3.0))
         let w = a + b * c
-        XCTAssertEqual(tfFunction(w, "sequence")!.description,
+        XCTAssertEqual(
+            tfFunction(w, "sequence")!.description,
             """
 
             sequence(placeholder_0:float, placeholder_1:float, placeholder_2:float) -> (add_4:float) {
@@ -82,7 +85,8 @@ final class LazyTensorTFFunctionBuilderTests : XCTestCase {
         let boolAttr = LazyTensorOperation("MatrixInverse", 1)
         boolAttr.updateAttribute("adjoint", true)
         boolAttr.addInput(a)
-        XCTAssertEqual(tfFunction(boolAttr, "boolAttr").description,
+        XCTAssertEqual(
+            tfFunction(boolAttr, "boolAttr").description,
             """
 
             boolAttr(placeholder_0:float) -> () {
@@ -97,7 +101,8 @@ final class LazyTensorTFFunctionBuilderTests : XCTestCase {
         intAttr.updateAttribute("num", 1)
         intAttr.updateAttribute("T", Float.tensorFlowDataType)
         intAttr.addInput(a)
-        XCTAssertEqual(tfFunction(intAttr, "intAttr").description,
+        XCTAssertEqual(
+            tfFunction(intAttr, "intAttr").description,
             """
 
             intAttr(placeholder_0:float) -> () {
@@ -112,7 +117,8 @@ final class LazyTensorTFFunctionBuilderTests : XCTestCase {
         floatAttr.updateAttribute("tolerance", 0.01)
         floatAttr.addInput(a)
         floatAttr.addInput(b)
-        XCTAssertEqual(tfFunction(floatAttr, "floatAttr").description,
+        XCTAssertEqual(
+            tfFunction(floatAttr, "floatAttr").description,
             """
 
             floatAttr(placeholder_0:float, placeholder_1:float) -> () {
@@ -126,7 +132,8 @@ final class LazyTensorTFFunctionBuilderTests : XCTestCase {
         let tag = StringTensor("Hello!")
         stringAttr.updateAttribute("output_stream", "stream")
         stringAttr.addInput(tag)
-        XCTAssertEqual(tfFunction(stringAttr, "stringAttr").description,
+        XCTAssertEqual(
+            tfFunction(stringAttr, "stringAttr").description,
             """
 
             stringAttr() -> () {
@@ -142,7 +149,8 @@ final class LazyTensorTFFunctionBuilderTests : XCTestCase {
         shapeAttr.updateAttribute("shape", TensorShape([5, 6]))
         shapeAttr.updateAttribute("T", Float.tensorFlowDataType)
         shapeAttr.addInput(a)
-        XCTAssertEqual(tfFunction(shapeAttr, "shapeAttr").description,
+        XCTAssertEqual(
+            tfFunction(shapeAttr, "shapeAttr").description,
             """
 
             shapeAttr(placeholder_0:float) -> () {
@@ -160,7 +168,8 @@ final class LazyTensorTFFunctionBuilderTests : XCTestCase {
         arrayAttr1.updateAttribute("layouts", [3, 4]) // [Int]
         arrayAttr1.addInputList([a,b])
 
-        XCTAssertEqual(tfFunction(arrayAttr1, "arrayAttr1").description,
+        XCTAssertEqual(
+            tfFunction(arrayAttr1, "arrayAttr1").description,
             """
 
             arrayAttr1(placeholder_0:float, placeholder_1:float) -> () {
@@ -174,7 +183,8 @@ final class LazyTensorTFFunctionBuilderTests : XCTestCase {
         let x = Tensor<Float>(5.5)
         constTensorAttr.updateAttribute("dtype", Float.tensorFlowDataType)
         constTensorAttr.updateAttribute("value", x.handle.handle._tfeTensorHandle)
-        XCTAssertEqual(tfFunction(constTensorAttr, "constTensorAttr").description,
+        XCTAssertEqual(
+            tfFunction(constTensorAttr, "constTensorAttr").description,
             """
 
             constTensorAttr() -> () {

--- a/Tests/TensorFlowTests/LazyTensorTFFunctionBuilderTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTFFunctionBuilderTests.swift
@@ -200,7 +200,7 @@ final class LazyTensorTFFunctionBuilderTests : XCTestCase {
         _ name: String? = nil
     ) -> TFFunction {
         let trace = LazyTensorTrace(lazyOp)
-        return TFFunction(trace, name: name)
+        return TFFunction(trace: trace, name: name)
     }
 
     private func materializedLazyTensor<T: TensorFlowScalar>(
@@ -225,7 +225,7 @@ final class LazyTensorTFFunctionBuilderTests : XCTestCase {
             return nil
         }
         let trace =  LazyTensorTrace(lazyOp)
-        return TFFunction(trace, name: name)
+        return TFFunction(trace: trace, name: name)
     }
 
     static var allTests = [

--- a/Tests/TensorFlowTests/XCTestManifests.swift
+++ b/Tests/TensorFlowTests/XCTestManifests.swift
@@ -31,6 +31,7 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(LazyTensorTests.allTests),
         testCase(LazyTensorTraceTests.allTests),
         testCase(LazyTensorOperationTests.allTests),
+        testCase(LazyTensorTFFunctionBuilderTests.allTests),
     ]
 }
 #endif


### PR DESCRIPTION
This PR introduces the functionality for the following conversions: 
     `LazyTensorTrace`  -> `TFGraph` -> `TFFunction`

