### PR TITLE
Add default implementations of new requirements in TensorArrayProtocol

### DIFF
--- a/Sources/TensorFlow/Core/TensorGroup.swift
+++ b/Sources/TensorFlow/Core/TensorGroup.swift
@@ -38,12 +38,11 @@ public protocol TensorArrayProtocol {
     init<C: RandomAccessCollection>(_handles: C) where C.Element: _AnyTensorHandle
 }
 
-extension TensorArrayProtocol {
+public extension TensorArrayProtocol {
     init<C: RandomAccessCollection>(_handles: C) where C.Element: _AnyTensorHandle {
         let status = TF_NewStatus()
         defer { TF_DeleteStatus(status) }
-        let buffer: UnsafeMutablePointer<CTensorHandle> =
-            UnsafeMutablePointer.allocate(capacity: _handles.count)
+        let buffer = UnsafeMutablePointer<CTensorHandle>.allocate(capacity: _handles.count)
         defer { buffer.deallocate() }
         for handle in _handles {
             // Increment the reference count in TF.
@@ -54,7 +53,7 @@ extension TensorArrayProtocol {
         self.init(_owning: buffer, count: _handles.count)
     }
 
-    var _tensorHandles : [_AnyTensorHandle] {
+    var _tensorHandles: [_AnyTensorHandle] {
         let status = TF_NewStatus()
         defer { TF_DeleteStatus(status) }
         let count = Int(_tensorHandleCount)

--- a/Tests/TensorFlowTests/OperatorTests/DatasetTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/DatasetTests.swift
@@ -18,18 +18,6 @@ import XCTest
 struct SimpleOutput: TensorGroup {
     let a: TensorHandle<Int32>
     let b: TensorHandle<Int32>
-
-    public init<C: RandomAccessCollection>(
-        _handles: C
-    ) where C.Element: _AnyTensorHandle {
-        precondition(_handles.count == 2)
-        let aIndex = _handles.startIndex
-        let bIndex = _handles.index(aIndex, offsetBy: 1)
-        a = TensorHandle<Int32>(handle: _handles[aIndex])
-        b = TensorHandle<Int32>(handle: _handles[bIndex])
-    }
-
-    public var _tensorHandles: [_AnyTensorHandle] { [a.handle, b.handle] }
 }
 
 final class DatasetTests: XCTestCase {

--- a/Tests/TensorFlowTests/TensorGroupTests.swift
+++ b/Tests/TensorFlowTests/TensorGroupTests.swift
@@ -22,33 +22,10 @@ extension TensorDataType : Equatable {
     }
 }
 
-struct Empty : TensorGroup {
-    init() {}
-    public init<C: RandomAccessCollection>(
-        _handles: C
-    ) where C.Element: _AnyTensorHandle {}
-    public var _tensorHandles: [_AnyTensorHandle] { [] }
-}
+struct Empty : TensorGroup {}
 
 struct Simple : TensorGroup, Equatable {
     var w, b: Tensor<Float>
-
-    init(w: Tensor<Float>, b: Tensor<Float>) {
-        self.w = w
-        self.b = b
-    }
-
-    public init<C: RandomAccessCollection>(
-        _handles: C
-    ) where C.Element: _AnyTensorHandle {
-        precondition(_handles.count == 2)
-        let wIndex = _handles.startIndex
-        let bIndex = _handles.index(wIndex, offsetBy: 1)
-        w = Tensor<Float>(handle: TensorHandle<Float>(handle: _handles[wIndex]))
-        b = Tensor<Float>(handle: TensorHandle<Float>(handle: _handles[bIndex]))
-    }
-
-    public var _tensorHandles: [_AnyTensorHandle] { [w.handle.handle, b.handle.handle] }
 }
 
 struct Mixed : TensorGroup, Equatable {
@@ -56,27 +33,6 @@ struct Mixed : TensorGroup, Equatable {
     var float: Tensor<Float>
     // Immutable.
     let int: Tensor<Int32>
-
-    init(float: Tensor<Float>, int: Tensor<Int32>) {
-        self.float = float
-        self.int = int
-    }
-
-    public init<C: RandomAccessCollection>(
-        _handles: C
-    ) where C.Element: _AnyTensorHandle {
-        precondition(_handles.count == 2)
-        let floatIndex = _handles.startIndex
-        let intIndex = _handles.index(floatIndex, offsetBy: 1)
-        float = Tensor<Float>(
-            handle: TensorHandle<Float>(handle: _handles[floatIndex]))
-        int = Tensor<Int32>(
-            handle: TensorHandle<Int32>(handle: _handles[intIndex]))
-    }
-
-    public var _tensorHandles: [_AnyTensorHandle] {
-        [float.handle.handle, int.handle.handle]
-    }
 }
 
 struct Nested : TensorGroup, Equatable {
@@ -84,73 +40,17 @@ struct Nested : TensorGroup, Equatable {
     let simple: Simple
     // Mutable.
     var mixed: Mixed
-
-    init(simple: Simple, mixed: Mixed) {
-        self.simple = simple
-        self.mixed = mixed
-    }
-
-    public init<C: RandomAccessCollection>(
-        _handles: C
-    ) where C.Element: _AnyTensorHandle {
-        let simpleStart = _handles.startIndex
-        let simpleEnd = _handles.index(
-            simpleStart, offsetBy: Int(Simple._tensorHandleCount))
-        simple = Simple(_handles: _handles[simpleStart..<simpleEnd])
-        mixed = Mixed(_handles: _handles[simpleEnd..<_handles.endIndex])
-    }
-
-    public var _tensorHandles: [_AnyTensorHandle] {
-        simple._tensorHandles + mixed._tensorHandles
-    }
 }
 
 struct Generic<T: TensorGroup & Equatable, U: TensorGroup & Equatable> : TensorGroup, Equatable {
     var t: T
     var u: U
-
-    public init(t: T, u: U) {
-        self.t = t
-        self.u = u
-    }
-
-    public init<C: RandomAccessCollection>(
-        _handles: C
-    ) where C.Element: _AnyTensorHandle {
-        let tStart = _handles.startIndex
-        let tEnd = _handles.index(tStart, offsetBy: Int(T._tensorHandleCount))
-        t = T.init(_handles: _handles[tStart..<tEnd])
-        u = U.init(_handles: _handles[tEnd..<_handles.endIndex])
-    }
-
-    public var _tensorHandles: [_AnyTensorHandle] {
-        t._tensorHandles + u._tensorHandles
-    }
 }
 
 struct UltraNested<T: TensorGroup & Equatable, V: TensorGroup & Equatable>
     : TensorGroup, Equatable {
     var a: Generic<T, V>
     var b: Generic<V, T>
-
-    init(a: Generic<T, V>, b: Generic<V,T>) {
-        self.a = a
-        self.b = b
-    }
-
-    public init<C: RandomAccessCollection>(
-        _handles: C
-    ) where C.Element: _AnyTensorHandle {
-        let firstStart = _handles.startIndex
-        let firstEnd = _handles.index(
-            firstStart, offsetBy: Int(Generic<T,V>._tensorHandleCount))
-        a = Generic<T,V>.init(_handles: _handles[firstStart..<firstEnd])
-        b = Generic<V,T>.init(_handles: _handles[firstEnd..<_handles.endIndex])
-    }
-
-    public var _tensorHandles: [_AnyTensorHandle] {
-        return a._tensorHandles + b._tensorHandles
-    }
 }
 
 extension TensorHandle {

--- a/Tests/TensorFlowTests/TensorGroupTests.swift
+++ b/Tests/TensorFlowTests/TensorGroupTests.swift
@@ -64,6 +64,12 @@ extension TensorHandle {
     }
 }
 
+extension TensorArrayProtocol {
+    var tfeTensorHandles: [TFETensorHandle] {
+        self._tensorHandles.map { $0 as! TFETensorHandle }
+    }
+}
+
 final class TensorGroupTests: XCTestCase {
     func testEmptyList() {
         XCTAssertEqual([], Empty._typeList)
@@ -84,8 +90,10 @@ final class TensorGroupTests: XCTestCase {
         let bHandle = b.handle.makeCopy()
 
         let expectedSimple = Simple(_handles: [wHandle, bHandle])
-
         XCTAssertEqual(expectedSimple, simple)
+
+        let reconstructedSimple = Simple(_handles: simple.tfeTensorHandles)
+        XCTAssertEqual(reconstructedSimple, simple)
     }
 
     func testMixedTypeList() {
@@ -103,8 +111,10 @@ final class TensorGroupTests: XCTestCase {
         let intHandle = int.handle.makeCopy()
 
         let expectedMixed = Mixed(_handles: [floatHandle, intHandle])
-
         XCTAssertEqual(expectedMixed, mixed)
+
+        let reconstructedMixed = Mixed(_handles: mixed.tfeTensorHandles)
+        XCTAssertEqual(reconstructedMixed, mixed)
     }
 
     func testNestedTypeList() {
@@ -129,8 +139,10 @@ final class TensorGroupTests: XCTestCase {
 
         let expectedNested = Nested(
             _handles: [wHandle, bHandle, floatHandle, intHandle])
-        
         XCTAssertEqual(expectedNested, nested)
+
+        let reconstructedNested = Nested(_handles: nested.tfeTensorHandles)
+        XCTAssertEqual(reconstructedNested, nested)
     }
 
     func testGenericTypeList() {
@@ -156,8 +168,10 @@ final class TensorGroupTests: XCTestCase {
 
         let expectedGeneric = Generic<Simple, Mixed>(
             _handles: [wHandle, bHandle, floatHandle, intHandle])
-
         XCTAssertEqual(expectedGeneric, generic)
+
+        let reconstructedGeneric = Generic<Simple, Mixed>(_handles: generic.tfeTensorHandles)
+        XCTAssertEqual(reconstructedGeneric, generic)
     }
 
     func testNestedGenericTypeList() {
@@ -198,8 +212,11 @@ final class TensorGroupTests: XCTestCase {
                 let expectedGeneric = UltraNested<Simple, Mixed>(
                     _handles: [wHandle1, bHandle1, floatHandle1,  intHandle1,
                         floatHandle2, intHandle2, wHandle2, bHandle2])
-
                 XCTAssertEqual(expectedGeneric, generic)
+
+                let reconstructedGeneric = UltraNested<Simple, Mixed>(
+                    _handles: generic.tfeTensorHandles)
+                XCTAssertEqual(reconstructedGeneric, generic)
             }
         }
 


### PR DESCRIPTION
Note that these implementations access `_cTensorHandle` and therefore, will trigger
materialization in the case of lazy tensor. Therefore, if the user needs to defer materialization, they will need to manually implement these methods. 

Note that this is a stop-gap solution while we continue to work on the DerivedConformances for TensorArrayProtocol.
