### PR TITLE
Remove Layer requirement of PointwiseMultiplicative and ElementaryFunctions

### DIFF
--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -20,8 +20,7 @@
 /// `Layer` instances define a differentiable `applied(to:)` method for mapping inputs to
 /// outputs.
 public protocol Layer: Differentiable, KeyPathIterable
-    where TangentVector: VectorProtocol & ElementaryFunctions &
-                         PointwiseMultiplicative & KeyPathIterable,
+    where TangentVector: VectorProtocol & KeyPathIterable,
           AllDifferentiableVariables == TangentVector {
     /// The input type of the layer.
     associatedtype Input: Differentiable
@@ -44,8 +43,7 @@ public extension Layer {
 }
 
 /// An empty struct representing empty `TangentVector`s for parameterless layers.
-public struct EmptyTangentVector: Differentiable, VectorProtocol, ElementaryFunctions,
-                                  PointwiseMultiplicative, KeyPathIterable {
+public struct EmptyTangentVector: Differentiable, VectorProtocol, KeyPathIterable {
     public typealias AllDifferentiableVariables = EmptyTangentVector
     public typealias VectorSpaceScalar = Float
 

--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -20,7 +20,7 @@
 /// `Layer` instances define a differentiable `applied(to:)` method for mapping inputs to
 /// outputs.
 public protocol Layer: Differentiable, KeyPathIterable
-    where TangentVector: VectorProtocol & KeyPathIterable,
+    where TangentVector: VectorProtocols & KeyPathIterable,
           AllDifferentiableVariables == TangentVector {
     /// The input type of the layer.
     associatedtype Input: Differentiable
@@ -43,7 +43,8 @@ public extension Layer {
 }
 
 /// An empty struct representing empty `TangentVector`s for parameterless layers.
-public struct EmptyTangentVector: Differentiable, VectorProtocol, KeyPathIterable {
+public struct EmptyTangentVector: Differentiable, VectorProtocol, ElementaryFunctions,
+                                  PointwiseMultiplicative, KeyPathIterable {
     public typealias AllDifferentiableVariables = EmptyTangentVector
     public typealias VectorSpaceScalar = Float
 

--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -20,7 +20,7 @@
 /// `Layer` instances define a differentiable `applied(to:)` method for mapping inputs to
 /// outputs.
 public protocol Layer: Differentiable, KeyPathIterable
-    where TangentVector: VectorProtocols & KeyPathIterable,
+    where TangentVector: VectorProtocol & KeyPathIterable,
           AllDifferentiableVariables == TangentVector {
     /// The input type of the layer.
     associatedtype Input: Differentiable


### PR DESCRIPTION
Fix: #343 

I was wondering if i should add a FIXIT by mentioning we reverted the change. 