### PR TITLE
_vjpConv2DBackpropInput incorrectly passing shape to conv2DBackpropFi…

### DIFF
--- a/Sources/TensorFlow/Operators/NN.swift
+++ b/Sources/TensorFlow/Operators/NN.swift
@@ -185,7 +185,7 @@ func _vjpConv2DBackpropInput<Scalar: TensorFlowFloatingPoint>(
     let value = conv2DBackpropInput(x, shape: shape, filter: filter,
                                     strides: strides, padding: padding, dilations: dilations)
     return (value, { v in
-        (conv2DBackpropFilter(x, input: v, filterSizes: shape, strides: strides,
+        (conv2DBackpropFilter(x, input: v, filterSizes: filter.shapeTensor, strides: strides,
                               padding: padding, dilations: dilations),
          conv2D(v, filter: filter, strides: strides, padding: padding, dilations: dilations))
     })


### PR DESCRIPTION
…lter filterSizes parameter instead of filter shape.