### PR TITLE
[WIP] Remove the `Layer.Input: Differentiable` Requirement

### DIFF
--- a/Sources/TensorFlow/Layers/Convolutional.swift
+++ b/Sources/TensorFlow/Layers/Convolutional.swift
@@ -58,7 +58,7 @@ public struct Conv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///
     /// - Parameter input: The input to the layer `[batchCount, width, inputChannels]`.
     /// - Returns: The output `[batchCount, newWidth, outputChannels]`.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         let conv = conv2D(input.expandingShape(at: 1), filter: filter.expandingShape(at: 0),
                           strides: (1, 1, stride, 1), padding: padding)
@@ -176,7 +176,7 @@ public struct Conv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return activation(conv2D(input, filter: filter, strides: (1, strides.0, strides.1, 1),
                                  padding: padding) + bias)
@@ -291,7 +291,7 @@ public struct Conv3D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return activation(conv3D(input, filter: filter,
                                  strides: (1, strides.0, strides.1, strides.2, 1),
@@ -409,7 +409,7 @@ public struct TransposedConv2D: Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
         let batchSize = input.shape[0]
         let w = (input.shape[1] - (1 * paddingIndex)) *
@@ -532,7 +532,7 @@ public struct DepthwiseConv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return activation(depthwiseConv2D(input, filter: filter,
                                           strides: (1, strides.0, strides.1, 1),

--- a/Sources/TensorFlow/Layers/Embedding.swift
+++ b/Sources/TensorFlow/Layers/Embedding.swift
@@ -63,7 +63,7 @@ public struct Embedding<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Parameter
     ///   - input: The indices that will be mapped to their vector representations.
     /// - Returns: The tensor created by replacing input indices with their vector representations.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: EmbeddingInput) -> Tensor<Scalar> {
         return embeddings.gathering(atIndices: input.indices)
     }

--- a/Sources/TensorFlow/Layers/Pooling.swift
+++ b/Sources/TensorFlow/Layers/Pooling.swift
@@ -42,10 +42,14 @@ public struct MaxPool1D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return maxPool2D(input.expandingShape(at: 1), filterSize: (1, 1, poolSize, 1),
-                         strides: (1, 1, stride, 1), padding: padding).squeezingShape(at: 1)
+        return maxPool2D(
+            input.expandingShape(at: 1),
+            filterSize: (1, 1, poolSize, 1),
+            strides: (1, 1, stride, 1),
+            padding: padding
+        ).squeezingShape(at: 1)
     }
 }
 
@@ -75,24 +79,25 @@ public struct MaxPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return maxPool2D(input, filterSize: poolSize, strides: strides, padding: padding)
     }
 }
 
 public extension MaxPool2D {
-  /// Creates a max pooling layer.
-  ///
-  /// - Parameters:
-  ///   - poolSize: Vertical and horizontal factors by which to downscale.
-  ///   - strides: The strides.
-  ///   - padding: The padding.
-  init(poolSize: (Int, Int), strides: (Int, Int), padding: Padding = .valid) {
-  self.init(poolSize: (1, poolSize.0, poolSize.1, 1),
+    /// Creates a max pooling layer.
+    ///
+    /// - Parameters:
+    ///   - poolSize: Vertical and horizontal factors by which to downscale.
+    ///   - strides: The strides.
+    ///   - padding: The padding.
+    init(poolSize: (Int, Int), strides: (Int, Int), padding: Padding = .valid) {
+        self.init(
+            poolSize: (1, poolSize.0, poolSize.1, 1),
             strides: (1, strides.0, strides.1, 1),
             padding: padding)
-  }
+    }
 }
 
 /// A max pooling layer for spatial or spatio-temporal data.
@@ -121,7 +126,7 @@ public struct MaxPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return maxPool3D(input, filterSize: poolSize, strides: strides, padding: padding)
     }
