### PR TITLE
Trigger execution of operations with no outputs.

### DIFF
--- a/Sources/TensorFlow/Core/LazyTensorOperation.swift
+++ b/Sources/TensorFlow/Core/LazyTensorOperation.swift
@@ -346,17 +346,19 @@ extension LazyTensorOperation: TFTensorOperation {
     }
 
     func execute() {
-        // Just run it now.
+        // If we want to stage this, we will need to add control dependencies.
+        // For the time-being, just build a TFE_Op and run it.
+        //
         let op = TFE_Op(name, outputCount)
-        // TODO: Materialize en masse and not one-by-one.
+        // TODO(https://bugs.swift.org/browse/TF-604):
+        //   Materialize inputs en masse and not one-by-one.
         for input in inputs {
             switch input {
             case .single(let v):
                 op.addInput(v._tfeTensorHandle)
-            case .list(let values): do {
-                    for v in values {
-                        op.addInput(v._tfeTensorHandle)
-                    }
+            case .list(let values):
+                for v in values {
+                    op.addInput(v._tfeTensorHandle)
                 }
             }
         }
@@ -372,12 +374,12 @@ extension LazyTensorOperation: TFTensorOperation {
             case .floatArray(let v): op.updateAttribute(name, v)
             case .doubleArray(let v): op.updateAttribute(name, v)
             case .stringArray(let v): op.updateAttribute(name, v)
-            case .constTensor(_): assert(false, "Const Tensor cannot be eager attribute.")
+            case .constTensor(_): fatalError("Const Tensor cannot be eager attribute.")
             case .tensorDataTypeValue(let v): op.updateAttribute(name, v)
             case .tensorDataTypeArray(let v): op.updateAttribute(name, v)
             case .optionalTensorShape(let v): op.updateAttribute(name, v)
             case .optionalTensorShapeArray(let v): op.updateAttribute(name, v)
-            case .tensorFunctionPointer(_): assert(false, "Unimplemented")
+            case .tensorFunctionPointer(_): fatalError("tensorFunctionPointer Unimplemented!")
             }
         }
         op.execute()

--- a/Sources/TensorFlow/Core/LazyTensorOperation.swift
+++ b/Sources/TensorFlow/Core/LazyTensorOperation.swift
@@ -345,7 +345,43 @@ extension LazyTensorOperation: TFTensorOperation {
         fatalError("Unimplemented [TFFunction] attribute.")
     }
 
-    func execute() {}
+    func execute() {
+        // Just run it now.
+        let op = TFE_Op(name, outputCount)
+        // TODO: Materialize en masse and not one-by-one.
+        for input in inputs {
+            switch input {
+            case .single(let v):
+                op.addInput(v._tfeTensorHandle)
+            case .list(let values): do {
+                    for v in values {
+                        op.addInput(v._tfeTensorHandle)
+                    }
+                }
+            }
+        }
+        for (name, value) in attributes {
+            switch value {
+            case .boolValue(let v): op.updateAttribute(name, v)
+            case .intValue(let v): op.updateAttribute(name, v)
+            case .floatValue(let v): op.updateAttribute(name, v)
+            case .doubleValue(let v): op.updateAttribute(name, v)
+            case .stringValue(let v): op.updateAttribute(name, v)
+            case .boolArray(let v): op.updateAttribute(name, v)
+            case .intArray(let v): op.updateAttribute(name, v)
+            case .floatArray(let v): op.updateAttribute(name, v)
+            case .doubleArray(let v): op.updateAttribute(name, v)
+            case .stringArray(let v): op.updateAttribute(name, v)
+            case .constTensor(_): assert(false, "Const Tensor cannot be eager attribute.")
+            case .tensorDataTypeValue(let v): op.updateAttribute(name, v)
+            case .tensorDataTypeArray(let v): op.updateAttribute(name, v)
+            case .optionalTensorShape(let v): op.updateAttribute(name, v)
+            case .optionalTensorShapeArray(let v): op.updateAttribute(name, v)
+            case .tensorFunctionPointer(_): assert(false, "Unimplemented")
+            }
+        }
+        op.execute()
+    }
 
     func execute<T0: TensorArrayProtocol>(
         _ count0: Int

--- a/Tests/TensorFlowTests/LazyTensorEvaluationTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorEvaluationTests.swift
@@ -86,8 +86,22 @@ final class LazyTensorEvaluationTests: XCTestCase {
         XCTAssertTrue(isMaterialized(sum))
     }
 
+    func testNoOutputOperations() {
+        let a = StringTensor("Hello ")
+        let b = StringTensor("World")
+        let c = Raw.add(a, b)
+        // c is not materialized yet.
+        XCTAssertFalse(isMaterialized(c.handle.handle))
+        Raw.printV2(c)
+        // c is materialized now as printV2 would be executed.
+        XCTAssertTrue(isMaterialized(c.handle.handle))
+    }
+
     private func isMaterialized<T: TensorFlowScalar>(_ input: Tensor<T>) -> Bool {
-        let tensor = input.handle.handle
+        return isMaterialized(input.handle.handle)
+    }
+
+    private func isMaterialized(_ tensor: _AnyTensorHandle) -> Bool {
         guard let lazyTensor = tensor as? LazyTensor else { return true }
         switch lazyTensor.handle {
         case .symbolic(let op, _, _): return op.outputs != nil
@@ -100,6 +114,7 @@ final class LazyTensorEvaluationTests: XCTestCase {
         ("testMultipleMaterializations", testMultipleMaterializations),
         ("testSimpleControlFlow", testSimpleControlFlow),
         ("testSimpleLoop", testSimpleLoop),
+        ("testNoOutputOperations", testNoOutputOperations)
     ]
 }
 


### PR DESCRIPTION
We cannot defer such operations until we support control dependencies in the trace. For the time-being, simply trigger execution right away for such operations.
