### PR TITLE
Add precondition message for Tensor initialization

### DIFF
--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -272,7 +272,7 @@ public extension Tensor {
     init<C: RandomAccessCollection>(shape: TensorShape, scalars: C) where C.Element == Scalar {
         precondition(shape.contiguousSize == scalars.count,
             """
-            The product of the dimensions of the shape must equal the number of scalars: 
+            The product of the dimensions of the shape must equal the number of scalars: \
             \(shape.contiguousSize) vs. \(scalars.count)
             """)
         let handle = TensorHandle<Scalar>(

--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -251,7 +251,7 @@ public extension Tensor {
     init(shape: TensorShape, scalars: UnsafeBufferPointer<Scalar>) {
         precondition(shape.contiguousSize == scalars.count,
             """
-            The product of the dimensions of the shape must equal the number of scalars: 
+            The product of the dimensions of the shape must equal the number of scalars: \
             \(shape.contiguousSize) vs. \(scalars.count)
             """)
         let handle = TensorHandle<Scalar>(

--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -140,7 +140,8 @@ public extension Tensor {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpScalarized where Scalar: TensorFlowFloatingPoint)
     func scalarized() -> Scalar {
-        precondition(shape.contiguousSize == 1, "This tensor has more than one scalar.")
+        precondition(shape.contiguousSize == 1,
+           "This tensor must have exactly one scalar: \(shape.contiguousSize).")
         return reshaped(to: []).scalar!
     }
 }
@@ -227,11 +228,14 @@ public extension Tensor {
     /// - Parameters:
     ///   - shape: The shape of the tensor.
     ///   - scalars: The scalar contents of the tensor.
-    /// - Precondition: The number of scalars must equal the product of the dimensions of the shape.
+    /// - Precondition: The product of the dimensions of the shape must equal the number of scalars.
     @inlinable
     init(shape: TensorShape, scalars: [Scalar]) {
-        precondition(scalars.count == shape.contiguousSize,
-            "The number of scalars does not equal the product of dimensions given in the shape.")
+        precondition(shape.contiguousSize == scalars.count,
+            """
+            The product of the dimensions of the shape must equal the number of scalars: 
+            \(shape.contiguousSize) vs. \(scalars.count)
+            """)
         self = scalars.withUnsafeBufferPointer { bufferPointer in
 	        Tensor(shape: shape, scalars: bufferPointer)
 	    }
@@ -242,12 +246,14 @@ public extension Tensor {
     /// - Parameters:
     ///   - shape: The shape of the tensor.
     ///   - scalars: The scalar contents of the tensor.
-    /// - Precondition: The number of scalars must equal the product of the
-    ///   dimensions of the shape.
+    /// - Precondition: The product of the dimensions of the shape must equal the number of scalars.
     @inlinable
     init(shape: TensorShape, scalars: UnsafeBufferPointer<Scalar>) {
-        precondition(scalars.count == shape.contiguousSize,
-            "The number of scalars does not equal the product of dimensions given in the shape.")
+        precondition(shape.contiguousSize == scalars.count,
+            """
+            The product of the dimensions of the shape must equal the number of scalars: 
+            \(shape.contiguousSize) vs. \(scalars.count)
+            """)
         let handle = TensorHandle<Scalar>(
             shape: shape.dimensions,
             scalarsInitializer: { address in
@@ -261,12 +267,14 @@ public extension Tensor {
     /// - Parameters:
     ///   - shape: The shape of the tensor.
     ///   - scalars: The scalar contents of the tensor.
-    /// - Precondition: The number of scalars must equal the product of the
-    ///   dimensions of the shape.
+    /// - Precondition: The product of the dimensions of the shape must equal the number of scalars.
     @inlinable
     init<C: RandomAccessCollection>(shape: TensorShape, scalars: C) where C.Element == Scalar {
-        precondition(scalars.count == shape.contiguousSize,
-            "The number of scalars does not equal the product of dimensions given in the shape.")
+        precondition(shape.contiguousSize == scalars.count,
+            """
+            The product of the dimensions of the shape must equal the number of scalars: 
+            \(shape.contiguousSize) vs. \(scalars.count)
+            """)
         let handle = TensorHandle<Scalar>(
             shape: shape.dimensions,
             scalarsInitializer: { addr in

--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -233,7 +233,7 @@ public extension Tensor {
     init(shape: TensorShape, scalars: [Scalar]) {
         precondition(shape.contiguousSize == scalars.count,
             """
-            The product of the dimensions of the shape must equal the number of scalars: 
+            The product of the dimensions of the shape must equal the number of scalars: \
             \(shape.contiguousSize) vs. \(scalars.count)
             """)
         self = scalars.withUnsafeBufferPointer { bufferPointer in

--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -233,8 +233,8 @@ public extension Tensor {
     init(shape: TensorShape, scalars: [Scalar]) {
         precondition(shape.contiguousSize == scalars.count,
             """
-            The product of the dimensions of the shape must equal the number of scalars: \
-            \(shape.contiguousSize) vs. \(scalars.count)
+            The shape requires \(shape.contiguousSize) scalars but \(scalars.count) were \
+            provided.
             """)
         self = scalars.withUnsafeBufferPointer { bufferPointer in
 	        Tensor(shape: shape, scalars: bufferPointer)
@@ -251,8 +251,8 @@ public extension Tensor {
     init(shape: TensorShape, scalars: UnsafeBufferPointer<Scalar>) {
         precondition(shape.contiguousSize == scalars.count,
             """
-            The product of the dimensions of the shape must equal the number of scalars: \
-            \(shape.contiguousSize) vs. \(scalars.count)
+            The shape requires \(shape.contiguousSize) scalars but \(scalars.count) were \
+            provided.
             """)
         let handle = TensorHandle<Scalar>(
             shape: shape.dimensions,
@@ -272,8 +272,8 @@ public extension Tensor {
     init<C: RandomAccessCollection>(shape: TensorShape, scalars: C) where C.Element == Scalar {
         precondition(shape.contiguousSize == scalars.count,
             """
-            The product of the dimensions of the shape must equal the number of scalars: \
-            \(shape.contiguousSize) vs. \(scalars.count)
+            The shape requires \(shape.contiguousSize) scalars but \(scalars.count) were \
+            provided.
             """)
         let handle = TensorHandle<Scalar>(
             shape: shape.dimensions,

--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -141,7 +141,7 @@ public extension Tensor {
     @differentiable(wrt: self, vjp: _vjpScalarized where Scalar: TensorFlowFloatingPoint)
     func scalarized() -> Scalar {
         precondition(shape.contiguousSize == 1,
-           "This tensor must have exactly one scalar to be scalarized, but it has \(shape.contiguousSize) scalars.")
+           "This tensor must have exactly one scalar but contains \(shape.contiguousSize).")
         return reshaped(to: []).scalar!
     }
 }

--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -141,7 +141,7 @@ public extension Tensor {
     @differentiable(wrt: self, vjp: _vjpScalarized where Scalar: TensorFlowFloatingPoint)
     func scalarized() -> Scalar {
         precondition(shape.contiguousSize == 1,
-           "This tensor must have exactly one scalar: \(shape.contiguousSize).")
+           "This tensor must have exactly one scalar to be scalarized, but it has \(shape.contiguousSize) scalars.")
         return reshaped(to: []).scalar!
     }
 }

--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -140,6 +140,7 @@ public extension Tensor {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpScalarized where Scalar: TensorFlowFloatingPoint)
     func scalarized() -> Scalar {
+        precondition(shape.contiguousSize == 1, "This tensor has more than one scalar.")
         return reshaped(to: []).scalar!
     }
 }
@@ -229,6 +230,8 @@ public extension Tensor {
     /// - Precondition: The number of scalars must equal the product of the dimensions of the shape.
     @inlinable
     init(shape: TensorShape, scalars: [Scalar]) {
+        precondition(scalars.count == shape.contiguousSize,
+            "The number of scalars does not equal the product of dimensions given in the shape.")
         self = scalars.withUnsafeBufferPointer { bufferPointer in
 	        Tensor(shape: shape, scalars: bufferPointer)
 	    }
@@ -243,7 +246,8 @@ public extension Tensor {
     ///   dimensions of the shape.
     @inlinable
     init(shape: TensorShape, scalars: UnsafeBufferPointer<Scalar>) {
-        precondition(scalars.count == shape.contiguousSize)
+        precondition(scalars.count == shape.contiguousSize,
+            "The number of scalars does not equal the product of dimensions given in the shape.")
         let handle = TensorHandle<Scalar>(
             shape: shape.dimensions,
             scalarsInitializer: { address in
@@ -261,7 +265,8 @@ public extension Tensor {
     ///   dimensions of the shape.
     @inlinable
     init<C: RandomAccessCollection>(shape: TensorShape, scalars: C) where C.Element == Scalar {
-        precondition(scalars.count == shape.contiguousSize)
+        precondition(scalars.count == shape.contiguousSize,
+            "The number of scalars does not equal the product of dimensions given in the shape.")
         let handle = TensorHandle<Scalar>(
             shape: shape.dimensions,
             scalarsInitializer: { addr in


### PR DESCRIPTION
Adds precondition messages for failing tensor initializer, `init(shape:scalars:)`, and failing scalarized, `scalarized()`.