@@ -135,20 +140,22 @@ public extension MaxPool3D {
     ///   - strides: The strides.
     ///   - padding: The padding.
     init(poolSize: (Int, Int, Int), strides: (Int, Int, Int), padding: Padding = .valid) {
-        self.init(poolSize: (1, poolSize.0, poolSize.1, poolSize.2, 1),
-                  strides: (1, strides.0, strides.1, strides.2, 1),
-                  padding: padding)
-  }
+        self.init(
+            poolSize: (1, poolSize.0, poolSize.1, poolSize.2, 1),
+            strides: (1, strides.0, strides.1, strides.2, 1),
+            padding: padding)
+    }
 }
 
 public extension MaxPool3D {
     /// Creates a max pooling layer with the specified pooling window size and stride. All
     /// pooling sizes and strides are the same.
     init(poolSize: Int, stride: Int, padding: Padding = .valid) {
-        self.init(poolSize: (poolSize, poolSize, poolSize),
-                  strides: (stride, stride, stride),
-                  padding: padding)
-  }
+        self.init(
+            poolSize: (poolSize, poolSize, poolSize),
+            strides: (stride, stride, stride),
+            padding: padding)
+    }
 }
 
 /// An average pooling layer for temporal data.
@@ -181,10 +188,14 @@ public struct AvgPool1D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return avgPool2D(input.expandingShape(at: 1), filterSize: (1, 1, poolSize, 1),
-                         strides: (1, 1, stride, 1), padding: padding).squeezingShape(at: 1)
+        return avgPool2D(
+            input.expandingShape(at: 1),
+            filterSize: (1, 1, poolSize, 1),
+            strides: (1, 1, stride, 1),
+            padding: padding
+        ).squeezingShape(at: 1)
     }
 }
 
@@ -214,7 +225,7 @@ public struct AvgPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return avgPool2D(input, filterSize: poolSize, strides: strides, padding: padding)
     }
@@ -228,10 +239,11 @@ public extension AvgPool2D {
     ///   - strides: The strides.
     ///   - padding: The padding.
     init(poolSize: (Int, Int), strides: (Int, Int), padding: Padding = .valid) {
-        self.init(poolSize: (1, poolSize.0, poolSize.1, 1),
-                  strides: (1, strides.0, strides.1, 1),
-                  padding: padding)
-  }
+        self.init(
+            poolSize: (1, poolSize.0, poolSize.1, 1),
+            strides: (1, strides.0, strides.1, 1),
+            padding: padding)
+    }
 }
 
 /// An average pooling layer for spatial or spatio-temporal data.
@@ -260,7 +272,7 @@ public struct AvgPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return avgPool3D(input, filterSize: poolSize, strides: strides, padding: padding)
     }
@@ -274,19 +286,21 @@ public extension AvgPool3D {
     ///   - strides: The strides.
     ///   - padding: The padding.
     init(poolSize: (Int, Int, Int), strides: (Int, Int, Int), padding: Padding = .valid) {
-        self.init(poolSize: (1, poolSize.0, poolSize.1, poolSize.2, 1),
-                  strides: (1, strides.0, strides.1, strides.2, 1),
-                  padding: padding)
-  }
+        self.init(
+            poolSize: (1, poolSize.0, poolSize.1, poolSize.2, 1),
+            strides: (1, strides.0, strides.1, strides.2, 1),
+            padding: padding)
+    }
 }
 
 public extension AvgPool3D {
     /// Creates an average pooling layer with the specified pooling window size and stride. All
     /// pooling sizes and strides are the same.
     init(poolSize: Int, strides: Int, padding: Padding = .valid) {
-        self.init(poolSize: (poolSize, poolSize, poolSize),
-                  strides: (strides, strides, strides),
-                  padding: padding)
+        self.init(
+            poolSize: (poolSize, poolSize, poolSize),
+            strides: (strides, strides, strides),
+            padding: padding)
     }
 }
 
@@ -300,7 +314,7 @@ public struct GlobalAvgPool1D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return input.mean(squeezingAxes: 1)
     }
@@ -316,7 +330,7 @@ public struct GlobalAvgPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return input.mean(squeezingAxes: [1, 2])
     }
@@ -332,7 +346,7 @@ public struct GlobalAvgPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return input.mean(squeezingAxes: [1, 2, 3])
     }
@@ -351,7 +365,7 @@ public struct GlobalMaxPool1D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   - context: The contextual information for the layer application, e.g. the current learning
     ///     phase.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return input.max(squeezingAxes: 1)
     }
@@ -367,7 +381,7 @@ public struct GlobalMaxPool2D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return input.max(squeezingAxes: [1, 2])
     }
@@ -383,7 +397,7 @@ public struct GlobalMaxPool3D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return input.max(squeezingAxes: [1, 2, 3])
     }

--- a/Sources/TensorFlow/Layers/Recurrent.swift
+++ b/Sources/TensorFlow/Layers/Recurrent.swift
@@ -1,291 +1,286 @@
-// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// // Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// //     http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
 
