### PR TITLE
Enhanced the 'Dense' layer to support batch matrix multiplication.

### DIFF
--- a/Sources/TensorFlow/Layers/Core.swift
+++ b/Sources/TensorFlow/Layers/Core.swift
@@ -139,10 +139,10 @@ public struct Reshape<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
 /// a weight matrix, `bias` is a bias vector, and `activation` is an element-wise activation
 /// function.
 ///
-/// This layer also supports 3-dimensional weight tensors with 2-dimensional bias matrices. In this 
-/// case the first dimension of both is treated as the batch size that is aligned with the first 
-/// dimension of `input` and the batch variant of the `matmul` operation is used, thus using a 
-/// different weight and bias for each element in input batch.
+/// This layer also supports 3-D weight tensors with 2-D bias matrices. In this case the first
+/// dimension of both is treated as the batch size that is aligned with the first dimension of
+/// `input` and the batch variant of the `matmul(_:_:)` operation is used, thus using a different
+/// weight and bias for each element in input batch.
 @frozen
 public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
     /// The weight matrix.
@@ -171,7 +171,7 @@ public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        if weight.rank == 3 {
+        if weight.rankTensor == Tensor<Int>(3) {
             let hidden = matmul(input.expandingShape(at: 1), weight)
             return activation(hidden.squeezingShape(at: 1) + bias)
         }

--- a/Sources/TensorFlow/Layers/Core.swift
+++ b/Sources/TensorFlow/Layers/Core.swift
@@ -151,6 +151,8 @@ public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
     public var bias: Tensor<Scalar>
     /// The element-wise activation function.
     @noDerivative public let activation: Activation
+    /// Indicates whether this is a batched dense layer.
+    @noDerivative internal let batched: Bool
     
     /// The element-wise activation function type.
     public typealias Activation = @differentiable (Tensor<Scalar>) -> Tensor<Scalar>
@@ -163,6 +165,7 @@ public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
         self.weight = weight
         self.bias = bias
         self.activation = activation
+        self.batched = weight.rank == 3
     }
 
     /// Returns the output obtained from applying the layer to the given input.
@@ -171,7 +174,7 @@ public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        if weight.rankTensor == Tensor<Int>(3) {
+        if batched {
             let hidden = matmul(input.expandingShape(at: 1), weight)
             return activation(hidden.squeezingShape(at: 1) + bias)
         }

--- a/Sources/TensorFlow/Layers/Core.swift
+++ b/Sources/TensorFlow/Layers/Core.swift
@@ -162,6 +162,8 @@ public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
         bias: Tensor<Scalar>,
         activation: @escaping Activation
     ) {
+        precondition(weight.rank <= 3, "The rank of the 'weight' tensor must be less than 4.")
+        precondition(bias.rank <= 2, "The rank of the 'bias' tensor must be less than 3.")
         self.weight = weight
         self.bias = bias
         self.activation = activation


### PR DESCRIPTION
This enhances the `Dense` layer to be more aligned with the `matmul` operation. More specifically, it allows it to use the batch variant of `matmul` if the rank of `weight` is equal to `3`. Not sure if we want to merge this here but I use it often in my work and it also aligns `Dense` with the functionality of `matmul`.