### PR TITLE
Added support for composing layers.

### DIFF
--- a/Sources/TensorFlow/Layers/Core.swift
+++ b/Sources/TensorFlow/Layers/Core.swift
@@ -12,44 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-precedencegroup FunctionCompositionPrecedence {
-    associativity: left
-    higherThan: MultiplicationPrecedence
-    lowerThan: BitwiseShiftPrecedence
-}
-
-infix operator >>> : FunctionCompositionPrecedence
-
-public struct ComposedLayer<Layer1: Layer, Layer2: Layer>: Layer
-    where Layer1.Output == Layer2.Input,
-          Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar {
-    public var layer1: Layer1
-    public var layer2: Layer2
-
-    public init(_ layer1: Layer1, _ layer2: Layer2) {
-        self.layer1 = layer1
-        self.layer2 = layer2
-    }
-
-    @differentiable
-    public func callAsFunction(_ input: Layer1.Input) -> Layer2.Output {
-        layer2(layer1(input))
-    }
-}
-
-public extension Layer {
-    /// Composes two layers to form a chain.
-    ///
-    /// The composition combinator composes two layers sequentially, feeding the output of the
-    /// first layer as input to the second layer.
-    static func >>> <OtherLayer>(
-        _ lhs: Self,
-        _ rhs: OtherLayer
-    ) -> ComposedLayer<Self, OtherLayer> {
-        ComposedLayer(lhs, rhs)
-    }
-}
-
 public extension Tensor where Scalar: TensorFlowFloatingPoint {
     /// Computes dropout given a probability.
     @differentiable(wrt: self where Scalar: Differentiable)

--- a/Sources/TensorFlow/Layers/Core.swift
+++ b/Sources/TensorFlow/Layers/Core.swift
@@ -46,7 +46,7 @@ public extension Layer {
         _ lhs: Self,
         _ rhs: OtherLayer
     ) -> ComposedLayer<Self, OtherLayer> {
-        return ComposedLayer(lhs, rhs)
+        ComposedLayer(lhs, rhs)
     }
 }
 

--- a/Sources/TensorFlow/Layers/Core.swift
+++ b/Sources/TensorFlow/Layers/Core.swift
@@ -204,13 +204,6 @@ public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-<<<<<<< Updated upstream
-=======
-        if weight.rankTensor == Tensor<Int32>(3) {
-            let hidden = matmul(input.expandingShape(at: 1), weight)
-            return activation(hidden.squeezingShape(at: 1) + bias)
-        }
->>>>>>> Stashed changes
         return activation(matmul(input, weight) + bias)
     }
 }

--- a/Sources/TensorFlow/Layers/Core.swift
+++ b/Sources/TensorFlow/Layers/Core.swift
@@ -12,6 +12,44 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+precedencegroup FunctionCompositionPrecedence {
+    associativity: left
+    higherThan: MultiplicationPrecedence
+    lowerThan: BitwiseShiftPrecedence
+}
+
+infix operator >>> : FunctionCompositionPrecedence
+
+public struct ComposedLayer<Layer1: Layer, Layer2: Layer>: Layer
+    where Layer1.Output == Layer2.Input,
+          Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar {
+    public var layer1: Layer1
+    public var layer2: Layer2
+
+    public init(_ layer1: Layer1, _ layer2: Layer2) {
+        self.layer1 = layer1
+        self.layer2 = layer2
+    }
+
+    @differentiable
+    public func callAsFunction(_ input: Layer1.Input) -> Layer2.Output {
+        layer2(layer1(input))
+    }
+}
+
+public extension Layer {
+    /// Composes two layers to form a chain.
+    ///
+    /// The composition combinator composes two layers sequentially, feeding the output of the
+    /// first layer as input to the second layer.
+    static func >>> <OtherLayer>(
+        _ lhs: Self,
+        _ rhs: OtherLayer
+    ) -> ComposedLayer<Self, OtherLayer> {
+        return ComposedLayer(lhs, rhs)
+    }
+}
+
 public extension Tensor where Scalar: TensorFlowFloatingPoint {
     /// Computes dropout given a probability.
     @differentiable(wrt: self where Scalar: Differentiable)
@@ -166,6 +204,13 @@ public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
+<<<<<<< Updated upstream
+=======
+        if weight.rankTensor == Tensor<Int32>(3) {
+            let hidden = matmul(input.expandingShape(at: 1), weight)
+            return activation(hidden.squeezingShape(at: 1) + bias)
+        }
+>>>>>>> Stashed changes
         return activation(matmul(input, weight) + bias)
     }
 }

