### PR TITLE
Error message for non-scalar Tensor case.

### DIFF
--- a/Sources/TensorFlow/Core/DifferentialOperators.swift
+++ b/Sources/TensorFlow/Core/DifferentialOperators.swift
@@ -30,7 +30,7 @@ public extension Differentiable {
     ) -> (value: Tensor<R>, gradient: TangentVector) {
         let (y, pb) = self.valueWithPullback(in: f)
         precondition(y.rank == 0, """
-            The function being differentiated produced a tensor with shape \(y.shape).
+            The function being differentiated produced a tensor with shape \(y.shape). \
             You can only compute the gradient of functions that return scalar values.
             """)
         return (y, pb(Tensor<R>(1)))
@@ -51,7 +51,7 @@ public extension Differentiable {
     ) -> (value: Tensor<R>, gradient: (TangentVector, T.TangentVector)) {
         let (y, pb) = self.valueWithPullback(at: x, in: f)
         precondition(y.rank == 0, """
-            The function being differentiated produced a tensor with shape \(y.shape).
+            The function being differentiated produced a tensor with shape \(y.shape). \
             You can only compute the gradient of functions that return scalar values.
             """)
         return (y, pb(Tensor<R>(1)))
@@ -71,10 +71,10 @@ public func valueWithGradient<T, R>(
 ) -> (value: Tensor<R>, gradient: T.TangentVector)
 where T: Differentiable, R: TensorFlowFloatingPoint {
     let (y, pullback) = valueWithPullback(at: x, in: f)
-        precondition(y.rank == 0, """
-            The function being differentiated produced a tensor with shape \(y.shape).
-            You can only compute the gradient of functions that return scalar values.
-            """)
+    precondition(y.rank == 0, """
+        The function being differentiated produced a tensor with shape \(y.shape). \
+        You can only compute the gradient of functions that return scalar values.
+        """)
     return (y, pullback(Tensor<R>(1)))
 }
 
@@ -86,10 +86,10 @@ public func valueWithGradient<T, U, R>(
 ) -> (value: Tensor<R>, gradient: (T.TangentVector, U.TangentVector))
     where T: Differentiable, U: Differentiable, R: TensorFlowFloatingPoint {
     let (y, pullback) = valueWithPullback(at: x, y, in: f)
-        precondition(y.rank == 0, """
-            The function being differentiated produced a tensor with shape \(y.shape).
-            You can only compute the gradient of functions that return scalar values.
-            """)
+    precondition(y.rank == 0, """
+        The function being differentiated produced a tensor with shape \(y.shape). \
+        You can only compute the gradient of functions that return scalar values.
+        """)
     return (y, pullback(Tensor<R>(1)))
 }
 

--- a/Sources/TensorFlow/Core/DifferentialOperators.swift
+++ b/Sources/TensorFlow/Core/DifferentialOperators.swift
@@ -29,7 +29,8 @@ public extension Differentiable {
         in f: @differentiable (Self) -> Tensor<R>
     ) -> (value: Tensor<R>, gradient: TangentVector) {
         let (y, pb) = self.valueWithPullback(in: f)
-        precondition(y.rank == 0)
+        precondition(y.rank == 0,
+            "The forward pass computed a non-scalar tensor (shape: \(y.shape)).")
         return (y, pb(Tensor<R>(1)))
     }
 
@@ -47,7 +48,8 @@ public extension Differentiable {
         in f: @differentiable (Self, T) -> Tensor<R>
     ) -> (value: Tensor<R>, gradient: (TangentVector, T.TangentVector)) {
         let (y, pb) = self.valueWithPullback(at: x, in: f)
-        precondition(y.rank == 0)
+        precondition(y.rank == 0,
+            "The forward pass computed a non-scalar tensor (shape: \(y.shape)).")
         return (y, pb(Tensor<R>(1)))
     }
 }
@@ -65,7 +67,8 @@ public func valueWithGradient<T, R>(
 ) -> (value: Tensor<R>, gradient: T.TangentVector)
 where T: Differentiable, R: TensorFlowFloatingPoint {
     let (y, pullback) = valueWithPullback(at: x, in: f)
-    precondition(y.rank == 0)
+    precondition(y.rank == 0,
+        "The forward pass computed a non-scalar tensor (shape: \(y.shape)).")
     return (y, pullback(Tensor<R>(1)))
 }
 
@@ -77,7 +80,8 @@ public func valueWithGradient<T, U, R>(
 ) -> (value: Tensor<R>, gradient: (T.TangentVector, U.TangentVector))
     where T: Differentiable, U: Differentiable, R: TensorFlowFloatingPoint {
     let (y, pullback) = valueWithPullback(at: x, y, in: f)
-    precondition(y.rank == 0)
+    precondition(y.rank == 0,
+        "The forward pass computed a non-scalar tensor (shape: \(y.shape)).")
     return (y, pullback(Tensor<R>(1)))
 }
 

--- a/Sources/TensorFlow/Core/DifferentialOperators.swift
+++ b/Sources/TensorFlow/Core/DifferentialOperators.swift
@@ -29,8 +29,10 @@ public extension Differentiable {
         in f: @differentiable (Self) -> Tensor<R>
     ) -> (value: Tensor<R>, gradient: TangentVector) {
         let (y, pb) = self.valueWithPullback(in: f)
-        precondition(y.rank == 0,
-            "The forward pass computed a non-scalar tensor (shape: \(y.shape)).")
+        precondition(y.rank == 0, """
+            The function being differentiated produced a tensor with shape \(y.shape).
+            You can only compute the gradient of functions that return scalar values.
+            """)
         return (y, pb(Tensor<R>(1)))
     }
 
@@ -48,8 +50,10 @@ public extension Differentiable {
         in f: @differentiable (Self, T) -> Tensor<R>
     ) -> (value: Tensor<R>, gradient: (TangentVector, T.TangentVector)) {
         let (y, pb) = self.valueWithPullback(at: x, in: f)
-        precondition(y.rank == 0,
-            "The forward pass computed a non-scalar tensor (shape: \(y.shape)).")
+        precondition(y.rank == 0, """
+            The function being differentiated produced a tensor with shape \(y.shape).
+            You can only compute the gradient of functions that return scalar values.
+            """)
         return (y, pb(Tensor<R>(1)))
     }
 }
