### PR TITLE
Rename "pointwise" to "element-wise" for consistency.

### DIFF
--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -560,7 +560,7 @@ extension Tensor: PointwiseMultiplicative where Scalar: Numeric {
     @inlinable
     public static var one: Tensor { Tensor(1) }
 
-    /// Returns the pointwise reciprocal of `self`.
+    /// Returns the element-wise reciprocal of `self`.
     @inlinable
     public var reciprocal: Tensor { 1 / self }
 


### PR DESCRIPTION
No remaining usages of "pointwise".