### PR TITLE
Turn lazy tensor off in 'tearDown()' in lazy tensor tests.

### DIFF
--- a/Tests/TensorFlowTests/LazyTensorTFFunctionBuilderTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTFFunctionBuilderTests.swift
@@ -22,6 +22,11 @@ final class LazyTensorTFFunctionBuilderTests : XCTestCase {
         _RuntimeConfig.useLazyTensor = true
     }
 
+    override class func tearDown() {
+        super.tearDown()
+        _RuntimeConfig.useLazyTensor = false
+    }
+
     func testSingletonInputs() {
         let a = materializedLazyTensor(Tensor<Float>(10.0))
         let w = Raw.identity(a)

--- a/Tests/TensorFlowTests/LazyTensorTraceTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTraceTests.swift
@@ -23,6 +23,11 @@ final class LazyTensorTraceTests: XCTestCase {
         _RuntimeConfig.useLazyTensor = true
     }
 
+    override class func tearDown() {
+        super.tearDown()
+        _RuntimeConfig.useLazyTensor = false
+    }
+
     func testSingleLiveTensor() {
         let a = Tensor<Float>(10.0)
         let b = Tensor<Float>(2.0)


### PR DESCRIPTION
This was triggering a runtime failure in other test suites that ran after lazy tensor tests.