### PR TITLE
Removed all uses of 'Differentiable.withoutDerivative()'.

### DIFF
--- a/Sources/TensorFlow/Layers/Recurrent.swift
+++ b/Sources/TensorFlow/Layers/Recurrent.swift
@@ -264,7 +264,7 @@ public struct RNN<Cell: RNNCell>: Layer {
 
     @differentiable(wrt: (self, inputs))
     public func callAsFunction(_ inputs: [Cell.TimeStepInput]) -> [Cell.TimeStepOutput] {
-        return self(inputs, initialState: cell.zeroState.withoutDerivative())
+        return self(inputs, initialState: Swift.withoutDerivative(at: cell.zeroState))
     }
 
     /* TODO: Uncomment once control flow and differentiation through force unwrapping is supported.

--- a/Sources/TensorFlow/Layers/Recurrent.swift
+++ b/Sources/TensorFlow/Layers/Recurrent.swift
@@ -264,7 +264,7 @@ public struct RNN<Cell: RNNCell>: Layer {
 
     @differentiable(wrt: (self, inputs))
     public func callAsFunction(_ inputs: [Cell.TimeStepInput]) -> [Cell.TimeStepOutput] {
-        return self(inputs, initialState: Swift.withoutDerivative(at: cell.zeroState))
+        return self(inputs, initialState: Swift.withoutDerivative(at: cell.zeroState, in: identity))
     }
 
     /* TODO: Uncomment once control flow and differentiation through force unwrapping is supported.

--- a/Sources/TensorFlow/Layers/Recurrent.swift
+++ b/Sources/TensorFlow/Layers/Recurrent.swift
@@ -264,7 +264,7 @@ public struct RNN<Cell: RNNCell>: Layer {
 
     @differentiable(wrt: (self, inputs))
     public func callAsFunction(_ inputs: [Cell.TimeStepInput]) -> [Cell.TimeStepOutput] {
-        return self(inputs, initialState: Swift.withoutDerivative(at: cell.zeroState, in: identity))
+        return self(inputs, initialState: Swift.withoutDerivative(at: cell.zeroState, in: { $0 }))
     }
 
     /* TODO: Uncomment once control flow and differentiation through force unwrapping is supported.

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -1938,7 +1938,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
                 where: rawMax.isFinite)
         }
         let result = TensorFlow.log(TensorFlow.exp(self - offset).sum(squeezingAxes: axes))
-        let resultShape = Swift.withoutDerivative(at: result.shapeTensor, in: identity)
+        let resultShape = Swift.withoutDerivative(at: result.shapeTensor)
         return result + offset.reshaped(toShape: resultShape)
     }
 

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -1938,7 +1938,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
                 where: rawMax.isFinite)
         }
         let result = TensorFlow.log(TensorFlow.exp(self - offset).sum(squeezingAxes: axes))
-        let resultShape = Swift.withoutDerivative(at: result.shapeTensor)
+        let resultShape = Swift.withoutDerivative(at: result.shapeTensor, in: identity)
         return result + offset.reshaped(toShape: resultShape)
     }
 


### PR DESCRIPTION
Friend PR of apple/swift#25691.

cc @rxwei