### PR TITLE
Update documentation in vanilla Conv layers

### DIFF
--- a/Sources/TensorFlow/Layers/Convolutional.swift
+++ b/Sources/TensorFlow/Layers/Convolutional.swift
@@ -68,10 +68,11 @@ public struct Conv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// (input width + 2 * padding size - (dilation * (filter width - 1) + 1)) / stride + 1
     ///
     /// and padding size is determined by the padding scheme.
-    /// - Note: Padding size equals zero when using `.valid`.
     ///
     /// - Parameter input: The input to the layer [batch count, input width, input channel count].
     /// - Returns: The output of shape [batch count, output width, output channel count].
+    ///
+    /// - Note: Padding size equals zero when using `.valid`.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         let conv = conv2D(
@@ -216,12 +217,13 @@ public struct Conv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// / stride width + 1
     ///
     /// and padding sizes are determined by the padding scheme.
-    /// - Note: Padding size equals zero when using `.valid`.
     ///
     /// - Parameter input: The input to the layer of shape
     ///   [batch count, input height, input width, input channel count].
     /// - Returns: The output of shape
     ///   [batch count, output height, output width, output channel count].
+    ///
+    /// - Note: Padding size equals zero when using `.valid`.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return activation(conv2D(
@@ -368,12 +370,13 @@ public struct Conv3D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// / stride width + 1
     ///
     /// and padding sizes are determined by the padding scheme.
-    /// - Note: Padding size equals zero when using `.valid`.
     ///
     /// - Parameter input: The input to the layer of shape
     ///   [batch count, input depth, input height, input width, input channel count].
     /// - Returns: The output of shape
     ///   [batch count, output depth, output height, output width, output channel count].
+    ///
+    /// - Note: Padding size equals zero when using `.valid`.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return activation(conv3D(

