### PR TITLE
Adds a mechanism to manually promote constants to inputs in Lazy Tensor.

### DIFF
--- a/Sources/TensorFlow/Core/LazyTensorOperation.swift
+++ b/Sources/TensorFlow/Core/LazyTensorOperation.swift
@@ -272,6 +272,60 @@ class LazyTensorOperation: TensorOperation {
     }
 }
 
+extension _AnyTensorHandle {
+    /// Wraps the `_tfeTensorHandle` as a `LazyTensor`.
+    var lazyTensor: LazyTensor { LazyTensor(self._tfeTensorHandle) }
+
+    /// Wraps the `_tfeTensorHandle` in a `LazyTensor` that will
+    /// be promoted to an input when used in a extracted trace.
+    var inputLazyTensor: LazyTensor { LazyTensor(_materialized: self._tfeTensorHandle) }
+}
+
+extension TensorHandle {
+    /// Wraps this handle in a `LazyTensor`.
+    public var lazyTensor: TensorHandle { TensorHandle(handle: handle.lazyTensor) }
+
+    /// Wraps this handle in a `LazyTensor` that will be promoted
+    /// to an input when used in a extracted trace.
+    public var inputLazyTensor: TensorHandle { TensorHandle(handle: handle.inputLazyTensor) }
+}
+
+extension Tensor {
+    /// Wraps this tensor in a `LazyTensor`.
+    public var lazyTensor: Tensor { Tensor(handle: handle.lazyTensor) }
+
+    /// Wraps this tensor in a `LazyTensor` that will be promoted
+    /// to an input when used in a extracted trace.
+    public var inputLazyTensor: Tensor { Tensor(handle: handle.inputLazyTensor) }
+}
+
+extension StringTensor {
+    /// Wraps this tensor in a `LazyTensor`.
+    public var lazyTensor: StringTensor { StringTensor(handle: handle.lazyTensor) }
+
+    /// Wraps this tensor in a `LazyTensor` that will be promoted
+    /// to an input when used in a extracted trace.
+    public var inputLazyTensor: StringTensor { StringTensor(handle: handle.inputLazyTensor) }
+}
+
+extension VariantHandle {
+    /// Wraps this variant handle in a `LazyTensor`.
+    public var lazyTensor: VariantHandle { VariantHandle(handle: handle.lazyTensor) }
+
+    /// Wraps this variant handle in a `LazyTensor` that will
+    /// be promoted to an input when used in a extracted trace.
+    public var inputLazyTensor: VariantHandle { VariantHandle(handle: handle.inputLazyTensor) }
+}
+
+extension ResourceHandle {
+    /// Wraps this variant handle in a `LazyTensor`.
+    public var lazyTensor: ResourceHandle { ResourceHandle(handle: handle.lazyTensor) }
+
+    /// Wraps this variant handle in a `LazyTensor` that will
+    /// be promoted to an input when used in a extracted trace.
+    public var inputLazyTensor: ResourceHandle { ResourceHandle(handle: handle.inputLazyTensor) }
+}
+
 extension LazyTensorOperation: TFTensorOperation {
     private func lazyTensorHandle(_ input: _AnyTensorHandle) -> LazyTensor {
         if let lazyHandle = input as? LazyTensor {

--- a/Sources/TensorFlow/Core/LazyTensorOperation.swift
+++ b/Sources/TensorFlow/Core/LazyTensorOperation.swift
@@ -130,6 +130,57 @@ class LazyTensor: _AnyTensorHandle {
     static var _materializationCallback: (String) -> () = { _ in }
 }
 
+extension _AnyTensorHandle {
+    /// Returns a concrete `LazyTensor` with an additional constraint that the
+    /// underlying concrete `LazyTensor` should be marked to be promoted as an
+    /// input when used in an extracted trace.  This provides a **temporary**
+    /// mechanism to promote a concrete lazy tensor to an input in extracted
+    /// traces. (Note that this may trigger materialization.)
+    var _concreteInputLazyTensor: LazyTensor {
+        LazyTensor(_materialized: self._tfeTensorHandle)
+    }
+}
+
+extension TensorHandle {
+    /// Returns `Self` that wraps `_concreteInputLazyTensor` of the underlying
+    /// `_AnyTensorHandle`
+    public var _concreteInputLazyTensor: TensorHandle {
+        TensorHandle(handle: handle._concreteInputLazyTensor)
+    }
+}
+
+extension Tensor {
+    /// Returns `Self` that wraps `_concreteInputLazyTensor` of the underlying
+    /// `_AnyTensorHandle`
+    public var _concreteInputLazyTensor: Tensor {
+        Tensor(handle: handle._concreteInputLazyTensor)
+    }
+}
+
+extension StringTensor {
+    /// Returns `Self` that wraps `_concreteInputLazyTensor` of the underlying
+    /// `_AnyTensorHandle`
+    public var _concreteInputLazyTensor: StringTensor {
+        StringTensor(handle: handle._concreteInputLazyTensor)
+    }
+}
+
+extension VariantHandle {
+    /// Returns `Self` that wraps `_concreteInputLazyTensor` of the underlying
+    /// `_AnyTensorHandle`
+    public var _concreteInputLazyTensor: VariantHandle {
+        VariantHandle(handle: handle._concreteInputLazyTensor)
+    }
+}
+
+extension ResourceHandle {
+    /// Returns `Self` that wraps `_concreteInputLazyTensor` of the underlying
+    /// `_AnyTensorHandle`
+    public var _concreteInputLazyTensor: ResourceHandle {
+        ResourceHandle(handle: handle._concreteInputLazyTensor)
+    }
+}
+
 class LazyTensorOperation: TensorOperation {
      typealias TensorValueHandle = LazyTensor
 
@@ -269,77 +320,6 @@ class LazyTensorOperation: TensorOperation {
     }
     func updateAttribute(_ name: String, _ value: [String]) {
         attributes[name] = Attribute.stringArray(value)
-    }
-}
-
-protocol _LazyTensorCompatible {
-    /// The underlying `LazyTensor` (if any).
-    var _lazyTensor: LazyTensor? { get }
-
-    /// Returns `Self` that wraps a concrete `LazyTensor`.
-    /// (Triggers materialization if needed.)
-    var _concreteLazyTensor: Self { get }
-
-    /// Similar to the `concreteLazyTensor` with an additional constraint that
-    /// the underlying concrete `LazyTensor` should be marked to be promoted as
-    /// an input when used in an extracted trace.
-    var _concreteInputLazyTensor: Self { get }
-}
-
-extension _AnyTensorHandle {
-    var _lazyTensor: LazyTensor? {
-        if let handle = self as? LazyTensor {
-            return handle
-        } else {
-            return nil
-        }
-    }
-    var _concreteLazyTensor: LazyTensor { LazyTensor(self._tfeTensorHandle) }
-    var _concreteInputLazyTensor: LazyTensor { LazyTensor(_materialized: self._tfeTensorHandle) }
-}
-
-extension TensorHandle: _LazyTensorCompatible {
-    var _lazyTensor: LazyTensor? { handle._lazyTensor }
-    public var _concreteLazyTensor: TensorHandle { TensorHandle(handle: handle._concreteLazyTensor) }
-    public var _concreteInputLazyTensor: TensorHandle {
-        TensorHandle(handle: handle._concreteInputLazyTensor)
-    }
-}
-
-extension Tensor: _LazyTensorCompatible {
-    var _lazyTensor: LazyTensor? { handle._lazyTensor }
-    public var _concreteLazyTensor: Tensor { Tensor(handle: handle._concreteLazyTensor) }
-    public var _concreteInputLazyTensor: Tensor { Tensor(handle: handle._concreteInputLazyTensor) }
-}
-
-extension StringTensor: _LazyTensorCompatible {
-    var _lazyTensor: LazyTensor? { handle._lazyTensor }
-    public var _concreteLazyTensor: StringTensor { StringTensor(handle: handle._concreteLazyTensor) }
-    public var _concreteInputLazyTensor: StringTensor {
-        StringTensor(handle: handle._concreteInputLazyTensor)
-    }
-}
-
-extension VariantHandle: _LazyTensorCompatible {
-    var _lazyTensor: LazyTensor? { handle._lazyTensor }
-    public var _concreteLazyTensor: VariantHandle { VariantHandle(handle: handle._concreteLazyTensor) }
-    public var _concreteInputLazyTensor: VariantHandle {
-        VariantHandle(handle: handle._concreteInputLazyTensor)
-    }
-}
-
-extension ResourceHandle: _LazyTensorCompatible {
-    var _lazyTensor: LazyTensor? { handle._lazyTensor }
-
-    /// Wraps this variant handle in a concrete `LazyTensor`.
-    public var _concreteLazyTensor: ResourceHandle {
-        ResourceHandle(handle: handle._concreteLazyTensor)
-    }
-
-    /// Wraps this variant handle in a concrete `LazyTensor` that will
-    /// be promoted to an input when used in a extracted trace.
-    public var _concreteInputLazyTensor: ResourceHandle {
-        ResourceHandle(handle: handle._concreteInputLazyTensor)
     }
 }
 

--- a/Sources/TensorFlow/Core/LazyTensorOperation.swift
+++ b/Sources/TensorFlow/Core/LazyTensorOperation.swift
@@ -272,74 +272,74 @@ class LazyTensorOperation: TensorOperation {
     }
 }
 
-protocol LazyTensorCompatible {
+protocol _LazyTensorCompatible {
     /// The underlying `LazyTensor` (if any).
-    var lazyTensor: LazyTensor? { get }
+    var _lazyTensor: LazyTensor? { get }
 
     /// Returns `Self` that wraps a concrete `LazyTensor`.
     /// (Triggers materialization if needed.)
-    var concreteLazyTensor: Self { get }
+    var _concreteLazyTensor: Self { get }
 
     /// Similar to the `concreteLazyTensor` with an additional constraint that
     /// the underlying concrete `LazyTensor` should be marked to be promoted as
     /// an input when used in an extracted trace.
-    var concreteInputLazyTensor: Self { get }
+    var _concreteInputLazyTensor: Self { get }
 }
 
 extension _AnyTensorHandle {
-    var lazyTensor: LazyTensor? {
+    var _lazyTensor: LazyTensor? {
         if let handle = self as? LazyTensor {
             return handle
         } else {
             return nil
         }
     }
-    var concreteLazyTensor: LazyTensor { LazyTensor(self._tfeTensorHandle) }
-    var concreteInputLazyTensor: LazyTensor { LazyTensor(_materialized: self._tfeTensorHandle) }
+    var _concreteLazyTensor: LazyTensor { LazyTensor(self._tfeTensorHandle) }
+    var _concreteInputLazyTensor: LazyTensor { LazyTensor(_materialized: self._tfeTensorHandle) }
 }
 
-extension TensorHandle: LazyTensorCompatible {
-    var lazyTensor: LazyTensor? { handle.lazyTensor }
-    public var concreteLazyTensor: TensorHandle { TensorHandle(handle: handle.concreteLazyTensor) }
-    public var concreteInputLazyTensor: TensorHandle {
-        TensorHandle(handle: handle.concreteInputLazyTensor)
+extension TensorHandle: _LazyTensorCompatible {
+    var _lazyTensor: LazyTensor? { handle._lazyTensor }
+    public var _concreteLazyTensor: TensorHandle { TensorHandle(handle: handle._concreteLazyTensor) }
+    public var _concreteInputLazyTensor: TensorHandle {
+        TensorHandle(handle: handle._concreteInputLazyTensor)
     }
 }
 
-extension Tensor: LazyTensorCompatible {
-    var lazyTensor: LazyTensor? { handle.lazyTensor }
-    public var concreteLazyTensor: Tensor { Tensor(handle: handle.concreteLazyTensor) }
-    public var concreteInputLazyTensor: Tensor { Tensor(handle: handle.concreteInputLazyTensor) }
+extension Tensor: _LazyTensorCompatible {
+    var _lazyTensor: LazyTensor? { handle._lazyTensor }
+    public var _concreteLazyTensor: Tensor { Tensor(handle: handle._concreteLazyTensor) }
+    public var _concreteInputLazyTensor: Tensor { Tensor(handle: handle._concreteInputLazyTensor) }
 }
 
-extension StringTensor: LazyTensorCompatible {
-    var lazyTensor: LazyTensor? { handle.lazyTensor }
-    public var concreteLazyTensor: StringTensor { StringTensor(handle: handle.concreteLazyTensor) }
-    public var concreteInputLazyTensor: StringTensor {
-        StringTensor(handle: handle.concreteInputLazyTensor)
+extension StringTensor: _LazyTensorCompatible {
+    var _lazyTensor: LazyTensor? { handle._lazyTensor }
+    public var _concreteLazyTensor: StringTensor { StringTensor(handle: handle._concreteLazyTensor) }
+    public var _concreteInputLazyTensor: StringTensor {
+        StringTensor(handle: handle._concreteInputLazyTensor)
     }
 }
 
-extension VariantHandle: LazyTensorCompatible {
-    var lazyTensor: LazyTensor? { handle.lazyTensor }
-    public var concreteLazyTensor: VariantHandle { VariantHandle(handle: handle.concreteLazyTensor) }
-    public var concreteInputLazyTensor: VariantHandle {
-        VariantHandle(handle: handle.concreteInputLazyTensor)
+extension VariantHandle: _LazyTensorCompatible {
+    var _lazyTensor: LazyTensor? { handle._lazyTensor }
+    public var _concreteLazyTensor: VariantHandle { VariantHandle(handle: handle._concreteLazyTensor) }
+    public var _concreteInputLazyTensor: VariantHandle {
+        VariantHandle(handle: handle._concreteInputLazyTensor)
     }
 }
 
-extension ResourceHandle: LazyTensorCompatible {
-    var lazyTensor: LazyTensor? { handle.lazyTensor }
+extension ResourceHandle: _LazyTensorCompatible {
+    var _lazyTensor: LazyTensor? { handle._lazyTensor }
 
     /// Wraps this variant handle in a concrete `LazyTensor`.
-    public var concreteLazyTensor: ResourceHandle {
-        ResourceHandle(handle: handle.concreteLazyTensor)
+    public var _concreteLazyTensor: ResourceHandle {
+        ResourceHandle(handle: handle._concreteLazyTensor)
     }
 
     /// Wraps this variant handle in a concrete `LazyTensor` that will
     /// be promoted to an input when used in a extracted trace.
-    public var concreteInputLazyTensor: ResourceHandle {
-        ResourceHandle(handle: handle.concreteInputLazyTensor)
+    public var _concreteInputLazyTensor: ResourceHandle {
+        ResourceHandle(handle: handle._concreteInputLazyTensor)
     }
 }
 

--- a/Tests/TensorFlowTests/LazyTensorTestHelper.swift
+++ b/Tests/TensorFlowTests/LazyTensorTestHelper.swift
@@ -1,0 +1,75 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import TensorFlow
+
+protocol _LazyTensorCompatible {
+    /// The underlying `LazyTensor` (if any).
+    var _lazyTensor: LazyTensor? { get }
+
+    /// Returns `Self` that wraps a concrete `LazyTensor`.
+    /// (Triggers materialization if needed.)
+    var _concreteLazyTensor: Self { get }
+
+    /// Similar to the `concreteLazyTensor` with an additional constraint that
+    /// the underlying concrete `LazyTensor` should be marked to be promoted as
+    /// an input when used in an extracted trace.
+    var _concreteInputLazyTensor: Self { get }
+}
+
+extension _AnyTensorHandle {
+    var _lazyTensor: LazyTensor? {
+        if let handle = self as? LazyTensor {
+            return handle
+        } else {
+            return nil
+        }
+    }
+    var _concreteLazyTensor: LazyTensor { LazyTensor(self._tfeTensorHandle) }
+}
+
+extension TensorHandle: _LazyTensorCompatible {
+    var _lazyTensor: LazyTensor? { handle._lazyTensor }
+    public var _concreteLazyTensor: TensorHandle {
+        TensorHandle(handle: handle._concreteLazyTensor)
+    }
+}
+
+extension Tensor: _LazyTensorCompatible {
+    var _lazyTensor: LazyTensor? { handle._lazyTensor }
+    public var _concreteLazyTensor: Tensor {
+        Tensor(handle: handle._concreteLazyTensor)
+    }
+}
+
+extension StringTensor: _LazyTensorCompatible {
+    var _lazyTensor: LazyTensor? { handle._lazyTensor }
+    public var _concreteLazyTensor: StringTensor {
+        StringTensor(handle: handle._concreteLazyTensor)
+    }
+}
+
+extension VariantHandle: _LazyTensorCompatible {
+    var _lazyTensor: LazyTensor? { handle._lazyTensor }
+    public var _concreteLazyTensor: VariantHandle {
+        VariantHandle(handle: handle._concreteLazyTensor)
+    }
+}
+
+extension ResourceHandle: _LazyTensorCompatible {
+    var _lazyTensor: LazyTensor? { handle._lazyTensor }
+    public var _concreteLazyTensor: ResourceHandle {
+        ResourceHandle(handle: handle._concreteLazyTensor)
+    }
+}

--- a/Tests/TensorFlowTests/LazyTensorTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTests.swift
@@ -105,13 +105,13 @@ final class LazyTensorTests: XCTestCase {
         XCTAssertTrue(isSymbolic(t0))
     }
 
-    private func checkConversions<T: LazyTensorCompatible>(_ x: T) {
-        let concreteLazyX = x.concreteLazyTensor
-        let concreteInputLazyX = x.concreteInputLazyTensor
-        XCTAssertFalse(isSymbolic(concreteLazyX.lazyTensor))
-        XCTAssertFalse(isSymbolic(concreteInputLazyX.lazyTensor))
-        XCTAssertFalse(isMaterializedConcrete(concreteLazyX.lazyTensor))
-        XCTAssertTrue(isMaterializedConcrete(concreteInputLazyX.lazyTensor))
+    private func checkConversions<T: _LazyTensorCompatible>(_ x: T) {
+        let concreteLazyX = x._concreteLazyTensor
+        let concreteInputLazyX = x._concreteInputLazyTensor
+        XCTAssertFalse(isSymbolic(concreteLazyX._lazyTensor))
+        XCTAssertFalse(isSymbolic(concreteInputLazyX._lazyTensor))
+        XCTAssertFalse(isMaterializedConcrete(concreteLazyX._lazyTensor))
+        XCTAssertTrue(isMaterializedConcrete(concreteInputLazyX._lazyTensor))
     }
 
     func testTensorToLazyTensorConversions() {

--- a/Tests/TensorFlowTests/LazyTensorTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTests.swift
@@ -75,13 +75,6 @@ final class LazyTensorTests: XCTestCase {
             XCTAssertEqual(expectedAllOps, actualAllOps)
         }
 
-        func isSymbolic(_ t: LazyTensor) -> Bool {
-            switch t.handle {
-            case .symbolic(_): return true
-            case .concrete(_): return false
-            }
-        }
-
         let op0 = LazyTensorOperation(
             _id: "0", name: "IdentityN", outputCount: 2)
         let op1 = LazyTensorOperation(
@@ -112,9 +105,54 @@ final class LazyTensorTests: XCTestCase {
         XCTAssertTrue(isSymbolic(t0))
     }
 
+    private func checkConversions<T: LazyTensorCompatible>(_ x: T) {
+        let concreteLazyX = x.concreteLazyTensor
+        let concreteInputLazyX = x.concreteInputLazyTensor
+        XCTAssertFalse(isSymbolic(concreteLazyX.lazyTensor))
+        XCTAssertFalse(isSymbolic(concreteInputLazyX.lazyTensor))
+        XCTAssertFalse(isMaterializedConcrete(concreteLazyX.lazyTensor))
+        XCTAssertTrue(isMaterializedConcrete(concreteInputLazyX.lazyTensor))
+    }
+
+    func testTensorToLazyTensorConversions() {
+        checkConversions(Tensor<Float>(10.0))
+        checkConversions(StringTensor("Hello!"))
+
+        // ResourceHandle and VariantHandle conversions.
+        let elements1: Tensor<Int32> = [0, 1, 2]
+        let elements2: Tensor<Int32> = [10, 11, 12]
+        let outputTypes = [Int32.tensorFlowDataType, Int32.tensorFlowDataType]
+        let outputShapes: [TensorShape?] = [nil, nil]
+        let dataset: VariantHandle = Raw.tensorSliceDataset(
+            components: [elements1, elements2],
+            outputShapes: outputShapes
+        )
+        let iterator: ResourceHandle = Raw.iteratorV2(sharedName: "blah",
+            container: "earth", outputTypes: outputTypes, outputShapes: outputShapes
+        )
+        checkConversions(dataset)
+        checkConversions(iterator)
+    }
+
+    private func isSymbolic(_ t: LazyTensor?) -> Bool {
+        guard let t = t else { return false }
+        switch t.handle {
+        case .symbolic(_): return true
+        case .concrete(_): return false
+        }
+    }
+
+    private func isMaterializedConcrete(_ t: LazyTensor?) -> Bool {
+        guard let t = t else { return false }
+        switch t.handle {
+        case .symbolic(_): return true
+        case .concrete(_, let isMaterialized): return isMaterialized
+        }
+    }
+
     static var allTests = [
         ("testConstructions", testConstructions),
         ("testLivenessTracking", testLivenessTracking),
+        ("testTensorToLazyTensorConversions", testTensorToLazyTensorConversions)
     ]
-
 }

--- a/Tests/TensorFlowTests/LazyTensorTraceTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTraceTests.swift
@@ -113,7 +113,7 @@ final class LazyTensorTraceTests: XCTestCase {
 
         // Since `lazyA` is not marked as an input, this will
         // be burnt into the trace as a constant.
-        let lazyA = a.concreteLazyTensor
+        let lazyA = a._concreteLazyTensor
         let w1 = lazyA * b
         let w1Trace = lazyTrace(w1)!
         XCTAssertEqual(w1Trace.description,
@@ -128,7 +128,7 @@ final class LazyTensorTraceTests: XCTestCase {
 
         // Since `lazyInputA` is marked as an input, this will
         // be promoted to an input for the trace.
-        let inputLazyA = a.concreteInputLazyTensor
+        let inputLazyA = a._concreteInputLazyTensor
         let w2 = inputLazyA * b
         let w2Trace = lazyTrace(w2)!
         XCTAssertEqual(w2Trace.description,

--- a/Tests/TensorFlowTests/LazyTensorTraceTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTraceTests.swift
@@ -107,15 +107,13 @@ final class LazyTensorTraceTests: XCTestCase {
             """)
     }
 
-    func testConstPromotion() {
+    func testManualConstPromotion() {
         let a = Tensor<Float>(10.0)
         let b = Tensor<Float>(2.0)
-        let concreteA = a.handle.handle._tfeTensorHandle
 
-        let lazyHandle = LazyTensor(concreteA)
-        let lazyA = Tensor(handle: TensorHandle<Float>(handle: lazyHandle))
-        // Since `lazyA` is not marked as a materialized concrete
-        // tensor, this will be burnt into the trace as a constant.
+        // Since `lazyA` is not marked as an input, this will
+        // be burnt into the trace as a constant.
+        let lazyA = a.lazyTensor
         let w1 = lazyA * b
         let w1Trace = lazyTrace(w1)!
         XCTAssertEqual(w1Trace.description,
@@ -127,12 +125,11 @@ final class LazyTensorTraceTests: XCTestCase {
             }
             """)
         XCTAssertEqual(w1Trace.inputValues.count, 0)
-        let materializedHandle = LazyTensor(_materialized: concreteA)
-        let materializedLazyA = Tensor(
-            handle: TensorHandle<Float>(handle: materializedHandle))
-        // Since `materializedLazyA` is marked as a materialized concrete
-        // tensor, this will be promoted to an input for the trace.
-        let w2 = materializedLazyA * b
+
+        // Since `lazyInputA` is marked as an input, this will
+        // be promoted to an input for the trace.
+        let inputLazyA = a.inputLazyTensor
+        let w2 = inputLazyA * b
         let w2Trace = lazyTrace(w2)!
         XCTAssertEqual(w2Trace.description,
             """
@@ -144,6 +141,40 @@ final class LazyTensorTraceTests: XCTestCase {
         // Make sure that the promoted constants are gathered as `inputValues`.
         XCTAssertEqual(w2Trace.inputValues.count, 1)
         XCTAssertEqual(w2Trace.inputValues[0].valueDescription, "10.0")
+    }
+
+    func testConstPromotion() {
+        let a = Tensor<Float>(1.0)
+        let b = Tensor<Float>(2.0)
+        let c = Tensor<Float>(3.0)
+        let y = a + b
+        let z = y * c
+
+        XCTAssertEqual(
+            lazyTrace(y)!.description,
+            """
+            lazyTrace_3() -> (%2) {
+              %0 = Const[dtype: float, value: 1.0]()
+              %1 = Const[dtype: float, value: 2.0]()
+              %2 = Add[T: float](%0, %1)
+            }
+            """)
+        XCTAssertEqual(y.scalarized(), 3.0)
+
+        /// Now that `y` is materialized and a constant,
+        /// the trace for `z` will use that as a constant.
+        let zTrace = lazyTrace(z)!
+        XCTAssertEqual(
+            zTrace.description,
+            """
+            lazyTrace_3(%0: float) -> (%2) {
+              %1 = Const[dtype: float, value: 3.0]()
+              %2 = Mul[T: float](%0, %1)
+            }
+            """)
+        // Make sure that the promoted constants are gathered as `inputValues`.
+        XCTAssertEqual(zTrace.inputValues.count, 1)
+        XCTAssertEqual(zTrace.inputValues[0].valueDescription, "3.0")
     }
 
     private func lazyTrace<T: TensorFlowScalar>(
@@ -165,6 +196,7 @@ final class LazyTensorTraceTests: XCTestCase {
         ("testSingleLiveTensor", testSingleLiveTensor),
         ("testMultipleLiveTensors", testMultipleLiveTensors),
         ("testSimpleControlFlow", testSimpleControlFlow),
+        ("testManualConstPromotion", testManualConstPromotion),
         ("testConstPromotion", testConstPromotion)
     ]
 }

--- a/Tests/TensorFlowTests/LazyTensorTraceTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTraceTests.swift
@@ -113,7 +113,7 @@ final class LazyTensorTraceTests: XCTestCase {
 
         // Since `lazyA` is not marked as an input, this will
         // be burnt into the trace as a constant.
-        let lazyA = a.lazyTensor
+        let lazyA = a.concreteLazyTensor
         let w1 = lazyA * b
         let w1Trace = lazyTrace(w1)!
         XCTAssertEqual(w1Trace.description,
@@ -128,7 +128,7 @@ final class LazyTensorTraceTests: XCTestCase {
 
         // Since `lazyInputA` is marked as an input, this will
         // be promoted to an input for the trace.
-        let inputLazyA = a.inputLazyTensor
+        let inputLazyA = a.concreteInputLazyTensor
         let w2 = inputLazyA * b
         let w2Trace = lazyTrace(w2)!
         XCTAssertEqual(w2Trace.description,
@@ -175,6 +175,7 @@ final class LazyTensorTraceTests: XCTestCase {
         // Make sure that the promoted constants are gathered as `inputValues`.
         XCTAssertEqual(zTrace.inputValues.count, 1)
         XCTAssertEqual(zTrace.inputValues[0].valueDescription, "3.0")
+        XCTAssertEqual(z.scalarized(), 9.0)
     }
 
     private func lazyTrace<T: TensorFlowScalar>(


### PR DESCRIPTION
Adds a `_concreteInputLazyTensor` property to the tensor-related types in the library. This provides **temporary** mechanism to promote constants to inputs manually in trace. Here is an example use case:
```
import TensorFlow

let a = Tensor<Float>(10.0)
let b = Tensor<Float>(5.0)
let w = a._concreteInputLazyTensor * b
print ("\(w)")
```

This will result in the following trace for `w`:
```
lazyTrace_3(%0: float) -> (%2) {
  %1 = Const[dtype: float, value: 5.0]()
  %2 = Mul[T: float](%0, %1)
} 
```
Note that the slot for `a` got promoted to an input. This is added to experiment with the lazy tensor implementation and is mostly intended to be used within the `TensorFlow` module.  If this turns out to be useful, we should provide a cleaner user-visible API.

This PR also adds a helper file for tests related to lazy tensor. 