### PR TITLE
added orthogonal initializer

### DIFF
--- a/Sources/TensorFlow/Initializers.swift
+++ b/Sources/TensorFlow/Initializers.swift
@@ -576,8 +576,8 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
         let columnCount = shape[shape.rank - 1]
         let flatShape: TensorShape = rowCount < columnCount ? [columnCount, rowCount] : [rowCount, columnCount]
         let normal = Tensor(randomNormal: flatShape, seed: seed)
-        var (q, r) = normal.qr(fullMatrices: false)
-        let d = r.diagPart()
+        var (q, r) = normal.qrDecomposition(fullMatrices: false)
+        let d = r.diagonalPart()
         q *= sign(d)
         if rowCount < columnCount {
             q = q.transposed()

--- a/Sources/TensorFlow/Initializers.swift
+++ b/Sources/TensorFlow/Initializers.swift
@@ -550,6 +550,21 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
 }
 
 public extension Tensor where Scalar: TensorFlowFloatingPoint {
+    /// Initializer that generates an orthogonal matrix or tensor. 
+    ///
+    /// If the shape of the tensor to initialize is two-dimensional, it is initialized with an 
+    /// orthogonal matrix obtained from the QR decomposition of a matrix of random numbers drawn 
+    /// from a normal distribution. If the matrix has fewer rows than columns then the output will 
+    /// have orthogonal rows. Otherwise, the output will have orthogonal columns.
+    /// 
+    /// If the shape of the tensor to initialize is more than two-dimensional, a matrix of shape 
+    /// (shape[0] * ... * shape[n - 2], shape[n - 1]) is initialized, where n is the length of the 
+    /// shape vector. The matrix is subsequently reshaped to give a tensor of the desired shape.
+    ///
+    /// - Parameters:
+    ///   - shape: The dimensions of the tensor.
+    ///   - gain: A multiplicative factor to apply to the orthogonal tensor.
+    ///
     init(
         orthogonal shape: TensorShape,
         gain: Scalar = 1,
@@ -562,7 +577,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
         let normal = Tensor(randomNormal: flatShape, seed: seed)
         var (q, r) = Raw.qr(normal, fullMatrices: false)
         let d = Raw.diagPart(r)
-        q *= Raw.sign(d)
+        q *= sign(d)
         if rowCount < columnCount {
             q = q.transposed()
         } 

--- a/Sources/TensorFlow/Initializers.swift
+++ b/Sources/TensorFlow/Initializers.swift
@@ -552,8 +552,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     init(
         orthogonal shape: TensorShape,
         gain: Scalar = 1,
-        seed: (Int32, Int32) = (Int32.random(in: Int32.min..<Int32.max),
-                                Int32.random(in: Int32.min..<Int32.max))
+        seed: (Int32, Int32) = randomSeedForTensorFlow()
     ) {
         let rowCount = shape.dimensions.dropLast().reduce(1, *)
         let columnCount = shape[shape.rank - 1]

--- a/Sources/TensorFlow/Initializers.swift
+++ b/Sources/TensorFlow/Initializers.swift
@@ -564,6 +564,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     /// - Parameters:
     ///   - shape: The dimensions of the tensor.
     ///   - gain: A multiplicative factor to apply to the orthogonal tensor.
+    ///   - seed: A tuple of two integers to seed the random number generator.
     ///
     init(
         orthogonal shape: TensorShape,
@@ -571,7 +572,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
         seed: (Int32, Int32) = (Int32.random(in: Int32.min..<Int32.max),
                                 Int32.random(in: Int32.min..<Int32.max))
     ) {
-        let rowCount = shape[0 ..< shape.rank - 1].dimensions.reduce(1, *)
+        let rowCount = shape[0..<(shape.rank - 1)].dimensions.reduce(1, *)
         let columnCount = shape[shape.rank - 1]
         let flatShape: TensorShape = rowCount < columnCount ? [columnCount, rowCount] : [rowCount, columnCount]
         let normal = Tensor(randomNormal: flatShape, seed: seed)

--- a/Sources/TensorFlow/Initializers.swift
+++ b/Sources/TensorFlow/Initializers.swift
@@ -550,7 +550,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
 }
 
 public extension Tensor where Scalar: TensorFlowFloatingPoint {
-    /// Initializer that generates an orthogonal matrix or tensor. 
+    /// Creates an orthogonal matrix or tensor. 
     ///
     /// If the shape of the tensor to initialize is two-dimensional, it is initialized with an 
     /// orthogonal matrix obtained from the QR decomposition of a matrix of random numbers drawn 
@@ -558,11 +558,11 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     /// have orthogonal rows. Otherwise, the output will have orthogonal columns.
     /// 
     /// If the shape of the tensor to initialize is more than two-dimensional, a matrix of shape 
-    /// (shape[0] * ... * shape[n - 2], shape[n - 1]) is initialized, where n is the length of the 
-    /// shape vector. The matrix is subsequently reshaped to give a tensor of the desired shape.
+    /// `[shape[0] * ... * shape[rank - 2], shape[rank - 1]]` is initialized.  The matrix is 
+    /// subsequently reshaped to give a tensor of the desired shape.
     ///
     /// - Parameters:
-    ///   - shape: The dimensions of the tensor.
+    ///   - shape: The shape of the tensor.
     ///   - gain: A multiplicative factor to apply to the orthogonal tensor.
     ///   - seed: A tuple of two integers to seed the random number generator.
     ///
@@ -572,9 +572,14 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
         seed: (Int32, Int32) = (Int32.random(in: Int32.min..<Int32.max),
                                 Int32.random(in: Int32.min..<Int32.max))
     ) {
-        let rowCount = shape[0..<(shape.rank - 1)].dimensions.reduce(1, *)
+        let rowCount = shape.dimensions.dropLast().reduce(1, *)
         let columnCount = shape[shape.rank - 1]
-        let flatShape: TensorShape = rowCount < columnCount ? [columnCount, rowCount] : [rowCount, columnCount]
+        var flatShape: TensorShape 
+        if rowCount < columnCount {
+            flatShape = [columnCount, rowCount]
+        } else {
+            flatShape = [rowCount, columnCount]
+        }
         let normal = Tensor(randomNormal: flatShape, seed: seed)
         var (q, r) = normal.qrDecomposition(fullMatrices: false)
         let d = r.diagonalPart()

--- a/Sources/TensorFlow/Initializers.swift
+++ b/Sources/TensorFlow/Initializers.swift
@@ -575,8 +575,8 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
         let columnCount = shape[shape.rank - 1]
         let flatShape: TensorShape = rowCount < columnCount ? [columnCount, rowCount] : [rowCount, columnCount]
         let normal = Tensor(randomNormal: flatShape, seed: seed)
-        var (q, r) = Raw.qr(normal, fullMatrices: false)
-        let d = Raw.diagPart(r)
+        var (q, r) = normal.qr(fullMatrices: false)
+        let d = r.diagPart()
         q *= sign(d)
         if rowCount < columnCount {
             q = q.transposed()

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -2155,36 +2155,6 @@ internal func _vjpMatmul<Scalar: TensorFlowFloatingPoint>(
     })
 }
 
-public extension Tensor where Scalar: TensorFlowFloatingPoint {
-    /// Computes the QR decomposition of each inner matrix in `tensor` such that
-    /// `tensor[..., :, :] = q[..., :, :] * r[..., :,:])`
-    /// 
-    /// - Parameters:
-    ///   - fullMatrices: If true, compute full-sized `q` and `r`. If false
-    ///     (the default), compute only the leading `P` columns of `q`.
-    ///  
-    func qr(fullMatrices: Bool = false) -> (Tensor<Scalar>, Tensor<Scalar>) {
-        return Raw.qr(self, fullMatrices: fullMatrices)
-    }
-
-    /// Returns the diagonal part of the tensor.
-    ///
-    /// For example:
-    ///
-    /// ```
-    /// # 't' is [[1, 0, 0, 0]
-    ///           [0, 2, 0, 0]
-    ///           [0, 0, 3, 0]
-    ///           [0, 0, 0, 4]]
-    ///
-    /// t.diagPart() ==> [1, 2, 3, 4]
-    /// ```
-    ///
-    func diagPart() -> Tensor<Scalar> {
-        return Raw.diagPart(self)
-    }
-}
-
 infix operator •: MultiplicationPrecedence
 
 public extension Tensor where Scalar: Numeric {
@@ -2211,3 +2181,34 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
         _vjpMatmul(lhs, rhs)
     }
 }
+
+public extension Tensor where Scalar: TensorFlowFloatingPoint {
+    /// Computes the QR decomposition of each inner matrix in `tensor` such that
+    /// `tensor[..., :, :] = q[..., :, :] * r[..., :,:])`
+    /// 
+    /// - Parameters:
+    ///   - fullMatrices: If true, compute full-sized `q` and `r`. If false
+    ///     (the default), compute only the leading `P` columns of `q`.
+    ///  
+    func qrDecomposition(fullMatrices: Bool = false) -> (q: Tensor<Scalar>, r: Tensor<Scalar>) {
+        return Raw.qr(self, fullMatrices: fullMatrices)
+    }
+
+    /// Returns the diagonal part of the tensor.
+    ///
+    /// For example:
+    ///
+    /// ```
+    /// # 't' is [[1, 0, 0, 0]
+    ///           [0, 2, 0, 0]
+    ///           [0, 0, 3, 0]
+    ///           [0, 0, 0, 4]]
+    ///
+    /// t.diagPart() ==> [1, 2, 3, 4]
+    /// ```
+    ///
+    func diagonalPart() -> Tensor<Scalar> {
+        return Raw.diagPart(self)
+    }
+}
+

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -2158,6 +2158,36 @@ internal func _vjpMatmul<Scalar: TensorFlowFloatingPoint>(
     })
 }
 