-/// An input to a recurrent neural network.
-public struct RNNCellInput<Input: Differentiable, State: Differentiable>: Differentiable {
-    /// The input at the current time step.
-    public var input: Input
-    /// The previous state.
-    public var state: State
+// /// An input to a recurrent neural network.
+// public struct RNNCellInput<Input, State> {
+//     /// The input at the current time step.
+//     public var input: Input
+//     /// The previous state.
+//     public var state: State
 
-    @differentiable
-    public init(input: Input, state: State) {
-        self.input = input
-        self.state = state
-    }
-}
+//     public init(input: Input, state: State) {
+//         self.input = input
+//         self.state = state
+//     }
+// }
 
-/// An output to a recurrent neural network.
-public struct RNNCellOutput<Output: Differentiable, State: Differentiable>: Differentiable {
-    /// The output at the current time step.
-    public var output: Output
-    /// The current state.
-    public var state: State
+// /// An output to a recurrent neural network.
+// public struct RNNCellOutput<Output: Differentiable, State: Differentiable>: Differentiable {
+//     /// The output at the current time step.
+//     public var output: Output
+//     /// The current state.
+//     public var state: State
 
-    @differentiable
-    public init(output: Output, state: State) {
-        self.output = output
-        self.state = state
-    }
-}
+//     @differentiable
+//     public init(output: Output, state: State) {
+//         self.output = output
+//         self.state = state
+//     }
+// }
 
-/// A recurrent neural network cell.
-public protocol RNNCell: Layer where Input == RNNCellInput<TimeStepInput, State>,
-                                     Output == RNNCellOutput<TimeStepOutput, State> {
-    /// The input at a time step.
-    associatedtype TimeStepInput: Differentiable
-    /// The output at a time step.
-    associatedtype TimeStepOutput: Differentiable
-    /// The state that may be preserved across time steps.
-    associatedtype State: Differentiable
-    /// The zero state.
-    var zeroState: State { get }
-}
+// /// A recurrent neural network cell.
+// public protocol RNNCell: Layer where Input == RNNCellInput<TimeStepInput, State>,
+//                                      Output == RNNCellOutput<TimeStepOutput, State> {
+//     /// The input at a time step.
+//     associatedtype TimeStepInput
+//     /// The output at a time step.
+//     associatedtype TimeStepOutput: Differentiable
+//     /// The state that may be preserved across time steps.
+//     associatedtype State: Differentiable
+//     /// The zero state.
+//     var zeroState: State { get }
+// }
 
-public extension RNNCell {
-    /// Returns the new state obtained from applying the RNN cell to the input at the current time
-    /// step and the previous state.
-    ///
-    /// - Parameters:
-    ///   - timeStepInput: The input at the current time step.
-    ///   - previousState: The previous state of the RNN cell.
-    /// - Returns: The output.
-    @differentiable
-    func callAsFunction(input: TimeStepInput, state: State) -> RNNCellOutput<TimeStepOutput, State> {
-        return self(RNNCellInput(input: input, state: state))
-    }
+// public extension RNNCell {
+//     /// Returns the new state obtained from applying the RNN cell to the input at the current time
+//     /// step and the previous state.
+//     ///
+//     /// - Parameters:
+//     ///   - timeStepInput: The input at the current time step.
+//     ///   - previousState: The previous state of the RNN cell.
+//     /// - Returns: The output.
+//     @differentiable(wrt: self)
+//     func callAsFunction(input: TimeStepInput, state: State) -> RNNCellOutput<TimeStepOutput, State> {
+//         return self(RNNCellInput(input: input, state: state))
+//     }
 
-    @differentiable
-    func call(input: TimeStepInput, state: State) -> RNNCellOutput<TimeStepOutput, State> {
-        return self(RNNCellInput(input: input, state: state))
-    }
-}
+//     @differentiable(wrt: self)
+//     func call(input: TimeStepInput, state: State) -> RNNCellOutput<TimeStepOutput, State> {
+//         return self(RNNCellInput(input: input, state: state))
+//     }
+// }
 
