### PR TITLE
Add Function/Lambda Layer 

### DIFF
--- a/Sources/TensorFlow/Layers/Core.swift
+++ b/Sources/TensorFlow/Layers/Core.swift
@@ -225,19 +225,15 @@ public extension Dense {
 }
 
 
-public struct Function<InputScalar: TensorFlowFloatingPoint, OutputScalar:TensorFlowFloatingPoint>: Layer {
+public struct Function<Input: Differentiable, Output: Differentiable>: Layer {
     /// The Function Layer arbitrarily takes any differentiable function and returns a Layer which can
     /// used as a wrapper around that function.
-    public typealias Input = Tensor<InputScalar>
-
-    public typealias Output = Tensor<OutputScalar>
 
     public typealias Body = @differentiable (Input) -> Output
 
     @noDerivative public let body: Body
 
-    public init(
-        body: @escaping Body) {
+    public init(_ body: @escaping Body) {
         self.body = body
     }
 

--- a/Sources/TensorFlow/Layers/Core.swift
+++ b/Sources/TensorFlow/Layers/Core.swift
@@ -224,7 +224,7 @@ public extension Dense {
     }
 }
 
-/// /// A layer that encloses a custom differentiable function.
+/// A layer that encloses a custom differentiable function.
 public struct Function<Input: Differentiable, Output: Differentiable>: Layer {
     public typealias Body = @differentiable (Input) -> Output
 

--- a/Sources/TensorFlow/Layers/Core.swift
+++ b/Sources/TensorFlow/Layers/Core.swift
@@ -224,10 +224,8 @@ public extension Dense {
     }
 }
 
-/// A `Function` layer arbitrarily stores any differentiable function and returns its
-/// `callAsFunction(_:)` method which can used as a wrapper around that function.
+/// /// A layer that encloses a custom differentiable function.
 public struct Function<Input: Differentiable, Output: Differentiable>: Layer {
-
     public typealias Body = @differentiable (Input) -> Output
 
     @noDerivative public let body: Body

--- a/Sources/TensorFlow/Layers/Core.swift
+++ b/Sources/TensorFlow/Layers/Core.swift
@@ -223,3 +223,26 @@ public extension Dense {
                   activation: activation)
     }
 }
+
+
+public struct Function<InputScalar: TensorFlowFloatingPoint, OutputScalar:TensorFlowFloatingPoint>: Layer {
+    /// The Function Layer arbitrarily takes any differentiable function and returns a Layer which can
+    /// used as a wrapper around that function.
+    public typealias Input = Tensor<InputScalar>
+
+    public typealias Output = Tensor<OutputScalar>
+
+    public typealias Body = @differentiable (Input) -> Output
+
+    @noDerivative public let body: Body
+
+    public init(
+        body: @escaping Body) {
+        self.body = body
+    }
+
+    @differentiable
+    public func callAsFunction(_ input: Input) -> Output {
+        return body(input)
+    }
+}

--- a/Sources/TensorFlow/Layers/Core.swift
+++ b/Sources/TensorFlow/Layers/Core.swift
@@ -224,10 +224,9 @@ public extension Dense {
     }
 }
 
