### PR TITLE
Update doc comment to fix wrong return type.

### DIFF
--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -247,7 +247,7 @@ public extension Tensor where Scalar: Numeric {
         return Raw.mul(lhs, rhs)
     }
 
-    ///  Returns the scalar by multiplying it with every scalar of the tensor.
+    /// Returns the tensor by multiplying it with every scalar of the tensor.
     @inlinable
     @differentiable(vjp: _vjpMultiply(lhs:rhs:) where Scalar: TensorFlowFloatingPoint)
     static func * (lhs: Scalar, rhs: Tensor) -> Tensor {


### PR DESCRIPTION
Wrong type `scalar` was written in doc comment. Replaced it with actual type `tensor`.