-/// A simple RNN cell.
-public struct SimpleRNNCell<Scalar: TensorFlowFloatingPoint>: RNNCell, VectorProtocol {
-    public var weight: Tensor<Scalar>
-    public var bias: Tensor<Scalar>
+// /// A simple RNN cell.
+// public struct SimpleRNNCell<Scalar: TensorFlowFloatingPoint>: RNNCell, VectorProtocol {
+//     public var weight: Tensor<Scalar>
+//     public var bias: Tensor<Scalar>
 
-    @noDerivative public var stateShape: TensorShape {
-        return TensorShape([1, weight.shape[1]])
-    }
+//     @noDerivative public var stateShape: TensorShape {
+//         return TensorShape([1, weight.shape[1]])
+//     }
 
-    public var zeroState: State {
-        return State(Tensor(zeros: stateShape))
-    }
+//     public var zeroState: State {
+//         return State(Tensor(zeros: stateShape))
+//     }
 
-    // TODO(TF-507): Revert to `typealias State = Tensor<Scalar>` after
-    // SR-10697 is fixed.
-    public struct State: Equatable, Differentiable, VectorProtocol, KeyPathIterable {
-        public var value: Tensor<Scalar>
-        public init(_ value: Tensor<Scalar>) {
-            self.value = value
-        }
-    }
+//     // TODO(TF-507): Revert to `typealias State = Tensor<Scalar>` after
+//     // SR-10697 is fixed.
+//     public struct State: Equatable, Differentiable, VectorProtocol, KeyPathIterable {
+//         public var value: Tensor<Scalar>
+//         public init(_ value: Tensor<Scalar>) {
+//             self.value = value
+//         }
+//     }
 
-    public typealias TimeStepInput = Tensor<Scalar>
-    public typealias TimeStepOutput = State
-    public typealias Input = RNNCellInput<TimeStepInput, State>
-    public typealias Output = RNNCellOutput<TimeStepOutput, State>
+//     public typealias TimeStepInput = Tensor<Scalar>
+//     public typealias TimeStepOutput = State
+//     public typealias Input = RNNCellInput<TimeStepInput, State>
+//     public typealias Output = RNNCellOutput<TimeStepOutput, State>
 
-    /// Creates a `SimpleRNNCell` with the specified input size and hidden state size.
-    ///
-    /// - Parameters:
-    ///   - inputSize: The number of features in 2-D input tensors.
-    ///   - hiddenSize: The number of features in 2-D hidden states.
-    ///   - seed: The random seed for initialization. The default value is random.
-    public init(inputSize: Int, hiddenSize: Int,
-                seed: (Int32, Int32) = (Int32.random(in: Int32.min..<Int32.max),
-                                        Int32.random(in: Int32.min..<Int32.max))) {
-        let concatenatedInputSize = inputSize + hiddenSize
-        self.weight = Tensor(glorotUniform: [concatenatedInputSize, hiddenSize], seed: seed)
-        self.bias = Tensor(zeros: [hiddenSize])
-    }
+//     /// Creates a `SimpleRNNCell` with the specified input size and hidden state size.
+//     ///
+//     /// - Parameters:
+//     ///   - inputSize: The number of features in 2-D input tensors.
+//     ///   - hiddenSize: The number of features in 2-D hidden states.
+//     ///   - seed: The random seed for initialization. The default value is random.
+//     public init(inputSize: Int, hiddenSize: Int,
+//                 seed: (Int32, Int32) = (Int32.random(in: Int32.min..<Int32.max),
+//                                         Int32.random(in: Int32.min..<Int32.max))) {
+//         let concatenatedInputSize = inputSize + hiddenSize
+//         self.weight = Tensor(glorotUniform: [concatenatedInputSize, hiddenSize], seed: seed)
+//         self.bias = Tensor(zeros: [hiddenSize])
+//     }
 
-    /// Returns the output obtained from applying the layer to the given input.
-    ///
-    /// - Parameter input: The input to the layer.
-    /// - Returns: The hidden state.
-    @differentiable
-    public func callAsFunction(_ input: Input) -> Output {
-        let concatenatedInput = input.input.concatenated(with: input.state.value, alongAxis: 1)
-        let newState = State(tanh(matmul(concatenatedInput, weight) + bias))
-        return Output(output: newState, state: newState)
-    }
-}
+//     /// Returns the output obtained from applying the layer to the given input.
+//     ///
+//     /// - Parameter input: The input to the layer.
+//     /// - Returns: The hidden state.
+//     @differentiable(wrt: self)
+//     public func callAsFunction(_ input: Input) -> Output {
+//         let concatenatedInput = input.input.concatenated(with: input.state.value, alongAxis: 1)
+//         let newState = State(tanh(matmul(concatenatedInput, weight) + bias))
+//         return Output(output: newState, state: newState)
+//     }
+// }
 