--- a/Sources/TensorFlow/Layers/Sequential.swift
+++ b/Sources/TensorFlow/Layers/Sequential.swift
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 /// A layer that sequentially composes two other layers.
-public struct Sequential<Layer1: Layer, Layer2: Layer>: Layer where
-    Layer1.Output == Layer2.Input,
-    Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar {
+public struct Sequential<Layer1: Layer, Layer2: Layer>: Layer
+    where Layer1.Output == Layer2.Input,
+          Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar {
     public var layer1: Layer1
     public var layer2: Layer2
 

--- a/Sources/TensorFlow/Layers/Sequential.swift
+++ b/Sources/TensorFlow/Layers/Sequential.swift
@@ -1,0 +1,240 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A layer that sequentially composes two other layers.
+public struct Sequential<Layer1: Layer, Layer2: Layer>: Layer where
+    Layer1.Output == Layer2.Input,
+    Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar {
+    public var layer1: Layer1
+    public var layer2: Layer2
+
+    public init(_ layer1: Layer1, _ layer2: Layer2) {
+        self.layer1 = layer1
+        self.layer2 = layer2
+    }
+
+    @differentiable
+    public func callAsFunction(_ input: Layer1.Input) -> Layer2.Output {
+        layer2(layer1(input))
+    }
+
+    public init(@LayerBuilder layers: () -> Self) {
+        self = layers()
+    }
+}
+
+@_functionBuilder
+public struct LayerBuilder {
+    public static func buildBlock<L1: Layer, L2: Layer>(_ l1: L1, _ l2: L2) -> Sequential<L1, L2>
+        where L1.Output == L2.Input {
+        Sequential(l1, l2)
+    }
+
+    public static func buildBlock<
+        L1: Layer,
+        L2: Layer,
+        L3: Layer
+    >(_ l1: L1, _ l2: L2, _ l3: L3)
+        -> Sequential<L1, Sequential<L2, L3>> where
+        L1.Output == L2.Input,
+        L2.Output == L3.Input,
+        L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
+        L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar
+    {
+        Sequential(l1, Sequential(l2, l3))
+    }
+
+    public static func buildBlock<
+        L1: Layer,
+        L2: Layer,
+        L3: Layer,
+        L4: Layer
+    >(_ l1: L1, _ l2: L2, _ l3: L3, _ l4: L4)
+        -> Sequential<L1, Sequential<L2, Sequential<L3, L4>>> where
+        L1.Output == L2.Input,
+        L2.Output == L3.Input,
+        L3.Output == L4.Input,
+        L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
+        L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
+        L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar
+    {
+        Sequential(l1, Sequential(l2, Sequential(l3, l4)))
+    }
+
+    public static func buildBlock<
+        L1: Layer,
+        L2: Layer,
+        L3: Layer,
+        L4: Layer,
+        L5: Layer
+    >(_ l1: L1, _ l2: L2, _ l3: L3, _ l4: L4, _ l5: L5)
+        -> Sequential<L1, Sequential<L2, Sequential<L3, Sequential<L4, L5>>>> where
+        L1.Output == L2.Input,
+        L2.Output == L3.Input,
+        L3.Output == L4.Input,
+        L4.Output == L5.Input,
+        L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
+        L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
+        L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
+        L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar
+    {
+        Sequential(l1, Sequential(l2, Sequential(l3, Sequential(l4, l5))))
+    }
+
+    public static func buildBlock<
+        L1: Layer,
+        L2: Layer,
+        L3: Layer,
+        L4: Layer,
+        L5: Layer,
+        L6: Layer
+    >(_ l1: L1, _ l2: L2, _ l3: L3, _ l4: L4, _ l5: L5, _ l6: L6)
+        -> Sequential<L1, Sequential<L2, Sequential<L3, Sequential<L4, Sequential<L5, L6>>>>> where
+        L1.Output == L2.Input,
+        L2.Output == L3.Input,
+        L3.Output == L4.Input,
+        L4.Output == L5.Input,
+        L5.Output == L6.Input,
+        L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
+        L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
+        L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
+        L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
+        L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar
+    {
+        Sequential(l1, Sequential(l2, Sequential(l3, Sequential(l4, Sequential(l5, l6)))))
+    }
+
+    public static func buildBlock<
+        L1: Layer,
+        L2: Layer,
+        L3: Layer,
+        L4: Layer,
+        L5: Layer,
+        L6: Layer,
+        L7: Layer
+    >(_ l1: L1, _ l2: L2, _ l3: L3, _ l4: L4, _ l5: L5, _ l6: L6, _ l7: L7)
+        -> Sequential<L1, Sequential<L2, Sequential<L3, Sequential<L4, Sequential<L5, Sequential<L6, L7>>>>>> where
+        L1.Output == L2.Input,
+        L2.Output == L3.Input,
+        L3.Output == L4.Input,
+        L4.Output == L5.Input,
+        L5.Output == L6.Input,
+        L6.Output == L7.Input,
+        L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
+        L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
+        L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
+        L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
+        L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
+        L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar
+    {
+        Sequential(l1, Sequential(l2, Sequential(l3, Sequential(l4, Sequential(l5, Sequential(l6, l7))))))
+    }
+
+    public static func buildBlock<
+        L1: Layer,
+        L2: Layer,
+        L3: Layer,
+        L4: Layer,
+        L5: Layer,
+        L6: Layer,
+        L7: Layer,
+        L8: Layer
+    >(_ l1: L1, _ l2: L2, _ l3: L3, _ l4: L4, _ l5: L5, _ l6: L6, _ l7: L7, _ l8: L8)
+        -> Sequential<L1, Sequential<L2, Sequential<L3, Sequential<L4, Sequential<L5, Sequential<L6, Sequential<L7, L8>>>>>>> where
+        L1.Output == L2.Input,
+        L2.Output == L3.Input,
+        L3.Output == L4.Input,
+        L4.Output == L5.Input,
+        L5.Output == L6.Input,
+        L6.Output == L7.Input,
+        L7.Output == L8.Input,
+        L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
+        L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
+        L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
+        L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
+        L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
+        L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar,
+        L7.TangentVector.VectorSpaceScalar == L8.TangentVector.VectorSpaceScalar
+    {
+        Sequential(l1, Sequential(l2, Sequential(l3, Sequential(l4, Sequential(l5, Sequential(l6, Sequential(l7, l8)))))))
+    }
+
+    public static func buildBlock<
+        L1: Layer,
+        L2: Layer,
+        L3: Layer,
+        L4: Layer,
+        L5: Layer,
+        L6: Layer,
+        L7: Layer,
+        L8: Layer,
+        L9: Layer
+    >(_ l1: L1, _ l2: L2, _ l3: L3, _ l4: L4, _ l5: L5, _ l6: L6, _ l7: L7, _ l8: L8, _ l9: L9)
+        -> Sequential<L1, Sequential<L2, Sequential<L3, Sequential<L4, Sequential<L5, Sequential<L6, Sequential<L7, Sequential<L8, L9>>>>>>>> where
+        L1.Output == L2.Input,
+        L2.Output == L3.Input,
+        L3.Output == L4.Input,
+        L4.Output == L5.Input,
+        L5.Output == L6.Input,
+        L6.Output == L7.Input,
+        L7.Output == L8.Input,
+        L8.Output == L9.Input,
+        L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
+        L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
+        L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
+        L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
+        L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
+        L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar,
+        L7.TangentVector.VectorSpaceScalar == L8.TangentVector.VectorSpaceScalar,
+        L8.TangentVector.VectorSpaceScalar == L9.TangentVector.VectorSpaceScalar
+    {
+        Sequential(l1, Sequential(l2, Sequential(l3, Sequential(l4, Sequential(l5, Sequential(l6, Sequential(l7, Sequential(l8, l9))))))))
+    }
+
+    public static func buildBlock<
+        L1: Layer,
+        L2: Layer,
+        L3: Layer,
+        L4: Layer,
+        L5: Layer,
+        L6: Layer,
+        L7: Layer,
+        L8: Layer,
+        L9: Layer,
+        L10: Layer
+    >(_ l1: L1, _ l2: L2, _ l3: L3, _ l4: L4, _ l5: L5, _ l6: L6, _ l7: L7, _ l8: L8, _ l9: L9, _ l10: L10)
+        -> Sequential<L1, Sequential<L2, Sequential<L3, Sequential<L4, Sequential<L5, Sequential<L6, Sequential<L7, Sequential<L8, Sequential<L9, L10>>>>>>>>> where
+        L1.Output == L2.Input,
+        L2.Output == L3.Input,
+        L3.Output == L4.Input,
+        L4.Output == L5.Input,
+        L5.Output == L6.Input,
+        L6.Output == L7.Input,
+        L7.Output == L8.Input,
+        L8.Output == L9.Input,
+        L9.Output == L10.Input,
+        L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
+        L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
+        L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
+        L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
+        L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
+        L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar,
+        L7.TangentVector.VectorSpaceScalar == L8.TangentVector.VectorSpaceScalar,
+        L8.TangentVector.VectorSpaceScalar == L9.TangentVector.VectorSpaceScalar,
+        L9.TangentVector.VectorSpaceScalar == L10.TangentVector.VectorSpaceScalar
+    {
+        Sequential(l1, Sequential(l2, Sequential(l3, Sequential(l4, Sequential(l5, Sequential(l6, Sequential(l7, Sequential(l8, Sequential(l9, l10)))))))))
+    }
+
+}

--- a/Sources/TensorFlow/Layers/Sequential.swift.gyb
+++ b/Sources/TensorFlow/Layers/Sequential.swift.gyb
@@ -1,0 +1,59 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A layer that sequentially composes two other layers.
+public struct Sequential<Layer1: Layer, Layer2: Layer>: Layer where
+    Layer1.Output == Layer2.Input,
+    Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar {
+    public var layer1: Layer1
+    public var layer2: Layer2
+
+    public init(_ layer1: Layer1, _ layer2: Layer2) {
+        self.layer1 = layer1
+        self.layer2 = layer2
+    }
+
+    @differentiable
+    public func callAsFunction(_ input: Layer1.Input) -> Layer2.Output {
+        layer2(layer1(input))
+    }
+
+    public init(@LayerBuilder layers: () -> Self) {
+        self = layers()
+    }
+}
+
+@_functionBuilder
+public struct LayerBuilder {
+    public static func buildBlock<L1: Layer, L2: Layer>(_ l1: L1, _ l2: L2) -> Sequential<L1, L2>
+        where L1.Output == L2.Input {
+        Sequential(l1, l2)
+    }
+
+    %for n in range(3, 11):
+    public static func buildBlock<
+        ${",\n        ".join(["L{}: Layer".format(i) for i in range(1, n+1)])}
+    >(${", ".join(["_ l{}: L{}".format(i, i) for i in range(1, n+1)])})
+        -> ${"".join(["Sequential<L{}, ".format(i) for i in range(1, n)])}L${n}${"".join([">" for i in range(1, n)])} where
+        ${",\n        ".join(["L{}.Output == L{}.Input".format(i, i+1)
+                          for i in range(1, n)])},
+        ${",\n        ".join(["L{}.TangentVector.VectorSpaceScalar == ".format(i) +
+                          "L{}.TangentVector.VectorSpaceScalar".format(i+1)
+                          for i in range(1, n)])}
+    {
+        ${"".join(["Sequential(l{}, ".format(i) for i in range(1, n)])}l${n}${"".join([")" for _ in range(1, n)])}
+    }
+
+    %end
+}

--- a/Sources/TensorFlow/Layers/Sequential.swift.gyb
+++ b/Sources/TensorFlow/Layers/Sequential.swift.gyb
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 /// A layer that sequentially composes two other layers.
-public struct Sequential<Layer1: Layer, Layer2: Layer>: Layer where
-    Layer1.Output == Layer2.Input,
-    Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar {
+public struct Sequential<Layer1: Layer, Layer2: Layer>: Layer
+    where Layer1.Output == Layer2.Input,
+          Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar {
     public var layer1: Layer1
     public var layer2: Layer2
 

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -16,12 +16,15 @@ import XCTest
 @testable import TensorFlow
 
 final class LayerTests: XCTestCase {
-    func testComposed() {
+    func testSequential() {
         let inputSize = 2
         let hiddenSize = 4
-        let dense1 = Dense<Float>(inputSize: inputSize, outputSize: hiddenSize, activation: relu)
-        let dense2 = Dense<Float>(inputSize: hiddenSize, outputSize: 1, activation: relu)
-        var model = dense1 >>> dense2
+        // let dense1 = Dense<Float>(inputSize: inputSize, outputSize: hiddenSize, activation: relu)
+        // let dense2 = Dense<Float>(inputSize: hiddenSize, outputSize: 1, activation: relu)
+        var model = Sequential {
+            Dense<Float>(inputSize: inputSize, outputSize: hiddenSize, activation: relu)
+            Dense<Float>(inputSize: hiddenSize, outputSize: 1, activation: relu)
+        }
         let optimizer = SGD(for: model, learningRate: 0.02)
         let x = Tensor<Float>([[0, 0], [0, 1], [1, 0], [1, 1]])
         let y = Tensor<Float>([0, 1, 1, 0])
@@ -370,7 +373,7 @@ final class LayerTests: XCTestCase {
     }
 
     static var allTests = [
-        ("testComposed", testComposed),
+        ("testSequential", testSequential),
         ("testConv1D", testConv1D),
         ("testConv1DDilation", testConv1DDilation),
         ("testConv2D", testConv2D),

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -15,6 +15,15 @@
 import XCTest
 @testable import TensorFlow
 
+fileprivate struct Sigmoid<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
+    public init() {}
+
+    @differentiable
+    public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
+        return sigmoid(input)
+    }
+}
+
 final class LayerTests: XCTestCase {
     func testSequential() {
         withRandomSeedForTensorFlow((12345, 12345)) {
@@ -24,8 +33,8 @@ final class LayerTests: XCTestCase {
                 Dense<Float>(
                     inputSize: inputSize,
                     outputSize: hiddenSize,
-                    activation: sigmoid,
                     weightInitializer: glorotUniform())
+                Sigmoid<Float>()
                 Dense<Float>(
                     inputSize: hiddenSize,
                     outputSize: 1,

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -16,6 +16,25 @@ import XCTest
 @testable import TensorFlow
 
 final class LayerTests: XCTestCase {
+    func testComposed() {
+        let inputSize = 2
+        let hiddenSize = 4
+        let dense1 = Dense<Float>(inputSize: inputSize, outputSize: hiddenSize, activation: relu)
+        let dense2 = Dense<Float>(inputSize: hiddenSize, outputSize: 1, activation: relu)
+        var model = dense1 >>> dense2
+        let optimizer = SGD(for: model, learningRate: 0.02)
+        let x = Tensor<Float>([[0, 0], [0, 1], [1, 0], [1, 1]])
+        let y = Tensor<Float>([0, 1, 1, 0])
+        for _ in 0..<1000 {
+            let 𝛁model = model.gradient { model -> Tensor<Float> in
+                let ŷ = model(x)
+                return meanSquaredError(predicted: ŷ, expected: y)
+            }
+            optimizer.update(&model, along: 𝛁model)
+        }
+        print(model.inferring(from: [[0, 0], [0, 1], [1, 0], [1, 1]]))
+    }
+
     func testConv1D() {
         let filter = Tensor<Float>(ones: [3, 1, 2]) * Tensor<Float>([[[0.5, 1]]])
         let bias = Tensor<Float>([0, 1])
@@ -351,6 +370,7 @@ final class LayerTests: XCTestCase {
     }
 
     static var allTests = [
+        ("testComposed", testComposed),
         ("testConv1D", testConv1D),
         ("testConv1DDilation", testConv1DDilation),
         ("testConv2D", testConv2D),


### PR DESCRIPTION
@rxwei not sure if we want to merge this following our earlier discussion but I open this to gather feedback and consider it.

Quoting the reason I brought this up from our earlier discussion:

> The reason I brought this up is that currently there is no simple way to compose layers. In order to create a layer that is defined as the composition of two other layers one needs to create an entirely new layer struct. For example, a multi-layer perceptron could be simply defined as something like this if we allowed for a composition operator:
> ```swift
> let mlp = Dense<Float>(inputSize: 784, outputSize: 128) >>> ReLU<Float>() >>>
>   Dense<Float>(inputSize: 128, outputSize: 64) >>> ReLU<Float>() >>>
>   Dense<Float>(inputSize: 64, outputSize: 32) >>> ReLU<Float>() >>>
>   Dense<Float>(inputSize: 32, outputSize: 10) >>> Softmax<Float>()
> ```
> This is useful when defining layer "wrappers", which I currently do for the contextual parameter generation methods that I propose in my research. Such wrappers could also be more generally useful. Currently one needs to define a new layer struct per such composition (I cannot use the `sequenced` API directly because I'm not applying the composition to an input).