### PR TITLE
Standardized the use of random seeds.

### DIFF
--- a/Sources/TensorFlow/BackwardsCompatibility.swift
+++ b/Sources/TensorFlow/BackwardsCompatibility.swift
@@ -27,8 +27,8 @@ public extension Tensor where Scalar == Int32 {
     init<G: RandomNumberGenerator>(
         randomUniform shape: TensorShape,
         generator: inout G,
-        lowerBound: Scalar = Scalar.self.min,
-        upperBound: Scalar = Scalar.self.max
+        lowerBound: Scalar = Scalar.min,
+        upperBound: Scalar = Scalar.max
     ) {
         let dist = UniformIntegerDistribution<Scalar>(
             lowerBound: lowerBound,
@@ -60,7 +60,6 @@ public extension Tensor where Scalar == Int32 {
             upperBound: upperBound)
     }
 }
-
 
 public extension Tensor where Scalar: BinaryFloatingPoint,
                               Scalar.RawSignificand: FixedWidthInteger {

--- a/Sources/TensorFlow/BackwardsCompatibility.swift
+++ b/Sources/TensorFlow/BackwardsCompatibility.swift
@@ -50,8 +50,8 @@ public extension Tensor where Scalar == Int32 {
     @available(*, deprecated, message: "This API will be removed after Swift for TensorFlow 0.4.")
     init(
         randomUniform shape: TensorShape,
-        lowerBound: Scalar = Scalar.self.min,
-        upperBound: Scalar = Scalar.self.max
+        lowerBound: Scalar = Scalar.min,
+        upperBound: Scalar = Scalar.max
     ) {
         self.init(
             randomUniform: shape,

--- a/Sources/TensorFlow/BackwardsCompatibility.swift
+++ b/Sources/TensorFlow/BackwardsCompatibility.swift
@@ -14,6 +14,137 @@
 
 // TODO: Remove this file after 0.4.
 
+public extension Tensor where Scalar == Int32 {
+    /// Creates a tensor with the specified shape, randomly sampling scalar values from a discrete 
+    /// uniform distribution.
+    ///
+    /// - Parameters:
+    ///   - shape: The dimensions of the tensor.
+    ///   - generator: Random number generator to use.
+    ///   - lowerBound: The lower bound of the distribution.
+    ///   - upperBound: The upper bound of the distribution.
+    @available(*, deprecated, message: "This API will be removed after Swift for TensorFlow 0.4.")
+    init<G: RandomNumberGenerator>(
+        randomUniform shape: TensorShape,
+        generator: inout G,
+        lowerBound: Scalar = Scalar.self.min,
+        upperBound: Scalar = Scalar.self.max
+    ) {
+        let dist = UniformIntegerDistribution<Scalar>(
+            lowerBound: lowerBound,
+            upperBound: upperBound)
+        var scalars: [Scalar] = []
+        for _ in 0 ..< shape.contiguousSize {
+            scalars.append(dist.next(using: &generator))
+        }
+        self.init(shape: shape, scalars: scalars)
+    }
+
+    /// Creates a tensor with the specified shape, randomly sampling scalar values from a discrete 
+    /// uniform distribution, using the default random number generator.
+    ///
+    /// - Parameters:
+    ///   - shape: The dimensions of the tensor.
+    ///   - lowerBound: The lower bound of the distribution.
+    ///   - upperBound: The upper bound of the distribution.
+    @available(*, deprecated, message: "This API will be removed after Swift for TensorFlow 0.4.")
+    init(
+        randomUniform shape: TensorShape,
+        lowerBound: Scalar = Scalar.self.min,
+        upperBound: Scalar = Scalar.self.max
+    ) {
+        self.init(
+            randomUniform: shape,
+            generator: &Context.local.randomNumberGenerator,
+            lowerBound: lowerBound,
+            upperBound: upperBound)
+    }
+}
+
+
+public extension Tensor where Scalar: BinaryFloatingPoint,
+                              Scalar.RawSignificand: FixedWidthInteger {
+    /// Creates a tensor with the specified shape, randomly sampling scalar values from a uniform 
+    /// distribution between `lowerBound` and `upperBound`.
+    ///
+    /// - Parameters:
+    ///   - shape: The dimensions of the tensor.
+    ///   - generator: Random number generator to use.
+    ///   - lowerBound: The lower bound of the distribution.
+    ///   - upperBound: The upper bound of the distribution.
+    @available(*, deprecated, message: "This API will be removed after Swift for TensorFlow 0.4.")
+    init<G: RandomNumberGenerator>(
+        randomUniform shape: TensorShape,
+        generator: inout G,
+        lowerBound: Scalar = 0,
+        upperBound: Scalar = 1
+    ) {
+        let dist = UniformFloatingPointDistribution<Scalar>(
+            lowerBound: lowerBound,
+            upperBound: upperBound)
+        var scalars: [Scalar] = []
+        for _ in 0 ..< shape.contiguousSize {
+            scalars.append(dist.next(using: &generator))
+        }
+        let sample = Tensor(shape: shape, scalars: scalars)
+        self = (upperBound - lowerBound) * sample + lowerBound
+    }
+
+    /// Creates a tensor with the specified shape, randomly sampling scalar values from a normal 
+    /// distribution.
+    ///
+    /// - Parameters:
+    ///   - shape: The dimensions of the tensor.
+    ///   - generator: Random number generator to use.
+    ///   - mean: The mean of the distribution.
+    ///   - standardDeviation: The standard deviation of the distribution.
+    @available(*, deprecated, message: "This API will be removed after Swift for TensorFlow 0.4.")
+    init<G: RandomNumberGenerator>(
+        randomNormal shape: TensorShape,
+        generator: inout G,
+        mean: Scalar = 0,
+        standardDeviation: Scalar = 1
+    ) {
+        let dist = NormalDistribution<Scalar>(mean: mean, standardDeviation: standardDeviation)
+        var scalars: [Scalar] = []
+        for _ in 0 ..< shape.contiguousSize {
+            scalars.append(dist.next(using: &generator))
+        }
+        let sample = Tensor(shape: shape, scalars: scalars)
+        self = standardDeviation * sample + mean
+    }
+}
+
+public extension Tensor where Scalar: TensorFlowFloatingPoint {
+    /// Performs Glorot uniform initialization for the specified shape, creating a tensor by
+    /// randomly sampling scalar values from a uniform distribution between `-limit` and `limit`,
+    /// where limit is `sqrt(6 / (fanIn + fanOut))` and `fanIn`/`fanOut` represent the number of
+    /// input and output features multiplied by the receptive field if present.
+    ///
+    /// - Parameters:
+    ///   - shape: The dimensions of the tensor.
+    ///   - generator: Random number generator to use.
+    @available(*, deprecated, message: "This API will be removed after Swift for TensorFlow 0.4.")
+    init<G: RandomNumberGenerator>(glorotUniform shape: TensorShape, generator: inout G) {
+        let uniform = Tensor(randomUniform: shape, generator: &generator)
+        self = Tensor.glorot(fromStandardUniform: uniform, shape: shape)
+    }
+    
+    /// Performs Glorot normal initialization for the specified shape, creating a tensor by
+    /// randomly sampling scalar values from a uniform distribution between `-limit` and `limit`,
+    /// where limit is `sqrt(2 / (fanIn + fanOut))` and `fanIn`/`fanOut` represent the number of
+    /// input and output features multiplied by the receptive field if present.
+    ///
+    /// - Parameters:
+    ///   - shape: The dimensions of the tensor.
+    ///   - generator: Random number generator to use.
+    @available(*, deprecated, message: "This API will be removed after Swift for TensorFlow 0.4.")
+    init<G: RandomNumberGenerator>(glorotNormal shape: TensorShape, generator: inout G) {
+        let normal = Tensor(randomNormal: shape, generator: &generator)
+        self = Tensor.glorot(fromStandardNormal: normal, shape: shape)
+    }
+}
+
 //===------------------------------------------------------------------------------------------===//
 // Old Initialization Schemes
 //===------------------------------------------------------------------------------------------===//
@@ -109,7 +240,7 @@ public extension Conv1D {
         padding: Padding = .valid,
         dilation: Int = 1,
         activation: @escaping Activation = identity,
-        seed: (Int32, Int32) = Context.local.randomSeed
+        seed: TensorFlowSeed = Context.local.randomSeed
     ) {
         let filterTensorShape = TensorShape([
             filterShape.0, filterShape.1, filterShape.2])
@@ -184,7 +315,7 @@ public extension Conv2D {
         padding: Padding = .valid,
         dilations: (Int, Int) = (1, 1),
         activation: @escaping Activation = identity,
-        seed: (Int32, Int32) = Context.local.randomSeed
+        seed: TensorFlowSeed = Context.local.randomSeed
     ) {
         let filterTensorShape = TensorShape([
             filterShape.0, filterShape.1, filterShape.2, filterShape.3])
@@ -254,7 +385,7 @@ public extension Conv3D {
         strides: (Int, Int, Int) = (1, 1, 1),
         padding: Padding = .valid,
         activation: @escaping Activation = identity,
-        seed: (Int32, Int32) = Context.local.randomSeed
+        seed: TensorFlowSeed = Context.local.randomSeed
     ) {
         let filterTensorShape = TensorShape([
             filterShape.0, filterShape.1, filterShape.2, filterShape.3, filterShape.4])
@@ -319,7 +450,7 @@ public extension TransposedConv2D {
         strides: (Int, Int) = (1, 1),
         padding: Padding = .valid,
         activation: @escaping Activation = identity,
-        seed: (Int32, Int32) = Context.local.randomSeed
+        seed: TensorFlowSeed = Context.local.randomSeed
     ) {
         let filterTensorShape = TensorShape([
             filterShape.0, filterShape.1, filterShape.2, filterShape.3])
@@ -382,7 +513,7 @@ public extension DepthwiseConv2D {
         strides: (Int, Int) = (1, 1),
         padding: Padding = .valid,
         activation: @escaping Activation = identity,
-        seed: (Int32, Int32) = Context.local.randomSeed
+        seed: TensorFlowSeed = Context.local.randomSeed
     ) {
         let filterTensorShape = TensorShape([
             filterShape.0, filterShape.1, filterShape.2, filterShape.3])
@@ -443,7 +574,7 @@ public extension Dense {
         inputSize: Int,
         outputSize: Int,
         activation: @escaping Activation = identity,
-        seed: (Int32, Int32) = Context.local.randomSeed
+        seed: TensorFlowSeed = Context.local.randomSeed
     ) {
         self.init(weight: Tensor(glorotUniform: [inputSize, outputSize],
                                  seed: seed),

--- a/Sources/TensorFlow/Context.swift
+++ b/Sources/TensorFlow/Context.swift
@@ -51,7 +51,7 @@ public struct Context {
     ///
     /// - Note: Whenever obtained, the random seed is also updated so that future stateless 
     ///   random TensorFlow op executions will result in non-deterministic results.
-    public var randomSeed: (Int32, Int32) {
+    public var randomSeed: TensorFlowSeed {
         mutating get {
             let seed = _randomSeed
             _randomSeed = (seed.0, seed.1 + 1)
@@ -60,7 +60,7 @@ public struct Context {
         set { _randomSeed = newValue }
     }
 
-    private var _randomSeed: (Int32, Int32) = randomSeedForTensorFlow()
+    private var _randomSeed: TensorFlowSeed = randomSeedForTensorFlow()
 
     /// The random number generator.
     internal var randomNumberGenerator: AnyRandomNumberGenerator =
@@ -121,7 +121,7 @@ public func withLearningPhase<R>(
 ///     return value of the `withRandomSeedForTensorFlow(_:_:)` function.
 /// - Returns: The return value, if any, of the `body` closure.
 public func withRandomSeedForTensorFlow<R>(
-    _ randomSeed: (Int32, Int32),
+    _ randomSeed: TensorFlowSeed,
     _ body: () throws -> R
 ) rethrows -> R {
     var context = ContextManager.local.currentContext

--- a/Sources/TensorFlow/Initializers.swift
+++ b/Sources/TensorFlow/Initializers.swift
@@ -332,52 +332,7 @@ public extension Tensor where Scalar: Numeric {
 // Random
 //===------------------------------------------------------------------------------------------===//
 
-public extension Tensor where Scalar == Int32 {
-    /// Creates a tensor with the specified shape, randomly sampling scalar values from a discrete 
-    /// uniform distribution.
-    ///
-    /// - Parameters:
-    ///   - shape: The dimensions of the tensor.
-    ///   - generator: Random number generator to use.
-    ///   - lowerBound: The lower bound of the distribution.
-    ///   - upperBound: The upper bound of the distribution.
-    init<G: RandomNumberGenerator>(
-        randomUniform shape: TensorShape,
-        generator: inout G,
-        lowerBound: Scalar = Scalar.self.min,
-        upperBound: Scalar = Scalar.self.max
-    ) {
-        let dist = UniformIntegerDistribution<Scalar>(
-            lowerBound: lowerBound,
-            upperBound: upperBound)
-        var scalars: [Scalar] = []
-        for _ in 0 ..< shape.contiguousSize {
-            scalars.append(dist.next(using: &generator))
-        }
-        self.init(shape: shape, scalars: scalars)
-    }
-
-    /// Creates a tensor with the specified shape, randomly sampling scalar values from a discrete 
-    /// uniform distribution, using the default random number generator.
-    ///
-    /// - Parameters:
-    ///   - shape: The dimensions of the tensor.
-    ///   - lowerBound: The lower bound of the distribution.
-    ///   - upperBound: The upper bound of the distribution.
-    init(
-        randomUniform shape: TensorShape,
-        lowerBound: Scalar = Scalar.self.min,
-        upperBound: Scalar = Scalar.self.max
-    ) {
-        self.init(
-            randomUniform: shape,
-            generator: &Context.local.randomNumberGenerator,
-            lowerBound: lowerBound,
-            upperBound: upperBound)
-    }
-}
-
-public extension Tensor where Scalar: BinaryFloatingPoint {
+public extension Tensor where Scalar: TensorFlowIndex {
     /// Creates a tensor with the specified shape, randomly sampling scalar values from a uniform 
     /// distribution between `lowerBound` and `upperBound`.
     ///
@@ -388,13 +343,36 @@ public extension Tensor where Scalar: BinaryFloatingPoint {
     ///   - seed: The seed value.
     init(
         randomUniform shape: TensorShape,
-        lowerBound: Scalar = 0,
-        upperBound: Scalar = 1,
-        seed: (Int32, Int32) = Context.local.randomSeed
+        lowerBound: Tensor<Scalar> = Tensor<Scalar>(0),
+        upperBound: Tensor<Scalar> = Tensor<Scalar>(1),
+        seed: TensorFlowSeed = Context.local.randomSeed
+    ) {
+        self = Raw.statelessRandomUniformInt(
+            shape: Tensor<Int32>((0..<shape.rank).map { Int32(shape[$0]) }),
+            seed: Tensor<Int32>([seed.graph, seed.op]),
+            minval: lowerBound,
+            maxval: upperBound)
+    }
+}
+
+public extension Tensor where Scalar: TensorFlowFloatingPoint {
+    /// Creates a tensor with the specified shape, randomly sampling scalar values from a uniform 
+    /// distribution between `lowerBound` and `upperBound`.
+    ///
+    /// - Parameters:
+    ///   - shape: The dimensions of the tensor.
+    ///   - lowerBound: The lower bound of the distribution.
+    ///   - upperBound: The upper bound of the distribution.
+    ///   - seed: The seed value.
+    init(
+        randomUniform shape: TensorShape,
+        lowerBound: Tensor<Scalar> = Tensor<Scalar>(0),
+        upperBound: Tensor<Scalar> = Tensor<Scalar>(1),
+        seed: TensorFlowSeed = Context.local.randomSeed
     ) {
         let sample: Tensor<Scalar> = Raw.statelessRandomUniform(
             shape: Tensor<Int32>((0..<shape.rank).map { Int32(shape[$0]) }),
-            seed: Tensor<Int32>([seed.0, seed.1]))
+            seed: Tensor<Int32>([seed.graph, seed.op]))
         self = (upperBound - lowerBound) * sample + lowerBound
     }
 
@@ -408,109 +386,20 @@ public extension Tensor where Scalar: BinaryFloatingPoint {
     ///   - seed: The seed value.
     init(
         randomNormal shape: TensorShape,
-        mean: Scalar = 0,
-        standardDeviation: Scalar = 1,
-        seed: (Int32, Int32) = Context.local.randomSeed
+        mean: Tensor<Scalar> = Tensor<Scalar>(0),
+        standardDeviation: Tensor<Scalar> = Tensor<Scalar>(1),
+        seed: TensorFlowSeed = Context.local.randomSeed
     ) {
         let sample: Tensor<Scalar> = Raw.statelessRandomNormal(
             shape: Tensor<Int32>((0..<shape.rank).map { Int32(shape[$0]) }),
-            seed: Tensor<Int32>([seed.0, seed.1]))
+            seed: Tensor<Int32>([seed.graph, seed.op]))
         self = standardDeviation * sample + mean
     }
 }
 
-public extension Tensor where Scalar: BinaryFloatingPoint,
-                              Scalar.RawSignificand: FixedWidthInteger {
-    /// Creates a tensor with the specified shape, randomly sampling scalar values from a uniform 
-    /// distribution between `lowerBound` and `upperBound`.
-    ///
-    /// - Parameters:
-    ///   - shape: The dimensions of the tensor.
-    ///   - generator: Random number generator to use.
-    ///   - lowerBound: The lower bound of the distribution.
-    ///   - upperBound: The upper bound of the distribution.
-    init<G: RandomNumberGenerator>(
-        randomUniform shape: TensorShape,
-        generator: inout G,
-        lowerBound: Scalar = 0,
-        upperBound: Scalar = 1
-    ) {
-        let dist = UniformFloatingPointDistribution<Scalar>(
-            lowerBound: lowerBound,
-            upperBound: upperBound)
-        var scalars: [Scalar] = []
-        for _ in 0 ..< shape.contiguousSize {
-            scalars.append(dist.next(using: &generator))
-        }
-        let sample = Tensor(shape: shape, scalars: scalars)
-        self = (upperBound - lowerBound) * sample + lowerBound
-    }
-
-    /// Creates a tensor with the specified shape, randomly sampling scalar values from a uniform 
-    /// distribution between `lowerBound` and `upperBound`, using the default random number 
-    /// generator.
-    ///
-    /// - Parameters:
-    ///   - shape: The dimensions of the tensor.
-    ///   - lowerBound: The lower bound of the distribution.
-    ///   - upperBound: The upper bound of the distribution.
-    init(
-        randomUniform shape: TensorShape,
-        lowerBound: Scalar = 0,
-        upperBound: Scalar = 1
-    ) {
-        self.init(
-            randomUniform: shape,
-            generator: &Context.local.randomNumberGenerator,
-            lowerBound: lowerBound,
-            upperBound: upperBound)
-    }
-
-    /// Creates a tensor with the specified shape, randomly sampling scalar values from a normal 
-    /// distribution.
-    ///
-    /// - Parameters:
-    ///   - shape: The dimensions of the tensor.
-    ///   - generator: Random number generator to use.
-    ///   - mean: The mean of the distribution.
-    ///   - standardDeviation: The standard deviation of the distribution.
-    init<G: RandomNumberGenerator>(
-        randomNormal shape: TensorShape,
-        generator: inout G,
-        mean: Scalar = 0,
-        standardDeviation: Scalar = 1
-    ) {
-        let dist = NormalDistribution<Scalar>(mean: mean, standardDeviation: standardDeviation)
-        var scalars: [Scalar] = []
-        for _ in 0 ..< shape.contiguousSize {
-            scalars.append(dist.next(using: &generator))
-        }
-        let sample = Tensor(shape: shape, scalars: scalars)
-        self = standardDeviation * sample + mean
-    }
-
-    /// Creates a tensor with the specified shape, randomly sampling scalar values from a normal 
-    /// distribution, using the default random number generator.
-    ///
-    /// - Parameters:
-    ///   - shape: The dimensions of the tensor.
-    ///   - mean: The mean of the distribution.
-    ///   - stddev: The standard deviation of the distribution.
-    init(
-        randomNormal shape: TensorShape,
-        mean: Scalar = 0,
-        standardDeviation: Scalar = 1
-    ) {
-        self.init(
-            randomNormal: shape,
-            generator: &Context.local.randomNumberGenerator,
-            mean: mean,
-            standardDeviation: standardDeviation)
-    }
-}
-
-fileprivate extension Tensor where Scalar: TensorFlowFloatingPoint {
-    private static func glorot(
+// TODO: Can become fileprivate after the 0.4 release.
+internal extension Tensor where Scalar: TensorFlowFloatingPoint {
+    static func glorot(
         fromStandardUniform randomUniform: __shared Tensor<Scalar>,
         shape: __shared TensorShape
     ) -> Tensor<Scalar> {
@@ -532,29 +421,15 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     ///
     /// - Parameters:
     ///   - shape: The dimensions of the tensor.
-    init(glorotUniform shape: TensorShape, seed: (Int32, Int32) = Context.local.randomSeed) {
+    init(glorotUniform shape: TensorShape, seed: TensorFlowSeed = Context.local.randomSeed) {
         let uniform = Tensor(randomUniform: shape, seed: seed)
         self = Tensor.glorot(fromStandardUniform: uniform, shape: shape)
     }
 }
 
-public extension Tensor where Scalar: TensorFlowFloatingPoint {
-    /// Performs Glorot uniform initialization for the specified shape, creating a tensor by
-    /// randomly sampling scalar values from a uniform distribution between `-limit` and `limit`,
-    /// where limit is `sqrt(6 / (fanIn + fanOut))` and `fanIn`/`fanOut` represent the number of
-    /// input and output features multiplied by the receptive field if present.
-    ///
-    /// - Parameters:
-    ///   - shape: The dimensions of the tensor.
-    ///   - generator: Random number generator to use.
-    init<G: RandomNumberGenerator>(glorotUniform shape: TensorShape, generator: inout G) {
-        let uniform = Tensor(randomUniform: shape, generator: &generator)
-        self = Tensor.glorot(fromStandardUniform: uniform, shape: shape)
-    }
-}
-
-fileprivate extension Tensor where Scalar: TensorFlowFloatingPoint {
-    private static func glorot(
+// TODO: Can become fileprivate after the 0.4 release.
+internal extension Tensor where Scalar: TensorFlowFloatingPoint {
+    static func glorot(
         fromStandardNormal standardNormal: __shared Tensor<Scalar>,
         shape: __shared TensorShape
     ) -> Tensor<Scalar> {
@@ -576,23 +451,8 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     ///
     /// - Parameters:
     ///   - shape: The dimensions of the tensor.
-    init(glorotNormal shape: TensorShape, seed: (Int32, Int32) = Context.local.randomSeed) {
+    init(glorotNormal shape: TensorShape, seed: TensorFlowSeed = Context.local.randomSeed) {
         let normal = Tensor(randomNormal: shape, seed: seed)
-        self = Tensor.glorot(fromStandardNormal: normal, shape: shape)
-    }
-}
-
-public extension Tensor where Scalar: TensorFlowFloatingPoint {
-    /// Performs Glorot normal initialization for the specified shape, creating a tensor by
-    /// randomly sampling scalar values from a uniform distribution between `-limit` and `limit`,
-    /// where limit is `sqrt(2 / (fanIn + fanOut))` and `fanIn`/`fanOut` represent the number of
-    /// input and output features multiplied by the receptive field if present.
-    ///
-    /// - Parameters:
-    ///   - shape: The dimensions of the tensor.
-    ///   - generator: Random number generator to use.
-    init<G: RandomNumberGenerator>(glorotNormal shape: TensorShape, generator: inout G) {
-        let normal = Tensor(randomNormal: shape, generator: &generator)
         self = Tensor.glorot(fromStandardNormal: normal, shape: shape)
     }
 }
@@ -613,11 +473,10 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     ///   - shape: The shape of the tensor.
     ///   - gain: A multiplicative factor to apply to the orthogonal tensor.
     ///   - seed: A tuple of two integers to seed the random number generator.
-    ///
     init(
         orthogonal shape: TensorShape,
-        gain: Scalar = 1,
-        seed: (Int32, Int32) = Context.local.randomSeed
+        gain: Tensor<Scalar> = Tensor<Scalar>(1),
+        seed: TensorFlowSeed = Context.local.randomSeed
     ) {
         let rowCount = shape.dimensions.dropLast().reduce(1, *)
         let columnCount = shape[shape.rank - 1]

--- a/Sources/TensorFlow/Layers/Initialization.swift
+++ b/Sources/TensorFlow/Layers/Initialization.swift
@@ -25,7 +25,7 @@ public func zeros<Scalar: TensorFlowFloatingPoint>() -> ParameterInitializer<Sca
 /// `sqrt(6 / (fanIn + fanOut))`, and `fanIn`/`fanOut` represent the number of input and output
 /// features multiplied by the receptive field, if present.
 public func glorotUniform<Scalar: TensorFlowFloatingPoint>(
-    seed: (Int32, Int32) = Context.local.randomSeed
+    seed: TensorFlowSeed = Context.local.randomSeed
 ) -> ParameterInitializer<Scalar> {
     { Tensor<Scalar>(glorotUniform: $0, seed: seed) }
 }

--- a/Sources/TensorFlow/Layers/Recurrent.swift
+++ b/Sources/TensorFlow/Layers/Recurrent.swift
@@ -108,7 +108,7 @@ public struct SimpleRNNCell<Scalar: TensorFlowFloatingPoint>: RNNCell {
     ///   - inputSize: The number of features in 2-D input tensors.
     ///   - hiddenSize: The number of features in 2-D hidden states.
     ///   - seed: The random seed for initialization. The default value is random.
-    public init(inputSize: Int, hiddenSize: Int, seed: (Int32, Int32) = Context.local.randomSeed) {
+    public init(inputSize: Int, hiddenSize: Int, seed: TensorFlowSeed = Context.local.randomSeed) {
         let concatenatedInputSize = inputSize + hiddenSize
         self.weight = Tensor(glorotUniform: [concatenatedInputSize, hiddenSize], seed: seed)
         self.bias = Tensor(zeros: [hiddenSize])
@@ -152,7 +152,7 @@ public struct LSTMCell<Scalar: TensorFlowFloatingPoint>: RNNCell {
     public init(
         inputSize: Int,
         hiddenSize: Int,
-        seed: (Int32, Int32) = Context.local.randomSeed
+        seed: TensorFlowSeed = Context.local.randomSeed
     ) {
         let concatenatedInputSize = inputSize + hiddenSize
         let gateWeightShape = TensorShape([concatenatedInputSize, hiddenSize])

--- a/Sources/TensorFlow/Random.swift
+++ b/Sources/TensorFlow/Random.swift
@@ -18,11 +18,13 @@ import Darwin
 import Glibc
 #endif
 
+public typealias TensorFlowSeed = (graph: Int32, op: Int32)
+
 /// Generates a new random seed for TensorFlow.
-public func randomSeedForTensorFlow(using seed: (Int32, Int32)? = nil) -> (Int32, Int32) {
+public func randomSeedForTensorFlow(using seed: TensorFlowSeed? = nil) -> TensorFlowSeed {
     var strongSeed = UInt64(0)
     if let s = seed {
-        let bytes = (s.0.bytes() + s.1.bytes())[...]
+        let bytes = (s.graph.bytes() + s.op.bytes())[...]
         let singleSeed = UInt64(bytes: bytes, startingAt: bytes.startIndex)
         strongSeed = UInt64(pow(Double(singleSeed % 2), Double(8 * 8)))
     } else {
@@ -41,9 +43,9 @@ public func randomSeedForTensorFlow(using seed: (Int32, Int32)? = nil) -> (Int32
     // Reference: https://github.com/openai/gym/blob/master/gym/utils/seeding.py
 
     let hash = strongSeed.bytes().sha512()
-    let first = Int32(bytes: [hash[0], hash[1], hash[2], hash[3]], startingAt: 0)
-    let second = Int32(bytes: [hash[4], hash[5], hash[6], hash[7]], startingAt: 0)
-    return (first, second)
+    let graph = Int32(bytes: [hash[0], hash[1], hash[2], hash[3]], startingAt: 0)
+    let op = Int32(bytes: [hash[4], hash[5], hash[6], hash[7]], startingAt: 0)
+    return (graph: graph, op: op)
 }
 
 //===------------------------------------------------------------------------------------------===//


### PR DESCRIPTION
I made `Initializers.swift` also use the same interface for random seeds that we use for layer initialization. This allows for a consistent notion of random seeds and how they work across the library. I also moved constructors that use stateful Swift random number generators in `BackwardsCompatibility.swift`. I also introduced a `TensorFlowRandomSeed` typealias to allow for easier refactoring if we decide to change things in the future.