-/// An LSTM cell.
-public struct LSTMCell<Scalar: TensorFlowFloatingPoint>: RNNCell, VectorProtocol {
-    public var inputWeight, updateWeight, forgetWeight, outputWeight: Tensor<Scalar>
-    public var inputBias, updateBias, forgetBias, outputBias: Tensor<Scalar>
+// /// An LSTM cell.
+// public struct LSTMCell<Scalar: TensorFlowFloatingPoint>: RNNCell, VectorProtocol {
+//     public var inputWeight, updateWeight, forgetWeight, outputWeight: Tensor<Scalar>
+//     public var inputBias, updateBias, forgetBias, outputBias: Tensor<Scalar>
 
-    @noDerivative public var stateShape: TensorShape {
-        return TensorShape([1, inputWeight.shape[1]])
-    }
+//     @noDerivative public var stateShape: TensorShape {
+//         return TensorShape([1, inputWeight.shape[1]])
+//     }
 
-    public var zeroState: State {
-        return State(cell: Tensor(zeros: stateShape), hidden: Tensor(zeros: stateShape))
-    }
+//     public var zeroState: State {
+//         return State(cell: Tensor(zeros: stateShape), hidden: Tensor(zeros: stateShape))
+//     }
 
-    public typealias TimeStepInput = Tensor<Scalar>
-    public typealias TimeStepOutput = State
-    public typealias Input = RNNCellInput<TimeStepInput, State>
-    public typealias Output = RNNCellOutput<TimeStepOutput, State>
+//     public typealias TimeStepInput = Tensor<Scalar>
+//     public typealias TimeStepOutput = State
+//     public typealias Input = RNNCellInput<TimeStepInput, State>
+//     public typealias Output = RNNCellOutput<TimeStepOutput, State>
 
-    /// Creates a `LSTMCell` with the specified input size and hidden state size.
-    ///
-    /// - Parameters:
-    ///   - inputSize: The number of features in 2-D input tensors.
-    ///   - hiddenSize: The number of features in 2-D hidden states.
-    public init(inputSize: Int, hiddenSize: Int,
-                seed: (Int32, Int32) = (Int32.random(in: Int32.min..<Int32.max),
-                                        Int32.random(in: Int32.min..<Int32.max))) {
-        let concatenatedInputSize = inputSize + hiddenSize
-        let gateWeightShape = TensorShape([concatenatedInputSize, hiddenSize])
-        let gateBiasShape = TensorShape([hiddenSize])
-        self.inputWeight = Tensor(glorotUniform: gateWeightShape, seed: seed)
-        self.inputBias = Tensor(zeros: gateBiasShape)
-        self.updateWeight = Tensor(glorotUniform: gateWeightShape, seed: seed)
-        self.updateBias = Tensor(zeros: gateBiasShape)
-        self.forgetWeight = Tensor(glorotUniform: gateWeightShape, seed: seed)
-        self.forgetBias = Tensor(ones: gateBiasShape)
-        self.outputWeight = Tensor(glorotUniform: gateWeightShape, seed: seed)
-        self.outputBias = Tensor(zeros: gateBiasShape)
-    }
+//     /// Creates a `LSTMCell` with the specified input size and hidden state size.
+//     ///
+//     /// - Parameters:
+//     ///   - inputSize: The number of features in 2-D input tensors.
+//     ///   - hiddenSize: The number of features in 2-D hidden states.
+//     public init(inputSize: Int, hiddenSize: Int,
+//                 seed: (Int32, Int32) = (Int32.random(in: Int32.min..<Int32.max),
+//                                         Int32.random(in: Int32.min..<Int32.max))) {
+//         let concatenatedInputSize = inputSize + hiddenSize
+//         let gateWeightShape = TensorShape([concatenatedInputSize, hiddenSize])
+//         let gateBiasShape = TensorShape([hiddenSize])
+//         self.inputWeight = Tensor(glorotUniform: gateWeightShape, seed: seed)
+//         self.inputBias = Tensor(zeros: gateBiasShape)
+//         self.updateWeight = Tensor(glorotUniform: gateWeightShape, seed: seed)
+//         self.updateBias = Tensor(zeros: gateBiasShape)
+//         self.forgetWeight = Tensor(glorotUniform: gateWeightShape, seed: seed)
+//         self.forgetBias = Tensor(ones: gateBiasShape)
+//         self.outputWeight = Tensor(glorotUniform: gateWeightShape, seed: seed)
+//         self.outputBias = Tensor(zeros: gateBiasShape)
+//     }
 
-    public struct State: Differentiable {
-        public var cell: Tensor<Scalar>
-        public var hidden: Tensor<Scalar>
+//     public struct State: Differentiable {
+//         public var cell: Tensor<Scalar>
+//         public var hidden: Tensor<Scalar>
 
-        @differentiable
-        public init(cell: Tensor<Scalar>, hidden: Tensor<Scalar>) {
-            self.cell = cell
-            self.hidden = hidden
-        }
-    }
+//         @differentiable
+//         public init(cell: Tensor<Scalar>, hidden: Tensor<Scalar>) {
+//             self.cell = cell
+//             self.hidden = hidden
+//         }
+//     }
 
-    /// Returns the output obtained from applying the layer to the given input.
-    ///
-    /// - Parameter input: The input to the layer.
-    /// - Returns: The hidden state.
-    @differentiable
-    public func callAsFunction(_ input: Input) -> Output {
-        let gateInput = input.input.concatenated(with: input.state.hidden, alongAxis: 1)
+//     /// Returns the output obtained from applying the layer to the given input.
+//     ///
+//     /// - Parameter input: The input to the layer.
+//     /// - Returns: The hidden state.
+//     @differentiable(wrt: self)
+//     public func callAsFunction(_ input: Input) -> Output {
+//         let gateInput = input.input.concatenated(with: input.state.hidden, alongAxis: 1)
 
-        let inputGate = sigmoid(matmul(gateInput, inputWeight) + inputBias)
-        let updateGate = tanh(matmul(gateInput, updateWeight) + updateBias)
-        let forgetGate = sigmoid(matmul(gateInput, forgetWeight) + forgetBias)
-        let outputGate = sigmoid(matmul(gateInput, outputWeight) + outputBias)
+//         let inputGate = sigmoid(matmul(gateInput, inputWeight) + inputBias)
+//         let updateGate = tanh(matmul(gateInput, updateWeight) + updateBias)
+//         let forgetGate = sigmoid(matmul(gateInput, forgetWeight) + forgetBias)
+//         let outputGate = sigmoid(matmul(gateInput, outputWeight) + outputBias)
 
-        let newCellState = input.state.cell * forgetGate + inputGate * updateGate
-        let newHiddenState = tanh(newCellState) * outputGate
+//         let newCellState = input.state.cell * forgetGate + inputGate * updateGate
+//         let newHiddenState = tanh(newCellState) * outputGate
 
-        let newState = State(cell: newCellState, hidden: newHiddenState)
+//         let newState = State(cell: newCellState, hidden: newHiddenState)
 
-        return Output(output: newState, state: newState)
-    }
-}
+//         return Output(output: newState, state: newState)
+//     }
+// }
 