+public extension Tensor where Scalar: FloatingPoint & TensorFlowScalar {
+    /// Computes the QR decomposition of each inner matrix in `tensor` such that
+    /// `tensor[..., :, :] = q[..., :, :] * r[..., :,:])`
+    /// 
+    /// - Parameters:
+    ///   - fullMatrices: If true, compute full-sized `q` and `r`. If false
+    ///     (the default), compute only the leading `P` columns of `q`.
+    ///  
+    func qr(fullMatrices: Bool = false) -> (Tensor<Scalar>, Tensor<Scalar>) {
+        return Raw.qr(self, fullMatrices: fullMatrices)
+    }
+
+    /// Returns the diagonal part of the tensor.
+    ///
+    /// For example:
+    ///
+    /// ```
+    /// # 't' is [[1, 0, 0, 0]
+    ///           [0, 2, 0, 0]
+    ///           [0, 0, 3, 0]
+    ///           [0, 0, 0, 4]]
+    ///
+    /// t.diagPart() ==> [1, 2, 3, 4]
+    /// ```
+    ///
+    func diagPart() -> Tensor<Scalar> {
+        return Raw.diagPart(self)
+    }
+}
+
 infix operator •: MultiplicationPrecedence
 
 public extension Tensor where Scalar: Numeric {

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -2183,8 +2183,9 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
 }
 
 public extension Tensor where Scalar: TensorFlowFloatingPoint {
-    /// Computes the QR decomposition of each inner matrix in `tensor` such that
-    /// `tensor[..., :, :] = q[..., :, :] * r[..., :,:])`
+    /// Returns the QR decomposition of each inner matrix in the tensor, a tensor with inner 
+    /// orthogonal matrices q and a tensor with inner upper triangular matrices r, such that the 
+    /// tensor is equal to matmul(q, r).
     /// 
     /// - Parameters:
     ///   - fullMatrices: If true, compute full-sized `q` and `r`. If false
@@ -2199,12 +2200,11 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     /// For example:
     ///
     /// ```
-    /// # 't' is [[1, 0, 0, 0]
-    ///           [0, 2, 0, 0]
-    ///           [0, 0, 3, 0]
-    ///           [0, 0, 0, 4]]
-    ///
-    /// t.diagPart() ==> [1, 2, 3, 4]
+    /// // 't' is [[1, 0, 0, 0]
+    /// //         [0, 2, 0, 0]
+    /// //         [0, 0, 3, 0]
+    /// //         [0, 0, 0, 4]]
+    /// // t.diagPart() ==> [1, 2, 3, 4]
     /// ```
     ///
     func diagonalPart() -> Tensor<Scalar> {

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -2184,12 +2184,12 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
 
 public extension Tensor where Scalar: TensorFlowFloatingPoint {
     /// Returns the QR decomposition of each inner matrix in the tensor, a tensor with inner 
-    /// orthogonal matrices q and a tensor with inner upper triangular matrices r, such that the 
-    /// tensor is equal to matmul(q, r).
+    /// orthogonal matrices `q` and a tensor with inner upper triangular matrices `r`, such that the 
+    /// tensor is equal to `matmul(q, r)`.
     /// 
     /// - Parameters:
-    ///   - fullMatrices: If true, compute full-sized `q` and `r`. If false
-    ///     (the default), compute only the leading `P` columns of `q`.
+    ///   - fullMatrices: If `true`, compute full-sized `q` and `r`. Otherwise compute only the 
+    ///     leading `min(shape[rank - 1], shape[rank - 2])` columns of `q`.
     ///  
     func qrDecomposition(fullMatrices: Bool = false) -> (q: Tensor<Scalar>, r: Tensor<Scalar>) {
         return Raw.qr(self, fullMatrices: fullMatrices)
@@ -2204,8 +2204,8 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     /// //         [0, 2, 0, 0]
     /// //         [0, 0, 3, 0]
     /// //         [0, 0, 0, 4]]
-    /// // t.diagPart() ==> [1, 2, 3, 4]
-    /// ```
+    /// t.diagonalPart()
+    /// // [1, 2, 3, 4]
     ///
     func diagonalPart() -> Tensor<Scalar> {
         return Raw.diagPart(self)

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -2158,7 +2158,7 @@ internal func _vjpMatmul<Scalar: TensorFlowFloatingPoint>(
     })
 }
 
-public extension Tensor where Scalar: FloatingPoint & TensorFlowScalar {
+public extension Tensor where Scalar: TensorFlowFloatingPoint {
     /// Computes the QR decomposition of each inner matrix in `tensor` such that
     /// `tensor[..., :, :] = q[..., :, :] * r[..., :,:])`
     /// 

--- a/Tests/TensorFlowTests/InitializerTests.swift
+++ b/Tests/TensorFlowTests/InitializerTests.swift
@@ -78,7 +78,7 @@ final class InitializerTests: XCTestCase {
             XCTAssertEqual(shape, t.shape.dimensions)
         
             // Check orthogonality by computing the inner product
-            t = t.reshaped(to: [t.shape.dimensions[0 ..< t.rank-1].reduce(1, *), t.shape[t.rank - 1]])
+            t = t.reshaped(to: [t.shape.dimensions[0..<(t.rank - 1)].reduce(1, *), t.shape[t.rank - 1]])
             if t.shape[0] > t.shape[1] {
                 let eye = Raw.diag(diagonal: Tensor<Float>(ones: [t.shape[1]]))
                 assertEqual(eye, matmul(t.transposed(), t), accuracy: 1e-5)

--- a/Tests/TensorFlowTests/InitializerTests.swift
+++ b/Tests/TensorFlowTests/InitializerTests.swift
@@ -72,13 +72,13 @@ final class InitializerTests: XCTestCase {
     }
 
     func testOrthogonalShapesValues() {
-        for shape in [[10, 10], [10, 9, 8], [100, 5, 5], [50, 40], [3, 3, 32, 64]]{
-            // Check the shape
+        for shape in [[10, 10], [10, 9, 8], [100, 5, 5], [50, 40], [3, 3, 32, 64]] {
+            // Check the shape.
             var t = Tensor<Float>(orthogonal: TensorShape(shape))
             XCTAssertEqual(shape, t.shape.dimensions)
         
-            // Check orthogonality by computing the inner product
-            t = t.reshaped(to: [t.shape.dimensions[0..<(t.rank - 1)].reduce(1, *), t.shape[t.rank - 1]])
+            // Check orthogonality by computing the inner product.
+            t = t.reshaped(to: [t.shape.dimensions.dropLast().reduce(1, *), t.shape[t.rank - 1]])
             if t.shape[0] > t.shape[1] {
                 let eye = Raw.diag(diagonal: Tensor<Float>(ones: [t.shape[1]]))
                 assertEqual(eye, matmul(t.transposed(), t), accuracy: 1e-5)

--- a/Tests/TensorFlowTests/InitializerTests.swift
+++ b/Tests/TensorFlowTests/InitializerTests.swift
@@ -81,10 +81,10 @@ final class InitializerTests: XCTestCase {
             t = t.reshaped(to: [t.shape.dimensions[0 ..< t.rank-1].reduce(1, *), t.shape[t.rank - 1]])
             if t.shape[0] > t.shape[1] {
                 let eye = Raw.diag(diagonal: Tensor<Float>(ones: [t.shape[1]]))
-                XCTAssertEqual(eye, round(matmul(t.transposed(), t)))
+                assertEqual(eye, matmul(t.transposed(), t), accuracy: 1e-5)
             } else {
                 let eye = Raw.diag(diagonal: Tensor<Float>(ones: [t.shape[0]]))
-                XCTAssertEqual(eye, round(matmul(t, t.transposed())))
+                assertEqual(eye, matmul(t, t.transposed()), accuracy: 1e-5)
             }
         }
     }

--- a/Tests/TensorFlowTests/InitializerTests.swift
+++ b/Tests/TensorFlowTests/InitializerTests.swift
@@ -71,6 +71,24 @@ final class InitializerTests: XCTestCase {
         XCTAssertEqual(ShapedArray(shape: [2, 2], scalars: [1, 0, 1, 0]), i8s.array)
     }
 
+    func testOrthogonalShapesValues() {
+        for shape in [[10, 10], [10, 9, 8], [100, 5, 5], [50, 40], [3, 3, 32, 64]]{
+            // Check the shape
+            var t = Tensor<Float>(orthogonal: TensorShape(shape))
+            XCTAssertEqual(shape, t.shape.dimensions)
+        
+            // Check orthogonality by computing the inner product
+            t = t.reshaped(to: [t.shape.dimensions[0 ..< t.rank-1].reduce(1, *), t.shape[t.rank - 1]])
+            if t.shape[0] > t.shape[1] {
+                let eye = Raw.diag(diagonal: Tensor<Float>(ones: [t.shape[1]]))
+                XCTAssertEqual(eye, round(matmul(t.transposed(), t)))
+            } else {
+                let eye = Raw.diag(diagonal: Tensor<Float>(ones: [t.shape[0]]))
+                XCTAssertEqual(eye, round(matmul(t, t.transposed())))
+            }
+        }
+    }
+
     static var allTests = [
         ("testInitializers", testInitializers),
         ("testFactoryInitializers", testFactoryInitializers),
@@ -78,6 +96,7 @@ final class InitializerTests: XCTestCase {
         ("testScalarToTensorConversion", testScalarToTensorConversion),
         ("testArrayConversion", testArrayConversion),
         ("testDataTypeCast", testDataTypeCast),
-        ("testBoolToNumericCast", testBoolToNumericCast)
+        ("testBoolToNumericCast", testBoolToNumericCast),
+        ("testOrthogonalShapesValues", testOrthogonalShapesValues)
     ]
 }

--- a/Tests/TensorFlowTests/OperatorTests/MathTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/MathTests.swift
@@ -437,6 +437,7 @@ final class MathOperatorTests: XCTestCase {
         ("testXORInference", testXORInference),
         ("testMLPClassifierStruct", testMLPClassifierStruct),
         ("testQRApproximation", testQRApproximation),
+        ("testDiagPart", testDiagPart),
         ("testBroadcastedAddGradient", testBroadcastedAddGradient)
     ]
 }

--- a/Tests/TensorFlowTests/OperatorTests/MathTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/MathTests.swift
@@ -368,16 +368,15 @@ final class MathOperatorTests: XCTestCase {
             let aReconstitutedFull = matmul(qFull, rFull)
             assertEqual(a, aReconstitutedFull, accuracy: 1e-5)
         }
-        
     }
 
     func testDiagonalPart() {
-        //test on 2D matrix
+        // Test on 2-D matrix.
         let t1 = Tensor<Float>(shape: [4, 4], scalars: (1...16).map(Float.init))
         let target1 = Tensor<Float>([1, 6, 11, 16])
         XCTAssertEqual(target1, t1.diagonalPart())
 
-        //test on 4D tensor
+        // Test on 4-D tensor.
         let t2 = Tensor<Float>([[[[1.0, 0.0, 0.0, 0.0],
                                   [0.0, 0.0, 0.0, 0.0]],
                                  [[0.0, 2.0, 0.0, 0.0],

--- a/Tests/TensorFlowTests/OperatorTests/MathTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/MathTests.swift
@@ -356,6 +356,48 @@ final class MathOperatorTests: XCTestCase {
         XCTAssertEqual(Double(prediction.scalars[0]), 0.816997, accuracy: 0.0001)
     }
 
+    func testQRApproximation() {
+        let shapes = [[5, 8], [3, 4, 4], [3, 3, 32, 64]]
+        for shape in shapes {
+            let a = Tensor<Float>(randomNormal: TensorShape(shape))
+            let (q, r) = a.qr()
+            let aReconstituted = matmul(q,r)
+            assertEqual(a, aReconstituted, accuracy: 1e-5)
+
+            let (qFull, rFull) = a.qr(fullMatrices: true)
+            let aReconstitutedFull = matmul(qFull, rFull)
+            assertEqual(a, aReconstitutedFull, accuracy: 1e-5)
+        }
+        
+    }
+
+    func testDiagPart() {
+        //test on 2D matrix
+        let t1 = Tensor<Float>(shape: [4, 4], scalars: (1...16).map(Float.init))
+        let target1 = Tensor<Float>([1, 6, 11, 16])
+        XCTAssertEqual(target1, t1.diagPart())
+
+        //test on 4D tensor
+        let t2 = Tensor<Float>([[[[1.0, 0.0, 0.0, 0.0],
+                                  [0.0, 0.0, 0.0, 0.0]],
+                                 [[0.0, 2.0, 0.0, 0.0],
+                                  [0.0, 0.0, 0.0, 0.0]],
+                                 [[0.0, 0.0, 3.0, 0.0],
+                                  [0.0, 0.0, 0.0, 0.0]],
+                                 [[0.0, 0.0, 0.0, 4.0],
+                                  [0.0, 0.0, 0.0, 0.0]]],
+                                [[[0.0, 0.0, 0.0, 0.0],
+                                  [5.0, 0.0, 0.0, 0.0]],
+                                 [[0.0, 0.0, 0.0, 0.0],
+                                  [0.0, 6.0, 0.0, 0.0]],
+                                 [[0.0, 0.0, 0.0, 0.0],
+                                  [0.0, 0.0, 7.0, 0.0]],
+                                 [[0.0, 0.0, 0.0, 0.0],
+                                  [0.0, 0.0, 0.0, 8.0]]]])
+        let target2 = Tensor<Float>([[1, 2, 3, 4], [5, 6, 7, 8]])
+        XCTAssertEqual(target2, t2.diagPart())
+    }
+
     func testBroadcastedAddGradient() {
         func foo(_ x: Tensor<Float>, _ y: Tensor<Float>) -> Tensor<Float> {
             return (x + y).sum()
@@ -394,6 +436,7 @@ final class MathOperatorTests: XCTestCase {
         ("testXWPlusB", testXWPlusB),
         ("testXORInference", testXORInference),
         ("testMLPClassifierStruct", testMLPClassifierStruct),
+        ("testQRApproximation", testQRApproximation),
         ("testBroadcastedAddGradient", testBroadcastedAddGradient)
     ]
 }

--- a/Tests/TensorFlowTests/OperatorTests/MathTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/MathTests.swift
@@ -356,26 +356,26 @@ final class MathOperatorTests: XCTestCase {
         XCTAssertEqual(Double(prediction.scalars[0]), 0.816997, accuracy: 0.0001)
     }
 
-    func testQRApproximation() {
+    func testQRDecompositionApproximation() {
         let shapes = [[5, 8], [3, 4, 4], [3, 3, 32, 64]]
         for shape in shapes {
             let a = Tensor<Float>(randomNormal: TensorShape(shape))
-            let (q, r) = a.qr()
+            let (q, r) = a.qrDecomposition()
             let aReconstituted = matmul(q,r)
             assertEqual(a, aReconstituted, accuracy: 1e-5)
 
-            let (qFull, rFull) = a.qr(fullMatrices: true)
+            let (qFull, rFull) = a.qrDecomposition(fullMatrices: true)
             let aReconstitutedFull = matmul(qFull, rFull)
             assertEqual(a, aReconstitutedFull, accuracy: 1e-5)
         }
         
     }
 
-    func testDiagPart() {
+    func testDiagonalPart() {
         //test on 2D matrix
         let t1 = Tensor<Float>(shape: [4, 4], scalars: (1...16).map(Float.init))
         let target1 = Tensor<Float>([1, 6, 11, 16])
-        XCTAssertEqual(target1, t1.diagPart())
+        XCTAssertEqual(target1, t1.diagonalPart())
 
         //test on 4D tensor
         let t2 = Tensor<Float>([[[[1.0, 0.0, 0.0, 0.0],
@@ -395,7 +395,7 @@ final class MathOperatorTests: XCTestCase {
                                  [[0.0, 0.0, 0.0, 0.0],
                                   [0.0, 0.0, 0.0, 8.0]]]])
         let target2 = Tensor<Float>([[1, 2, 3, 4], [5, 6, 7, 8]])
-        XCTAssertEqual(target2, t2.diagPart())
+        XCTAssertEqual(target2, t2.diagonalPart())
     }
 
     func testBroadcastedAddGradient() {
@@ -436,8 +436,8 @@ final class MathOperatorTests: XCTestCase {
         ("testXWPlusB", testXWPlusB),
         ("testXORInference", testXORInference),
         ("testMLPClassifierStruct", testMLPClassifierStruct),
-        ("testQRApproximation", testQRApproximation),
-        ("testDiagPart", testDiagPart),
+        ("testQRDecompositionApproximation", testQRDecompositionApproximation),
+        ("testDiagonalPart", testDiagonalPart),
         ("testBroadcastedAddGradient", testBroadcastedAddGradient)
     ]
 }


### PR DESCRIPTION
Added an orthogonal initialiser like the one in [TensorFlow python](https://github.com/tensorflow/tensorflow/blob/r1.14/tensorflow/python/ops/init_ops.py#L548).

Is there a swift test similar to `assert_allclose` to use for equality with tolerance for small differences?