### PR TITLE
Enhanced the 'Tensor.batchGathering(atIndices:)' function.

### DIFF
--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -411,8 +411,8 @@ public extension Tensor {
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func batchGathering<Index: TensorFlowIndex>(
         atIndices indices: Tensor<Index>,
-        alongAxis axis: Int,
-        numBatchDims batchDims: Int
+        alongAxis axis: Int = 1,
+        batchDimCount batchDims: Int = 1
     ) -> Tensor {
         // TODO: precondition(batchDims >= 0 && batchDims < indices.rank,
         //                    "'numBatchDims' must be non-negative and less than 'indices.rank'.")
@@ -440,7 +440,7 @@ public extension Tensor {
             let result = tensor.batchGathering(
                 atIndices: indices,
                 alongAxis: batchDims,
-                numBatchDims: batchDims)
+                batchDimCount: batchDims)
 
             // Move the result dimensions corresponding to self[batchDims ..< axis] to just before
             // the dimensions corresponding to indices[batchDims ...].

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -18,7 +18,7 @@ infix operator .!=: ComparisonPrecedence
 @inlinable
 @differentiable(where Scalar: TensorFlowFloatingPoint)
 public func identity<Scalar>(_ x: Tensor<Scalar>) -> Tensor<Scalar> {
-    return x
+    x
 }
 
 //===------------------------------------------------------------------------------------------===//
@@ -391,20 +391,20 @@ public extension Tensor {
     }
 
     /// Returns slices of this tensor at `indices` along the `axis` dimension, while ignoring the 
-    /// first `batchDims` dimensions that correspond to batch dimensions. The gather is performed 
-    /// along the first non-batch dimension.
+    /// first `batchDimensionCount` dimensions that correspond to batch dimensions. The gather is 
+    /// performed along the first non-batch dimension.
     ///
     /// Performs similar functionality to `gathering`, except that the resulting tensor shape is 
-    /// now `self.shape[..<axis] + indices.shape[batchDims...] + self.shape[(axis + 1)...]`.
+    /// now `shape[..<axis] + indices.shape[batchDimensionCount...] + shape[(axis + 1)...]`.
     ///
     /// - Parameters:
     ///   - indices: Contains the indices to gather.
     ///   - axis: Dimension along which to gather. Negative values wrap around.
-    ///   - batchDims: Number of leading batch dimensions to ignore.
+    ///   - batchDimensionCount: Number of leading batch dimensions to ignore.
     ///
-    /// - Precondition: `axis` must be in the range `[-rank, rank)`, while also being greater than
-    ///   or equal to `batchDims`.
-    /// - Precondition: `batchDims` must be less than `indices.rank`.
+    /// - Precondition: `axis` must be in the range `-rank..<rank`, while also being greater than
+    ///   or equal to `batchDimensionCount`.
+    /// - Precondition: `batchDimensionCount` must be less than `indices.rank`.
     ///
     /// - Returns: The gathered tensor.
     @inlinable
@@ -412,43 +412,48 @@ public extension Tensor {
     func batchGathering<Index: TensorFlowIndex>(
         atIndices indices: Tensor<Index>,
         alongAxis axis: Int = 1,
-        batchDimCount batchDims: Int = 1
+        batchDimensionCount: Int = 1
     ) -> Tensor {
-        // TODO: precondition(batchDims >= 0 && batchDims < indices.rank,
-        //                    "'numBatchDims' must be non-negative and less than 'indices.rank'.")
-        // TODO: precondition(batchDims < rank, 
-        //                    "'numBatchDims' must be less than the tensor's rank.")
+        // TODO: precondition(batchDimensionCount >= 0,
+        //                    "'batchDimensionCount' must be non-negative.")
+        // TODO: precondition(batchDimensionCount < indices.rank,
+        //                    "'batchDimensionCount' must be less than 'indices.rank'.")
+        // TODO: precondition(batchDimensionCount < rank, 
+        //                    "'batchDimensionCount' must be less than the tensor's rank.")
 
         // Handle the axis argument by transposing the axis dimension so that it is the first
         // non-batch dimension, recursively calling `batchGathering` with `axis = 0`, and then
         // transposing the result to put the pre-axis dimensions before the indices dimensions.
-        if axis != batchDims {
+        if axis != batchDimensionCount {
             // Adjust axis to be positive.
             let posAxis = axis < 0 ? axis + rank : axis
 
             // TODO: precondition(posAxis >= 0 && posAxis < rank, "'axis' is out of range.")
-            // TODO: precondition(batchDims <= posAxis,
-            //                    "'batchDims' must be less than or equal to 'axis'.")
+            // TODO: precondition(batchDimensionCount <= posAxis,
+            //                    "'batchDimensionCount' must be less than or equal to 'axis'.")
 
-            // Move self[axis] up to self[batchDims].
+            // Move self[axis] up to self[batchDimensionCount].
             let permutation = Tensor<Int32>(concatenating: [
-                Tensor<Int32>(rangeFrom: 0, to: Int32(batchDims), stride: 1),
+                Tensor<Int32>(rangeFrom: 0, to: Int32(batchDimensionCount), stride: 1),
                 Tensor<Int32>(Int32(axis)).rankLifted(),
-                Tensor<Int32>(rangeFrom: Int32(batchDims), to: Int32(posAxis), stride: 1),
+                Tensor<Int32>(rangeFrom: Int32(batchDimensionCount), to: Int32(posAxis), stride: 1),
                 Tensor<Int32>(rangeFrom: Int32(axis) + 1, to: Int32(rank), stride: 1)])
             let tensor = transposed(withPermutations: permutation)
             let result = tensor.batchGathering(
                 atIndices: indices,
-                alongAxis: batchDims,
-                batchDimCount: batchDims)
+                alongAxis: batchDimensionCount,
+                batchDimensionCount: batchDimensionCount)
 
-            // Move the result dimensions corresponding to self[batchDims ..< axis] to just before
-            // the dimensions corresponding to indices[batchDims ...].
-            let start = indices.rank + posAxis - batchDims
+            // Move the result dimensions corresponding to self[batchDimensionCount..<axis] to
+            // just before the dimensions corresponding to indices[batchDimensionCount...].
+            let start = indices.rank + posAxis - batchDimensionCount
             let resultPermutation = Tensor<Int32>(concatenating: [
-                Tensor<Int32>(rangeFrom: 0, to: Int32(batchDims), stride: 1),
+                Tensor<Int32>(rangeFrom: 0, to: Int32(batchDimensionCount), stride: 1),
                 Tensor<Int32>(rangeFrom: Int32(indices.rank), to: Int32(start), stride: 1),
-                Tensor<Int32>(rangeFrom: Int32(batchDims), to: Int32(indices.rank), stride: 1),
+                Tensor<Int32>(
+                    rangeFrom: Int32(batchDimensionCount),
+                    to: Int32(indices.rank),
+                    stride: 1),
                 Tensor<Int32>(rangeFrom: Int32(start), to: Int32(result.rank), stride: 1)])
             return result.transposed(withPermutations: resultPermutation)
         }
@@ -456,9 +461,9 @@ public extension Tensor {
         let batchIndices = withoutDerivative(at: { () -> Tensor<Index> in
             var batchIndices = indices
             var accumulated = Tensor<Index>(ones: [])
-            for d in (1...batchDims).reversed() {
-                accumulated *= Tensor<Index>(shapeTensor[d])
-                let dValue = shapeTensor[d - 1]
+            for d in (1...batchDimensionCount).reversed() {
+                accumulated *= Tensor<Index>(self.shapeTensor[d])
+                let dValue = self.shapeTensor[d - 1]
                 let dIndices = Tensor<Index>(
                     rangeFrom: Tensor<Index>(zeros: []),
                     to: Tensor<Index>(dValue),
@@ -474,8 +479,8 @@ public extension Tensor {
         }())
 
         let flatIndices = batchIndices.flattened()
-        let outerShape = shapeTensor[Int(batchDims + 1)...]
-        let innerShape = shapeTensor[..<Int(batchDims + 1)].product(squeezingAxes: [0])
+        let outerShape = shapeTensor[(batchDimensionCount + 1)...]
+        let innerShape = shapeTensor[..<(batchDimensionCount + 1)].product(squeezingAxes: [0])
         let flatTensor = reshaped(toShape: innerShape.rankLifted().concatenated(with: outerShape))
         let flatResult = flatTensor.gathering(atIndices: flatIndices)
         return flatResult.reshaped(toShape: indices.shapeTensor.concatenated(with: outerShape))

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -458,7 +458,7 @@ public extension Tensor {
             return result.transposed(withPermutations: resultPermutation)
         }
 
-        let batchIndices = withoutDerivative(at: { () -> Tensor<Index> in
+        let batchIndices: Tensor<Index> = withoutDerivative(at: {
             var batchIndices = indices
             var accumulated = Tensor<Index>(ones: [])
             for d in (1...batchDimensionCount).reversed() {

--- a/Tests/TensorFlowTests/OperatorTests/BasicTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/BasicTests.swift
@@ -15,16 +15,6 @@
 import XCTest
 @testable import TensorFlow
 
-infix operator ++: AdditionPrecedence
-infix operator .=
-
-infix operator ..: StridedRangeFormationPrecedence
-precedencegroup StridedRangeFormationPrecedence {
-    associativity: left
-    higherThan: CastingPrecedence
-    lowerThan: RangeFormationPrecedence
-}
-
 final class BasicOperatorTests: XCTestCase {
     func testGathering() {
         let x = Tensor<Float>([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])

--- a/Tests/TensorFlowTests/OperatorTests/BasicTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/BasicTests.swift
@@ -32,6 +32,17 @@ final class BasicOperatorTests: XCTestCase {
         XCTAssertEqual(y, Tensor<Float>([3.0, 6.0]))
     }
 
+    func testBatchGathering() {
+        let x = Tensor<Float>([[
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0]]])
+        let y = x.batchGathering(
+            atIndices: Tensor<Int32>([1, 0]),
+            alongAxis: 2,
+            batchDimCount: 2)
+        XCTAssertEqual(y, Tensor<Float>([2.0, 4.0]))
+    }
+
     func testPadded() {
         let x = Tensor<Float>(ones: [2, 2])
         let target = Tensor<Float>([[3, 3, 3], [1, 1, 3], [1, 1, 3]])
@@ -596,6 +607,7 @@ final class BasicOperatorTests: XCTestCase {
 
     static var allTests = [
         ("testGathering", testGathering),
+        ("testBatchGathering", testBatchGathering),
         ("testPadded", testPadded),
         ("testVJPPadded", testVJPPadded),
         ("testElementIndexing", testElementIndexing),

--- a/Tests/TensorFlowTests/OperatorTests/BasicTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/BasicTests.swift
@@ -29,7 +29,7 @@ final class BasicOperatorTests: XCTestCase {
         let y = x.batchGathering(
             atIndices: Tensor<Int32>([1, 0]),
             alongAxis: 2,
-            batchDimCount: 2)
+            batchDimensionCount: 2)
         XCTAssertEqual(y, Tensor<Float>([2.0, 4.0]))
     }
 


### PR DESCRIPTION
Enhanced the `Tensor.batchGathering(atIndices:)` function so that it has the same functionality as the Python API version. It now supports a variable number of batch dimensions as well as an axis to gather along.

This became possible now due to support for control flow auto-diff. :)