-public struct RNN<Cell: RNNCell>: Layer {
-    public typealias Input = [Cell.TimeStepInput]
-    public typealias Output = [Cell.TimeStepOutput]
+// public struct RNN<Cell: RNNCell>: Layer {
+//     public typealias Input = [Cell.TimeStepInput]
+//     public typealias Output = [Cell.TimeStepOutput]
 
-    public var cell: Cell
+//     public var cell: Cell
 
-    public init(_ cell: @autoclosure () -> Cell) {
-        self.cell = cell()
-    }
+//     public init(_ cell: @autoclosure () -> Cell) {
+//         self.cell = cell()
+//     }
 
-    @differentiable(wrt: (self, input), vjp: _vjpCall(_:initialState:))
-    public func callAsFunction(_ input: [Cell.TimeStepInput],
-                     initialState: Cell.State) -> [Cell.TimeStepOutput] {
-        var currentHiddenState = initialState
-        var timeStepOutputs: [Cell.TimeStepOutput] = []
-        for timestep in input {
-            let output = cell(input: timestep, state: currentHiddenState)
-            currentHiddenState = output.state
-            timeStepOutputs.append(output.output)
-        }
-        return timeStepOutputs
-    }
+//     @differentiable(wrt: self, vjp: _vjpCall(_:initialState:))
+//     public func callAsFunction(
+//         _ input: [Cell.TimeStepInput],
+//         initialState: Cell.State
+//     ) -> [Cell.TimeStepOutput] {
+//         var currentHiddenState = initialState
+//         var timeStepOutputs: [Cell.TimeStepOutput] = []
+//         for timestep in input {
+//             let output = cell(input: timestep, state: currentHiddenState)
+//             currentHiddenState = output.state
+//             timeStepOutputs.append(output.output)
+//         }
+//         return timeStepOutputs
+//     }
 
-    @differentiable(wrt: (self, input))
-    public func call(_ input: [Cell.TimeStepInput], initialState: Cell.State) -> [Cell.TimeStepOutput] {
-        return callAsFunction(input, initialState: initialState)
-    }
+//     @differentiable(wrt: self)
+//     public func call(_ input: [Cell.TimeStepInput], initialState: Cell.State) -> [Cell.TimeStepOutput] {
+//         return callAsFunction(input, initialState: initialState)
+//     }
 
-    @usableFromInline
-    internal func _vjpCall(
-        _ inputs: [Cell.TimeStepInput], initialState: Cell.State
-    ) -> ([Cell.TimeStepOutput],
-          (Array<Cell.TimeStepOutput>.TangentVector)
-              -> (TangentVector, Array<Cell.TimeStepInput>.TangentVector)) {
-        let timeStepCount = inputs.count
-        var currentHiddenState = cell.zeroState
-        var timeStepOutputs: [Cell.TimeStepOutput] = []
-        timeStepOutputs.reserveCapacity(timeStepCount)
-        var backpropagators: [Cell.Backpropagator] = []
-        backpropagators.reserveCapacity(timeStepCount)
-        for timestep in inputs {
-            let (output, backpropagator) =
-                cell.appliedForBackpropagation(to: .init(input: timestep,
-                                                         state: currentHiddenState))
-            currentHiddenState = output.state
-            timeStepOutputs.append(output.output)
-            backpropagators.append(backpropagator)
-        }
-        return (timeStepOutputs, { 𝛁outputs in
-            precondition(𝛁outputs.base.count == timeStepCount,
-                         "The number of output gradients must equal the number of time steps")
-            var 𝛁cell = Cell.TangentVector.zero
-            var 𝛁state = Cell.State.TangentVector.zero
-            var reversed𝛁inputs: [Cell.TimeStepInput.TangentVector] = []
-            reversed𝛁inputs.reserveCapacity(timeStepCount)
-            for (𝛁output, backpropagator) in zip(𝛁outputs.base, backpropagators).reversed() {
-                let (new𝛁cell, 𝛁input) = backpropagator(.init(output: 𝛁output, state: 𝛁state))
-                𝛁cell = new𝛁cell
-                𝛁state = 𝛁input.state
-                reversed𝛁inputs.append(𝛁input.input)
-            }
-            return (.init(cell: 𝛁cell), .init(Array(reversed𝛁inputs.reversed())))
-        })
-    }
+//     @usableFromInline
+//     internal func _vjpCall(
+//         _ inputs: [Cell.TimeStepInput],
+//         initialState: Cell.State
+//     ) -> ([Cell.TimeStepOutput], (Array<Cell.TimeStepOutput>.TangentVector) -> TangentVector) {
+//         let timeStepCount = inputs.count
+//         var currentHiddenState = cell.zeroState
+//         var timeStepOutputs: [Cell.TimeStepOutput] = []
+//         timeStepOutputs.reserveCapacity(timeStepCount)
+//         var backpropagators: [Cell.Backpropagator] = []
+//         backpropagators.reserveCapacity(timeStepCount)
+//         for timestep in inputs {
+//             let (output, backpropagator) = cell.appliedForBackpropagation(
+//                 to: .init(input: timestep, state: currentHiddenState))
+//             currentHiddenState = output.state
+//             timeStepOutputs.append(output.output)
+//             backpropagators.append(backpropagator)
+//         }
+//         return (timeStepOutputs, { 𝛁outputs in
+//             precondition(𝛁outputs.base.count == timeStepCount,
+//                          "The number of output gradients must equal the number of time steps")
+//             var 𝛁cell = Cell.TangentVector.zero
+//             var 𝛁state = Cell.State.TangentVector.zero
+//             for (𝛁output, backpropagator) in zip(𝛁outputs.base, backpropagators).reversed() {
+//                 let (_, 𝛁input) = backpropagator(.init(output: 𝛁output, state: 𝛁state))
+//                 𝛁state = 𝛁input.state
+//             }
+//             return (.init(cell: 𝛁cell))
+//         })
+//     }
 
-    @differentiable(wrt: (self, inputs))
-    public func callAsFunction(_ inputs: [Cell.TimeStepInput]) -> [Cell.TimeStepOutput] {
-        return self(inputs, initialState: cell.zeroState.withoutDerivative())
-    }
+//     @differentiable(wrt: self)
+//     public func callAsFunction(_ inputs: [Cell.TimeStepInput]) -> [Cell.TimeStepOutput] {
+//         return self(inputs, initialState: cell.zeroState.withoutDerivative())
+//     }
 
-    /* TODO: Uncomment once control flow and differentiation through force unwrapping is supported.
-    @differentiable(wrt: (self, inputs))
-    public func lastOutput(from inputs: [Cell.TimeStepInput],
-                           initialState: Cell.State) -> Cell.TimeStepOutput {
-        precondition(!inputs.isEmpty, "inputs cannot be empty")
-        return self(inputs, initialState: initialState).last!
-    }
+//     /* TODO: Uncomment once control flow and differentiation through force unwrapping is supported.
+//     @differentiable(wrt: self)
+//     public func lastOutput(from inputs: [Cell.TimeStepInput],
+//                            initialState: Cell.State) -> Cell.TimeStepOutput {
+//         precondition(!inputs.isEmpty, "inputs cannot be empty")
+//         return self(inputs, initialState: initialState).last!
+//     }
 
-    @differentiable(wrt: (self, inputs))
-    public func lastOutput(from inputs: [Cell.TimeStepInput]) -> Cell.TimeStepOutput {
-        precondition(!inputs.isEmpty, "inputs cannot be empty")
-        return self(inputs, initialState: cell.zeroState).last!
-    }
-    */
-}
+//     @differentiable(wrt: self)
+//     public func lastOutput(from inputs: [Cell.TimeStepInput]) -> Cell.TimeStepOutput {
+//         precondition(!inputs.isEmpty, "inputs cannot be empty")
+//         return self(inputs, initialState: cell.zeroState).last!
+//     }
+//     */
+// }
 
