### PR TITLE
[Tensor] Add precondition in 'Tensor.init(arrayLiteral:)' to reject 'init()' calls.

### DIFF
--- a/Sources/TensorFlow/Core/ShapedArray.swift
+++ b/Sources/TensorFlow/Core/ShapedArray.swift
@@ -703,6 +703,7 @@ extension ShapedArray: ExpressibleByArrayLiteral where Scalar: TensorFlowScalar 
     public typealias ArrayLiteralElement = _TensorElementLiteral<Scalar>
     @inlinable
     public init(arrayLiteral elements: _TensorElementLiteral<Scalar>...) {
+        precondition(!elements.isEmpty, "Cannot create a 'ShapedArray' with no elements")
         self = Tensor<Scalar>(_tensorElementLiterals: elements).array
     }
 }
@@ -1065,6 +1066,7 @@ extension ShapedArraySlice: ExpressibleByArrayLiteral where Scalar: TensorFlowSc
     public typealias ArrayLiteralElement = _TensorElementLiteral<Scalar>
     @inlinable
     public init(arrayLiteral elements: _TensorElementLiteral<Scalar>...) {
+        precondition(!elements.isEmpty, "Cannot create a 'ShapedArraySlice' with no elements")
         self.init(base: Tensor(_tensorElementLiterals: elements).array)
     }
 }

--- a/Sources/TensorFlow/Core/ShapedArray.swift
+++ b/Sources/TensorFlow/Core/ShapedArray.swift
@@ -587,15 +587,15 @@ extension ShapedArray: RandomAccessCollection, MutableCollection {
     public subscript(index: Int) -> Element {
         get {
             precondition(!isScalar, "Scalar has no elements and cannot be subscripted.")
-            precondition(index < endIndex, "ShapedArray index is out of range")
-            precondition(index >= startIndex, "Negative ShapedArray index is out of range")
+            precondition(index < endIndex, "ShapedArray index is out of range.")
+            precondition(index >= startIndex, "Negative ShapedArray index is out of range.")
             return ShapedArraySlice(base: self, baseIndices: [index])
         }
         set {
             precondition(!isScalar, "Scalar has no elements and cannot be subscripted.")
-            precondition(index < endIndex, "ShapedArray index is out of range")
-            precondition(index >= startIndex, "Negative ShapedArray index is out of range")
-            precondition(shape.dropFirst().elementsEqual(newValue.shape), "Element shape mismatch")
+            precondition(index < endIndex, "ShapedArray index is out of range.")
+            precondition(index >= startIndex, "Negative ShapedArray index is out of range.")
+            precondition(shape.dropFirst().elementsEqual(newValue.shape), "Element shape mismatch.")
             let scalarIndex = self.scalarIndex(fromIndex: index)
             withUnsafeMutableBufferPointer { destBuffPtr in
                 let ptr = destBuffPtr.baseAddress!.advanced(by: scalarIndex)
@@ -703,7 +703,7 @@ extension ShapedArray: ExpressibleByArrayLiteral where Scalar: TensorFlowScalar 
     public typealias ArrayLiteralElement = _TensorElementLiteral<Scalar>
     @inlinable
     public init(arrayLiteral elements: _TensorElementLiteral<Scalar>...) {
-        precondition(!elements.isEmpty, "Cannot create a 'ShapedArray' with no elements")
+        precondition(!elements.isEmpty, "Cannot create a 'ShapedArray' with no elements.")
         self = Tensor<Scalar>(_tensorElementLiterals: elements).array
     }
 }
@@ -837,7 +837,7 @@ public struct ShapedArraySlice<Scalar>: _ShapedArrayProtocol {
         baseIndices indices: __owned [Int] = [],
         bounds: Range<Int>? = nil
     ) {
-        precondition(indices.count <= base.rank, "Number of base indices exceeds base rank")
+        precondition(indices.count <= base.rank, "Number of base indices exceeds base rank.")
         precondition(
             zip(base.shape, indices).allSatisfy { $1 >= 0 && $1 < $0 },
             "Base indices are out of range")
@@ -1066,7 +1066,7 @@ extension ShapedArraySlice: ExpressibleByArrayLiteral where Scalar: TensorFlowSc
     public typealias ArrayLiteralElement = _TensorElementLiteral<Scalar>
     @inlinable
     public init(arrayLiteral elements: _TensorElementLiteral<Scalar>...) {
-        precondition(!elements.isEmpty, "Cannot create a 'ShapedArraySlice' with no elements")
+        precondition(!elements.isEmpty, "Cannot create a 'ShapedArraySlice' with no elements.")
         self.init(base: Tensor(_tensorElementLiterals: elements).array)
     }
 }

--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -398,6 +398,7 @@ extension Tensor: ExpressibleByArrayLiteral {
     /// Creates a tensor initialized with the given elements.
     @inlinable
     public init(arrayLiteral elements: _TensorElementLiteral<Scalar>...) {
+        precondition(!elements.isEmpty, "Cannot create a 'Tensor' with no elements")
         self.init(_tensorElementLiterals: elements)
     }
 }

--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -398,7 +398,7 @@ extension Tensor: ExpressibleByArrayLiteral {
     /// Creates a tensor initialized with the given elements.
     @inlinable
     public init(arrayLiteral elements: _TensorElementLiteral<Scalar>...) {
-        precondition(!elements.isEmpty, "Cannot create a 'Tensor' with no elements")
+        precondition(!elements.isEmpty, "Cannot create a 'Tensor' with no elements.")
         self.init(_tensorElementLiterals: elements)
     }
 }

--- a/Tests/TensorFlowTests/TensorTests.swift
+++ b/Tests/TensorFlowTests/TensorTests.swift
@@ -25,7 +25,6 @@ final class TensorTests: XCTestCase {
             }
             return b
         }
-
         XCTAssertEqual(0, selectValue(true).scalar)
     }
 


### PR DESCRIPTION
A long-standing issue in Swift is that labeled variadic parameters can accept 0 arguments when a label does not exist. Here is a related discussion on Swift Evolution: [Should labeled variadic parameters accept 0 arguments?](https://forums.swift.org/t/should-labeled-variadic-parameters-accept-0-arguments/12500)

When there is no `Tensor.init()`, an `init()` expression will resolve to a call to `init(arrayLiteral:)` with no arguments, which is semantically invalid for `Tensor`, `ShapedArray`, and `ShapedArraySlice`. Declaring an `init()` with an `@available(*, unavailable)` does not work becuase the type checker would still resolve `init()` calls to `init(arrayLiteral:)`. Before Swift supports finer control over labeled variadic parameters, the only thing we can do is to fail early at run-time.

XCTest does not yet provide test utilities for crashers. We can add such a test utility along with tests for such run-time errors later.

Resolves [TF-644](https://bugs.swift.org/browse/TF-644).