-
+/// A `Function` layer arbitrarily stores any differentiable function and returns its
+/// `callAsFunction(_:)` method which can used as a wrapper around that function.
 public struct Function<Input: Differentiable, Output: Differentiable>: Layer {
-    /// The Function Layer arbitrarily takes any differentiable function and returns a Layer which can
-    /// used as a wrapper around that function.
 
     public typealias Body = @differentiable (Input) -> Output
 

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -250,7 +250,7 @@ final class LayerTests: XCTestCase {
 
 
     func testFunction() {
-        let tanhLayer = Function<Float, Float>(tanh)
+        let tanhLayer = Function<Tensor<Float>, Tensor<Float>>(tanh)
         let input = Tensor(shape:[5, 1], scalars:(0..<5).map(Float.init))
         let output = tanhLayer.inferring(from: input)
         let expected = Tensor<Float>([[0.0], [0.7615942], [0.9640276], [0.9950547], [0.9993292]])

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -38,7 +38,7 @@ final class LayerTests: XCTestCase {
         // Input shapes.
         let inputHeight = 2
         let inputWidth = 5
-        
+
         let filter = Tensor<Float>(shape: [width, inputChannels, outputChannels],
                                    scalars: [2, 3, 4, 1, 2, 3])
         let bias = Tensor<Float>([0])
@@ -248,6 +248,15 @@ final class LayerTests: XCTestCase {
         XCTAssertEqual(output.shape, expected)
     }
 
+
+    func testFunction() {
+        let tanhLayer = Function<Float, Float>(tanh)
+        let input = Tensor(shape:[5, 1], scalars:(0..<5).map(Float.init))
+        let output = tanhLayer.inferring(from: input)
+        let expected = Tensor<Float>([[0.0], [0.7615942], [0.9640276], [0.9950547], [0.9993292]])
+        XCTAssertEqual(output, expected)
+    }
+
     func testFlatten() {
         let layer = Flatten<Float>()
         let input = Tensor(shape: [10, 2, 2], scalars: (0..<40).map(Float.init))
@@ -256,14 +265,14 @@ final class LayerTests: XCTestCase {
         XCTAssertEqual(output.shape, expected)
     }
 
-    func testEmbedding() {       
-        var layer = Embedding<Float>(vocabularySize: 3, embeddingSize: 5)       
+    func testEmbedding() {
+        var layer = Embedding<Float>(vocabularySize: 3, embeddingSize: 5)
         var data = Tensor<Int32>(shape: [2, 3], scalars: [0, 1, 2, 1, 2, 2])
         var input = EmbeddingInput(indices: data)
         var output = layer.inferring(from: input)
         let expectedShape = TensorShape([2, 3, 5])
         XCTAssertEqual(output.shape, expectedShape)
-    
+
         let pretrained = Tensor<Float>(shape:[2, 2], scalars: [0.4, 0.3, 0.2, 0.1])
         layer = Embedding<Float>(embeddings: pretrained)
         data = Tensor<Int32>(shape: [2, 2], scalars: [0, 1, 1, 1])
@@ -331,6 +340,7 @@ final class LayerTests: XCTestCase {
         ("testAvgPool1D", testAvgPool1D),
         ("testAvgPool2D", testAvgPool2D),
         ("testAvgPool3D", testAvgPool3D),
+        ("testFunction", testFunction),
         ("testGlobalAvgPool1D", testGlobalAvgPool1D),
         ("testGlobalAvgPool2D", testGlobalAvgPool2D),
         ("testGlobalAvgPool3D", testGlobalAvgPool3D),

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -248,15 +248,6 @@ final class LayerTests: XCTestCase {
         XCTAssertEqual(output.shape, expected)
     }
 
-
-    func testFunction() {
-        let tanhLayer = Function<Tensor<Float>, Tensor<Float>>(tanh)
-        let input = Tensor(shape:[5, 1], scalars:(0..<5).map(Float.init))
-        let output = tanhLayer.inferring(from: input)
-        let expected = Tensor<Float>([[0.0], [0.7615942], [0.9640276], [0.9950547], [0.9993292]])
-        XCTAssertEqual(output, expected)
-    }
-
     func testFlatten() {
         let layer = Flatten<Float>()
         let input = Tensor(shape: [10, 2, 2], scalars: (0..<40).map(Float.init))
@@ -327,6 +318,14 @@ final class LayerTests: XCTestCase {
         // XCTAssertEqual(𝛁rnn.cell.bias, [  0.2496884,  0.66947335,   0.7978788, -0.22378457])
     }
 
+    func testFunction() {
+        let tanhLayer = Function<Tensor<Float>, Tensor<Float>>(tanh)
+        let input = Tensor(shape: [5, 1], scalars: (0..<5).map(Float.init))
+        let output = tanhLayer.inferring(from: input)
+        let expected = Tensor<Float>([[0.0], [0.7615942], [0.9640276], [0.9950547], [0.9993292]])
+        XCTAssertEqual(output, expected)
+    }
+
     static var allTests = [
         ("testConv1D", testConv1D),
         ("testConv1DDilation", testConv1DDilation),
@@ -340,7 +339,6 @@ final class LayerTests: XCTestCase {
         ("testAvgPool1D", testAvgPool1D),
         ("testAvgPool2D", testAvgPool2D),
         ("testAvgPool3D", testAvgPool3D),
-        ("testFunction", testFunction),
         ("testGlobalAvgPool1D", testGlobalAvgPool1D),
         ("testGlobalAvgPool2D", testGlobalAvgPool2D),
         ("testGlobalAvgPool3D", testGlobalAvgPool3D),
@@ -354,6 +352,7 @@ final class LayerTests: XCTestCase {
         ("testFlatten", testFlatten),
         ("testEmbedding", testEmbedding),
         ("testSimpleRNNCell", testSimpleRNNCell),
-        ("testRNN", testRNN)
+        ("testRNN", testRNN),
+        ("testFunction", testFunction)
     ]
 }


### PR DESCRIPTION
Working on this currently, IMO a major functionality addition to the Layer API we currently have. This would allow for any differentiable function to be wrapped around and added as a layer in a model.

Also avoids API redundancies for layers like reshape, padded etc. 

I'm currently getting the error that the layer doesn't conform to protocol of Layer and that a call function is needed. As far as i understand, for a structure to inherit a protocol, you need to extend and define all the functions in the protocol, something like abstract classes theoretically. Any thoughts on where i might be going or doing it wrong?

Refer to discussion in #54 [here](https://github.com/tensorflow/swift-apis/issues/54#issuecomment-502435415)