@@ -67,8 +71,10 @@ public func valueWithGradient<T, R>(
 ) -> (value: Tensor<R>, gradient: T.TangentVector)
 where T: Differentiable, R: TensorFlowFloatingPoint {
     let (y, pullback) = valueWithPullback(at: x, in: f)
-    precondition(y.rank == 0,
-        "The forward pass computed a non-scalar tensor (shape: \(y.shape)).")
+        precondition(y.rank == 0, """
+            The function being differentiated produced a tensor with shape \(y.shape).
+            You can only compute the gradient of functions that return scalar values.
+            """)
     return (y, pullback(Tensor<R>(1)))
 }
 
@@ -80,8 +86,10 @@ public func valueWithGradient<T, U, R>(
 ) -> (value: Tensor<R>, gradient: (T.TangentVector, U.TangentVector))
     where T: Differentiable, U: Differentiable, R: TensorFlowFloatingPoint {
     let (y, pullback) = valueWithPullback(at: x, y, in: f)
-    precondition(y.rank == 0,
-        "The forward pass computed a non-scalar tensor (shape: \(y.shape)).")
+        precondition(y.rank == 0, """
+            The function being differentiated produced a tensor with shape \(y.shape).
+            You can only compute the gradient of functions that return scalar values.
+            """)
     return (y, pullback(Tensor<R>(1)))
 }
 


### PR DESCRIPTION
When taking the gradient of a function, the function must return a scalar.
Because Tensors do not encode their shape or rank, this is checked dynamically
at runtime. Previously, we did not provide an error message, resulting in the
following error messages:

```
Precondition failed: file /swift-base/tensorflow-swift-apis/Sources/TensorFlow/Core/DifferentialOperators.swift, line 68
Current stack trace:
0    libswiftCore.so                    0x00007f1629f45830 swift_reportError + 50
1    libswiftCore.so                    0x00007f1629fb45d0 _swift_stdlib_reportFatalErrorInFile + 115
2    libswiftCore.so                    0x00007f1629edca7e <unavailable> + 3734142
3    libswiftCore.so                    0x00007f1629edcbf7 <unavailable> + 3734519
4    libswiftCore.so                    0x00007f1629cab10d <unavailable> + 1433869
5    libswiftCore.so                    0x00007f1629eb1a88 <unavailable> + 3558024
6    libswiftCore.so                    0x00007f1629caa569 <unavailable> + 1430889
9    repl_swift                         0x0000000000400490 <unavailable> + 1168
11   libswiftCore.so                    0x00007f1629caa569 <unavailable> + 1430889
14   repl_swift                         0x0000000000400490 <unavailable> + 1168
16   libswiftCore.so                    0x00007f1629caa569 <unavailable> + 1430889
17   libswiftTensorFlow.so              0x00007f16272250b0 <unavailable> + 2543792
18   libswiftTensorFlow.so              0x00007f1627098280 checkOk(_:file:line:) + 467
19   libswiftTensorFlow.so              0x00007f162709f480 TFE_Op.evaluateUnsafe() + 506
20   libswiftTensorFlow.so              0x00007f162709fcf0 TFE_Op.execute<A>(_:) + 132
21   libswiftTensorFlow.so              0x00007f16270a8984 <unavailable> + 985476
22   libswiftTensorFlow.so              0x00007f162713dc20 static Raw.matMul<A>(_:_:transposeA:transposeB:) + 1221
23   libswiftTensorFlow.so              0x00007f1627293c00 matmul<A>(_:transposed:_:transposed:) + 1427
24   libswiftTensorFlow.so              0x00007f16272f6210 _vjpMatmul<A>(_:transposed:_:transposed:) + 201
25   libswiftTensorFlow.so              0x00007f16273564b4 <unavailable> + 3794100
26   libswiftTensorFlow.so              0x00007f162731f960 AD__$s10TensorFlow5DenseV14callAsFunctionyAA0A0VyxGAGF__vjp_src_0_wrt_0_1 + 680
31   repl_swift                         0x0000000000400490 <unavailable> + 1168
Current stack trace:
	frame #4: 0x00007f162b926120 $__lldb_expr57`main at <Cell 8>:1
```

This change provides the user with a bit more context and prints out the shape
their computation produced to help them debug what might have gone wrong.