--- a/Sources/TensorFlow/Layers/Convolutional.swift
+++ b/Sources/TensorFlow/Layers/Convolutional.swift
@@ -18,9 +18,9 @@
 /// tensor of outputs.
 @frozen
 public struct Conv1D<Scalar: TensorFlowFloatingPoint>: Layer {
-    /// The 3-D convolution kernel `[width, inputChannels, outputChannels]`.
+    /// The 3-D convolution filter.
     public var filter: Tensor<Scalar>
-    /// The bias vector `[outputChannels]`.
+    /// The bias vector.
     public var bias: Tensor<Scalar>
     /// An activation function.
     public typealias Activation = @differentiable (Tensor<Scalar>) -> Tensor<Scalar>
@@ -37,8 +37,9 @@ public struct Conv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// dilation and padding.
     ///
     /// - Parameters:
-    ///   - filter: The 3-D convolution kernel `[width, inputChannels, outputChannels]`.
-    ///   - bias: The bias vector `[outputChannels]`.
+    ///   - filter: The 3-D convolution filter of shape
+    ///     `[filter width, input channel count, output channel count]`.
+    ///   - bias: The bias vector of shape `[output channel count]`.
     ///   - activation: The element-wise activation function.
     ///   - stride: The stride of the sliding window for the temporal dimension.
     ///   - padding: The padding algorithm for convolution.
@@ -61,8 +62,8 @@ public struct Conv1D<Scalar: TensorFlowFloatingPoint>: Layer {
 
     /// Returns the output obtained from applying the layer to the given input.
     ///
-    /// - Parameter input: The input to the layer `[batchCount, width, inputChannels]`.
-    /// - Returns: The output `[batchCount, newWidth, outputChannels]`.
+    /// - Parameter input: The input to the layer `[batch count, width, input channel count]`.
+    /// - Returns: The output `[batch count, new width, output channel count]`.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         let conv = conv2D(
@@ -82,7 +83,7 @@ public extension Conv1D where Scalar.RawSignificand: FixedWidthInteger {
     ///
     /// - Parameters:
     ///   - filterShape: The 3-D shape of the filter, representing
-    ///     `[width, inputChannels, outputChannels]`.
+    ///     `[filter width, input channel count, output channel count]`.
     ///   - stride: The stride of the sliding window for the temporal dimension.
     ///   - padding: The padding algorithm for convolution.
     ///   - dilation: The dilation factor for the temporal dimension.
@@ -118,7 +119,7 @@ public extension Conv1D {
     ///
     /// - Parameters:
     ///   - filterShape: The 3-D shape of the filter, representing
-    ///     `[width, inputChannels, outputChannels]`.
+    ///     `[filter width, input channel count, output channel count]`.
     ///   - stride: The stride of the sliding window for the temporal dimension.
     ///   - padding: The padding algorithm for convolution.
     ///   - dilation: The dilation factor for the temporal dimension.
@@ -150,7 +151,7 @@ public extension Conv1D {
 /// tensor of outputs.
 @frozen
 public struct Conv2D<Scalar: TensorFlowFloatingPoint>: Layer {
-    /// The 4-D convolution kernel.
+    /// The 4-D convolution filter.
     public var filter: Tensor<Scalar>
     /// The bias vector.
     public var bias: Tensor<Scalar>
@@ -169,8 +170,9 @@ public struct Conv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// dilations and padding.
     ///
     /// - Parameters:
-    ///   - filter: The 4-D convolution kernel.
-    ///   - bias: The bias vector.
+    ///   - filter: The 4-D convolution filter of shape
+    ///     `[filter height, filter width, input channel count, output channel count]`.
+    ///   - bias: The bias vector of shape `[output channel count]`.
     ///   - activation: The element-wise activation function.
     ///   - strides: The strides of the sliding window for spatial dimensions.
     ///   - padding: The padding algorithm for convolution.
@@ -212,7 +214,8 @@ public extension Conv2D {
     /// initialization with the specified generator. The bias vector is initialized with zeros.
     ///
     /// - Parameters:
-    ///   - filterShape: The shape of the 4-D convolution kernel.
+    ///   - filterShape: The shape of the 4-D convolution filter, representing
+    ///     `[filter height, filter width, input channel count, output channel count]`.
     ///   - strides: The strides of the sliding window for spatial dimensions.
     ///   - padding: The padding algorithm for convolution.
     ///   - dilations: The dilation factor for spatial dimensions.
@@ -247,7 +250,8 @@ public extension Conv2D {
     /// initialization with the specified seed. The bias vector is initialized with zeros.
     ///
     /// - Parameters:
-    ///   - filterShape: The shape of the 4-D convolution kernel.
+    ///   - filterShape: The shape of the 4-D convolution filter, representing
+    ///     `[filter height, filter width, input channel count, output channel count]`.
     ///   - strides: The strides of the sliding window for spatial dimensions.
     ///   - padding: The padding algorithm for convolution.
     ///   - dilations: The dilation factor for spatial dimensions.
@@ -279,7 +283,7 @@ public extension Conv2D {
 /// tensor of outputs.
 @frozen
 public struct Conv3D<Scalar: TensorFlowFloatingPoint>: Layer {
-    /// The 5-D convolution kernel.
+    /// The 5-D convolution filter.
     public var filter: Tensor<Scalar>
     /// The bias vector.
     public var bias: Tensor<Scalar>
@@ -296,8 +300,10 @@ public struct Conv3D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// padding.
     ///
     /// - Parameters:
-    ///   - filter: The 5-D convolution kernel.
-    ///   - bias: The bias vector.
+    ///   - filter: The 5-D convolution filter of shape
+    ///    `[filter depth, filter height, filter width, input channel count,
+    ///     output channel count]`.
+    ///   - bias: The bias vector of shape `[output channel count]`.
     ///   - activation: The element-wise activation function.
     ///   - strides: The strides of the sliding window for spatial dimensions.
     ///   - padding: The padding algorithm for convolution.
@@ -335,7 +341,9 @@ public extension Conv3D {
     /// initialization with the specified generator. The bias vector is initialized with zeros.
     ///
     /// - Parameters:
-    ///   - filterShape: The shape of the 5-D convolution kernel.
+    ///   - filterShape: The shape of the 5-D convolution filter, representing
+    ///    `[filter depth, filter height, filter width, input channel count,
+    ///     output channel count]`. 
     ///   - strides: The strides of the sliding window for spatial/spatio-temporal dimensions.
     ///   - padding: The padding algorithm for convolution.
     ///   - activation: The element-wise activation function.
@@ -367,7 +375,9 @@ public extension Conv3D {
     /// initialization with the specified seed. The bias vector is initialized with zeros.
     ///
     /// - Parameters:
-    ///   - filterShape: The shape of the 5-D convolution kernel.
+    ///   - filterShape: The shape of the 5-D convolution filter, representing
+    ///    `[filter depth, filter height, filter width, input channel count,
+    ///     output channel count]`.
     ///   - strides: The strides of the sliding window for spatial/spatio-temporal dimensions.
     ///   - padding: The padding algorithm for convolution.
     ///   - activation: The element-wise activation function.

--- a/Sources/TensorFlow/Layers/Convolutional.swift
+++ b/Sources/TensorFlow/Layers/Convolutional.swift
@@ -67,7 +67,7 @@ public struct Conv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   where output width is computed as:
     ///
     ///   output width =
-    ///   [(input width + 2 * padding size - (dilation * (filter width - 1) + 1)) / stride] + 1
+    ///   (input width + 2 * padding size - (dilation * (filter width - 1) + 1)) / stride + 1
     ///
     ///   and padding size is determined by the padding scheme. Note that padding size equals zero
     ///   when using .valid.
@@ -211,15 +211,15 @@ public struct Conv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   where the output spatial dimensions are computed as:
     ///
     ///   output height =
-    ///   [(input height + 2 * padding height - (dilation height * (filter height - 1) + 1))
-    ///   / stride height] + 1
+    ///   (input height + 2 * padding height - (dilation height * (filter height - 1) + 1))
+    ///   / stride height + 1
     ///
     ///   output width =
-    ///   [(input width + 2 * padding width - (dilation width * (filter width - 1) + 1))
-    ///   / stride width] + 1
+    ///   (input width + 2 * padding width - (dilation width * (filter width - 1) + 1))
+    ///   / stride width + 1
     ///
     ///   and padding sizes are determined by the padding scheme. Note padding sizes equal zero
-    ///   when using .valid.
+    ///   when using `.valid`.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return activation(conv2D(
@@ -358,16 +358,16 @@ public struct Conv3D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   where the spatial dimensions are computed as:
     ///
     ///   output depth =
-    ///   [(input depth + 2 * padding depth - (dilation depth * (filter depth - 1) + 1))
-    ///   / stride depth] + 1
+    ///   (input depth + 2 * padding depth - (dilation depth * (filter depth - 1) + 1))
+    ///   / stride depth + 1
     ///
     ///   output height =
-    ///   [(input height + 2 * padding height - (dilation height * (filter height - 1) + 1))
-    ///   / stride height] + 1
+    ///   (input height + 2 * padding height - (dilation height * (filter height - 1) + 1))
+    ///   / stride height + 1
     ///
     ///   output width =
-    ///   [(input width + 2 * padding width - (dilation width * (filter width - 1) + 1))
-    ///   / stride width] + 1
+    ///   (input width + 2 * padding width - (dilation width * (filter width - 1) + 1))
+    ///   / stride width + 1
     ///
     ///   and padding sizes are determined by the padding scheme. Note that padding sizes equal zero
     ///   when using .valid.

--- a/Sources/TensorFlow/Layers/Convolutional.swift
+++ b/Sources/TensorFlow/Layers/Convolutional.swift
@@ -390,7 +390,7 @@ public extension Conv3D {
     ///   - filterShape: The shape of the 5-D convolution filter, representing
     ///     (filter depth, filter height, filter width, input channel count,
     ///     output channel count).
-    ///   - strides: The strides of the sliding window for spatial dimensions of shape
+    ///   - strides: The strides of the sliding window for spatial dimensions, i.e.
     ///     (stride depth, stride height, stride width)
     ///   - padding: The padding algorithm for convolution.
     ///   - activation: The element-wise activation function.
@@ -425,7 +425,7 @@ public extension Conv3D {
     ///   - filterShape: The shape of the 5-D convolution filter, representing
     ///     (filter depth, filter height, filter width, input channel count,
     ///     output channel count).
-    ///   - strides: The strides of the sliding window for spatial dimensions of shape
+    ///   - strides: The strides of the sliding window for spatial dimensions, i.e.
     ///     (stride depth, stride height, stride width)
     ///   - padding: The padding algorithm for convolution.
     ///   - activation: The element-wise activation function.

--- a/Sources/TensorFlow/Layers/Convolutional.swift
+++ b/Sources/TensorFlow/Layers/Convolutional.swift
@@ -62,15 +62,16 @@ public struct Conv1D<Scalar: TensorFlowFloatingPoint>: Layer {
 
     /// Returns the output obtained from applying the layer to the given input.
     ///
+    /// The output width is computed as:
+    ///
+    /// output width =
+    /// (input width + 2 * padding size - (dilation * (filter width - 1) + 1)) / stride + 1
+    ///
+    /// and padding size is determined by the padding scheme.
+    /// - Note: Padding size equals zero when using `.valid`.
+    ///
     /// - Parameter input: The input to the layer [batch count, input width, input channel count].
-    /// - Returns: The output of shape [batch count, output width, output channel count],
-    ///   where output width is computed as:
-    ///
-    ///   output width =
-    ///   (input width + 2 * padding size - (dilation * (filter width - 1) + 1)) / stride + 1
-    ///
-    ///   and padding size is determined by the padding scheme. Note that padding size equals zero
-    ///   when using `.valid`.
+    /// - Returns: The output of shape [batch count, output width, output channel count].
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         let conv = conv2D(
@@ -204,22 +205,23 @@ public struct Conv2D<Scalar: TensorFlowFloatingPoint>: Layer {
 
     /// Returns the output obtained from applying the layer to the given input.
     ///
+    /// The output spatial dimensions are computed as:
+    ///
+    /// output height =
+    /// (input height + 2 * padding height - (dilation height * (filter height - 1) + 1))
+    /// / stride height + 1
+    ///
+    /// output width =
+    /// (input width + 2 * padding width - (dilation width * (filter width - 1) + 1))
+    /// / stride width + 1
+    ///
+    /// and padding sizes are determined by the padding scheme.
+    /// - Note: Padding size equals zero when using `.valid`.
+    ///
     /// - Parameter input: The input to the layer of shape
     ///   [batch count, input height, input width, input channel count].
     /// - Returns: The output of shape
-    ///   [batch count, output height, output width, output channel count],
-    ///   where the output spatial dimensions are computed as:
-    ///
-    ///   output height =
-    ///   (input height + 2 * padding height - (dilation height * (filter height - 1) + 1))
-    ///   / stride height + 1
-    ///
-    ///   output width =
-    ///   (input width + 2 * padding width - (dilation width * (filter width - 1) + 1))
-    ///   / stride width + 1
-    ///
-    ///   and padding sizes are determined by the padding scheme. Note padding sizes equal zero
-    ///   when using `.valid`.
+    ///   [batch count, output height, output width, output channel count].
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return activation(conv2D(
@@ -351,26 +353,27 @@ public struct Conv3D<Scalar: TensorFlowFloatingPoint>: Layer {
 
     /// Returns the output obtained from applying the layer to the given input.
     ///
+    /// The output spatial dimensions are computed as:
+    ///
+    /// output depth =
+    /// (input depth + 2 * padding depth - (dilation depth * (filter depth - 1) + 1))
+    /// / stride depth + 1
+    ///
+    /// output height =
+    /// (input height + 2 * padding height - (dilation height * (filter height - 1) + 1))
+    /// / stride height + 1
+    ///
+    /// output width =
+    /// (input width + 2 * padding width - (dilation width * (filter width - 1) + 1))
+    /// / stride width + 1
+    ///
+    /// and padding sizes are determined by the padding scheme.
+    /// - Note: Padding size equals zero when using `.valid`.
+    ///
     /// - Parameter input: The input to the layer of shape
-    ///   [batch count, input depth, input height, input width, input channel count]
+    ///   [batch count, input depth, input height, input width, input channel count].
     /// - Returns: The output of shape
-    ///   [batch count, output depth, output height, output width, output channel count]
-    ///   where the spatial dimensions are computed as:
-    ///
-    ///   output depth =
-    ///   (input depth + 2 * padding depth - (dilation depth * (filter depth - 1) + 1))
-    ///   / stride depth + 1
-    ///
-    ///   output height =
-    ///   (input height + 2 * padding height - (dilation height * (filter height - 1) + 1))
-    ///   / stride height + 1
-    ///
-    ///   output width =
-    ///   (input width + 2 * padding width - (dilation width * (filter width - 1) + 1))
-    ///   / stride width + 1
-    ///
-    ///   and padding sizes are determined by the padding scheme. Note that padding sizes equal zero
-    ///   when using `.valid`.
+    ///   [batch count, output depth, output height, output width, output channel count].
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return activation(conv3D(

--- a/Sources/TensorFlow/Layers/Convolutional.swift
+++ b/Sources/TensorFlow/Layers/Convolutional.swift
@@ -70,7 +70,7 @@ public struct Conv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   (input width + 2 * padding size - (dilation * (filter width - 1) + 1)) / stride + 1
     ///
     ///   and padding size is determined by the padding scheme. Note that padding size equals zero
-    ///   when using .valid.
+    ///   when using `.valid`.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         let conv = conv2D(
@@ -370,7 +370,7 @@ public struct Conv3D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   / stride width + 1
     ///
     ///   and padding sizes are determined by the padding scheme. Note that padding sizes equal zero
-    ///   when using .valid.
+    ///   when using `.valid`.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         return activation(conv3D(


### PR DESCRIPTION
While attempting to build a model with Conv layers, I continually forgot the filterShape argument representation. Hopefully adding the below documentation will be helpful to others.