-extension RNN: Equatable where Cell: Equatable {}
-extension RNN: AdditiveArithmetic where Cell: AdditiveArithmetic {}
-extension RNN: VectorProtocol where Cell: VectorProtocol {}
+// extension RNN: Equatable where Cell: Equatable {}
+// extension RNN: AdditiveArithmetic where Cell: AdditiveArithmetic {}
+// extension RNN: VectorProtocol where Cell: VectorProtocol {}
 
-public typealias SimpleRNN<Scalar: TensorFlowFloatingPoint> = RNN<SimpleRNNCell<Scalar>>
-public typealias LSTM<Scalar: TensorFlowFloatingPoint> = RNN<LSTMCell<Scalar>>
+// public typealias SimpleRNN<Scalar: TensorFlowFloatingPoint> = RNN<SimpleRNNCell<Scalar>>
+// public typealias LSTM<Scalar: TensorFlowFloatingPoint> = RNN<LSTMCell<Scalar>>

--- a/Sources/TensorFlow/Layers/Upsampling.swift
+++ b/Sources/TensorFlow/Layers/Upsampling.swift
@@ -28,7 +28,7 @@ public struct UpSampling1D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         let shape = input.shape
         let (batchSize, timesteps, channels) = (shape[0], shape[1], shape[2])
@@ -54,7 +54,7 @@ public struct UpSampling2D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         let shape = input.shape
         let (batchSize, height, width, channels) = (shape[0], shape[1], shape[2], shape[3])
@@ -106,7 +106,7 @@ public struct UpSampling3D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         var result = repeatingElements(input, alongAxis: 1, count: size)
         result = repeatingElements(result, alongAxis: 2, count: size)


### PR DESCRIPTION
@rxwei This is work-in-progress for removing the `Differentiable` requirement from `Layer.Input`. I'll work on the recurrent layers later but I first want to sort out an issue that comes up with the current changes alone. When I try to compile this PR I get the same auto-diff error as in #147. I'm not sure what the underlying reason is, but it seems like an auto-diff bug in the compiler.

Regarding this PR, I feel that `Input` should not need to conform to `Differentiable` in layers as in the general use cases we're only differentiating with respect to the layer itself. Regarding layer compositions (e.g., `sequenced`), I added conditional differentiability support.