### PR TITLE
Split the `Layer` protocol into `Layer` and `Module` where `Module` does not require `Input: Differentiable`.

### DIFF
--- a/Sources/TensorFlow/Bindings/EagerExecution.swift
+++ b/Sources/TensorFlow/Bindings/EagerExecution.swift
@@ -68,7 +68,6 @@ internal struct TFE_Op: TFTensorOperation {
         let count = input._tensorHandleCount
         var buffer = UnsafeMutableBufferPointer<CTensorHandle>.allocate(capacity: Int(count))
         defer { buffer.deallocate() }
-        let pointer = UnsafeMutablePointer<OpaquePointer?>(buffer.baseAddress)
         input._unpackTensorHandles(into: buffer.baseAddress)
         for i in 0..<Int(count) {
             TFE_OpAddInput(op, buffer[i], status)

--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -48,7 +48,7 @@ public protocol Layer: XXX where Input: Differentiable {
 public extension Layer {
     @differentiable
     func call(_  input: Input) -> Output {
-        return callAsFunction(input)
+        callAsFunction(input)
     }
 }
 
@@ -69,7 +69,10 @@ public struct EmptyTangentVector: Differentiable, VectorProtocol, ElementaryFunc
 /// A parameterless neural network layer.
 ///
 /// The `TangentVector` of parameterless layers is always `EmptyTangentVector`.
-public protocol ParameterlessLayer: Layer where AllDifferentiableVariables == EmptyTangentVector {}
+public protocol ParameterlessLayer: Layer where AllDifferentiableVariables == EmptyTangentVector {
+    @differentiable
+    func callAsFunction(_ input: Input) -> Output
+}
 
 public extension ParameterlessLayer {
     var allDifferentiableVariables: EmptyTangentVector {

--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public protocol XXX: Differentiable, KeyPathIterable
+public protocol Module: Differentiable, KeyPathIterable
     where TangentVector: VectorProtocol & ElementaryFunctions &
                          PointwiseMultiplicative & KeyPathIterable,
           AllDifferentiableVariables == TangentVector {
@@ -36,7 +36,7 @@ public protocol XXX: Differentiable, KeyPathIterable
 ///
 /// `Layer` instances define a differentiable `callAsFunction(_:)` method for mapping inputs to
 /// outputs.
-public protocol Layer: XXX where Input: Differentiable {
+public protocol Layer: Module where Input: Differentiable {
     /// Returns the output obtained from applying the layer to the given input.
     ///
     /// - Parameter input: The input to the layer.

--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -12,22 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+public protocol XXX: Differentiable, KeyPathIterable
+    where TangentVector: VectorProtocol & ElementaryFunctions &
+                         PointwiseMultiplicative & KeyPathIterable,
+          AllDifferentiableVariables == TangentVector {
+    /// The input type of the layer.
+    associatedtype Input
+    /// The output type of the layer.
+    associatedtype Output: Differentiable
+
+    /// Returns the output obtained from applying the layer to the given input.
+    ///
+    /// - Parameter input: The input to the layer.
+    /// - Returns: The output.
+    @differentiable(wrt: self)
+    func callAsFunction(_ input: Input) -> Output
+}
+
 /// A neural network layer.
 ///
 /// Types that conform to `Layer` represent functions that map inputs to outputs. They may have an
 /// internal state represented by parameters, such as weight tensors.
 ///
-/// `Layer` instances define a differentiable `applied(to:)` method for mapping inputs to
+/// `Layer` instances define a differentiable `callAsFunction(_:)` method for mapping inputs to
 /// outputs.
-public protocol Layer: Differentiable, KeyPathIterable
-    where TangentVector: VectorProtocol & ElementaryFunctions &
-                         PointwiseMultiplicative & KeyPathIterable,
-          AllDifferentiableVariables == TangentVector {
-    /// The input type of the layer.
-    associatedtype Input: Differentiable
-    /// The output type of the layer.
-    associatedtype Output: Differentiable
-
+public protocol Layer: XXX where Input: Differentiable {
     /// Returns the output obtained from applying the layer to the given input.
     ///
     /// - Parameter input: The input to the layer.
@@ -78,7 +87,7 @@ public extension Layer {
     /// - Returns: The inference output.
     @differentiable
     func inferring(from input: Input) -> Output {
-        return withLearningPhase(LearningPhase.inference) { self(input) }
+        withLearningPhase(LearningPhase.inference) { self(input) }
     }
 
     // TODO(rxwei): Remove this custom VJP once differentiation supports currying.
@@ -87,7 +96,7 @@ public extension Layer {
     internal func _vjpInferring(from input: Input)
         -> (value: Output, pullback: (Output.TangentVector)
             -> (AllDifferentiableVariables, Input.TangentVector)) {
-        return withLearningPhase(LearningPhase.inference) {
+        withLearningPhase(LearningPhase.inference) {
             let (output, pullback) = appliedForBackpropagation(to: input)
             return (output, { v in pullback(v) })
         }

--- a/Sources/TensorFlow/Layers/Convolutional.swift
+++ b/Sources/TensorFlow/Layers/Convolutional.swift
@@ -564,7 +564,7 @@ public struct ZeroPadding1D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.padded(forSizes: [(padding.0, padding.1)])
+        input.padded(forSizes: [(padding.0, padding.1)])
     }
 }
 

--- a/Sources/TensorFlow/Layers/Embedding.swift
+++ b/Sources/TensorFlow/Layers/Embedding.swift
@@ -16,7 +16,7 @@
 ///
 /// `Embedding` is effectively a lookup table that maps indices from a fixed vocabulary to fixed-size
 /// (dense) vector representations, e.g. `[[0], [3]] -> [[0.25, 0.1], [0.6, -0.2]]`.
-public struct Embedding<Scalar: TensorFlowFloatingPoint>: XXX {
+public struct Embedding<Scalar: TensorFlowFloatingPoint>: Module {
     /// A learnable lookup table that maps vocabulary indices to their dense vector representations.
     public var embeddings: Tensor<Scalar>
 

--- a/Sources/TensorFlow/Layers/Embedding.swift
+++ b/Sources/TensorFlow/Layers/Embedding.swift
@@ -12,29 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// An input structure containing the embedding indices.
-///
-/// - Note: Often times, `Embedding` is followed by a `Flatten` and a `Dense` layer. When this 
-///   is the case, ensure that all input sequences of indices have the same dimension.
-// NOTE: This structure is needed to conform `Embedding` to the Layer protocol.
-@frozen
-public struct EmbeddingInput: Differentiable {
-    /// Sequences of indices that will be passed into the layer.
-    @noDerivative public var indices: Tensor<Int32>
-
-    /// Creates an `EmbeddingInput`.
-    ///
-    /// - Parameter indices: The embedding indices.
-    public init(indices: Tensor<Int32>) {
-        self.indices = indices
-    }
-}
-
 /// An embedding layer.
 ///
 /// `Embedding` is effectively a lookup table that maps indices from a fixed vocabulary to fixed-size
 /// (dense) vector representations, e.g. `[[0], [3]] -> [[0.25, 0.1], [0.6, -0.2]]`.
-public struct Embedding<Scalar: TensorFlowFloatingPoint>: Layer {
+public struct Embedding<Scalar: TensorFlowFloatingPoint>: XXX {
     /// A learnable lookup table that maps vocabulary indices to their dense vector representations.
     public var embeddings: Tensor<Scalar>
 
@@ -63,8 +45,8 @@ public struct Embedding<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Parameter
     ///   - input: The indices that will be mapped to their vector representations.
     /// - Returns: The tensor created by replacing input indices with their vector representations.
-    @differentiable
-    public func callAsFunction(_ input: EmbeddingInput) -> Tensor<Scalar> {
-        return embeddings.gathering(atIndices: input.indices)
+    @differentiable(wrt: self)
+    public func callAsFunction(_ input: Tensor<Int32>) -> Tensor<Scalar> {
+        embeddings.gathering(atIndices: input)
     }
 }

--- a/Sources/TensorFlow/Layers/Pooling.swift
+++ b/Sources/TensorFlow/Layers/Pooling.swift
@@ -40,7 +40,7 @@ public struct MaxPool1D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return maxPool2D(
+        maxPool2D(
             input.expandingShape(at: 1),
             filterSize: (1, 1, poolSize, 1),
             strides: (1, 1, stride, 1),
@@ -73,7 +73,7 @@ public struct MaxPool2D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return maxPool2D(input, filterSize: poolSize, strides: strides, padding: padding)
+        maxPool2D(input, filterSize: poolSize, strides: strides, padding: padding)
     }
 }
 
@@ -120,7 +120,7 @@ public struct MaxPool3D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return maxPool3D(input, filterSize: poolSize, strides: strides, padding: padding)
+        maxPool3D(input, filterSize: poolSize, strides: strides, padding: padding)
     }
 }
 
@@ -178,7 +178,7 @@ public struct AvgPool1D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return avgPool2D(
+        avgPool2D(
             input.expandingShape(at: 1),
             filterSize: (1, 1, poolSize, 1),
             strides: (1, 1, stride, 1),
@@ -211,7 +211,7 @@ public struct AvgPool2D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return avgPool2D(input, filterSize: poolSize, strides: strides, padding: padding)
+        avgPool2D(input, filterSize: poolSize, strides: strides, padding: padding)
     }
 }
 
@@ -258,7 +258,7 @@ public struct AvgPool3D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return avgPool3D(input, filterSize: poolSize, strides: strides, padding: padding)
+        avgPool3D(input, filterSize: poolSize, strides: strides, padding: padding)
     }
 }
 
@@ -300,7 +300,7 @@ public struct GlobalAvgPool1D<Scalar: TensorFlowFloatingPoint>: ParameterlessLay
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.mean(squeezingAxes: 1)
+        input.mean(squeezingAxes: 1)
     }
 }
 
@@ -316,7 +316,7 @@ public struct GlobalAvgPool2D<Scalar: TensorFlowFloatingPoint>: ParameterlessLay
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.mean(squeezingAxes: [1, 2])
+        input.mean(squeezingAxes: [1, 2])
     }
 }
 
@@ -332,7 +332,7 @@ public struct GlobalAvgPool3D<Scalar: TensorFlowFloatingPoint>: ParameterlessLay
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.mean(squeezingAxes: [1, 2, 3])
+        input.mean(squeezingAxes: [1, 2, 3])
     }
 }
 
@@ -351,7 +351,7 @@ public struct GlobalMaxPool1D<Scalar: TensorFlowFloatingPoint>: ParameterlessLay
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.max(squeezingAxes: 1)
+        input.max(squeezingAxes: 1)
     }
 }
 
@@ -367,7 +367,7 @@ public struct GlobalMaxPool2D<Scalar: TensorFlowFloatingPoint>: ParameterlessLay
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.max(squeezingAxes: [1, 2])
+        input.max(squeezingAxes: [1, 2])
     }
 }
 
@@ -383,6 +383,6 @@ public struct GlobalMaxPool3D<Scalar: TensorFlowFloatingPoint>: ParameterlessLay
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.max(squeezingAxes: [1, 2, 3])
+        input.max(squeezingAxes: [1, 2, 3])
     }
 }

--- a/Sources/TensorFlow/Layers/Sequential.swift
+++ b/Sources/TensorFlow/Layers/Sequential.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// A layer that sequentially composes two other layers.
-public struct Sequential<Layer1: XXX, Layer2: Layer>: XXX
+public struct Sequential<Layer1: Module, Layer2: Layer>: Module
     where Layer1.Output == Layer2.Input,
           Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar {
     public var layer1: Layer1
@@ -43,13 +43,13 @@ extension Sequential: Layer where Layer1: Layer {
 
 @_functionBuilder
 public struct LayerBuilder {
-    public static func buildBlock<L1: XXX, L2: Layer>(_ l1: L1, _ l2: L2) -> Sequential<L1, L2>
+    public static func buildBlock<L1: Module, L2: Layer>(_ l1: L1, _ l2: L2) -> Sequential<L1, L2>
         where L1.Output == L2.Input {
         Sequential(l1, l2)
     }
 
     public static func buildBlock<
-        L1: XXX,
+        L1: Module,
         L2: Layer,
         L3: Layer
     >(_ l1: L1, _ l2: L2, _ l3: L3)
@@ -63,7 +63,7 @@ public struct LayerBuilder {
     }
 
     public static func buildBlock<
-        L1: XXX,
+        L1: Module,
         L2: Layer,
         L3: Layer,
         L4: Layer
@@ -80,7 +80,7 @@ public struct LayerBuilder {
     }
 
     public static func buildBlock<
-        L1: XXX,
+        L1: Module,
         L2: Layer,
         L3: Layer,
         L4: Layer,
@@ -100,7 +100,7 @@ public struct LayerBuilder {
     }
 
     public static func buildBlock<
-        L1: XXX,
+        L1: Module,
         L2: Layer,
         L3: Layer,
         L4: Layer,
@@ -123,7 +123,7 @@ public struct LayerBuilder {
     }
 
     public static func buildBlock<
-        L1: XXX,
+        L1: Module,
         L2: Layer,
         L3: Layer,
         L4: Layer,
@@ -149,7 +149,7 @@ public struct LayerBuilder {
     }
 
     public static func buildBlock<
-        L1: XXX,
+        L1: Module,
         L2: Layer,
         L3: Layer,
         L4: Layer,
@@ -178,7 +178,7 @@ public struct LayerBuilder {
     }
 
     public static func buildBlock<
-        L1: XXX,
+        L1: Module,
         L2: Layer,
         L3: Layer,
         L4: Layer,
@@ -210,7 +210,7 @@ public struct LayerBuilder {
     }
 
     public static func buildBlock<
-        L1: XXX,
+        L1: Module,
         L2: Layer,
         L3: Layer,
         L4: Layer,

--- a/Sources/TensorFlow/Layers/Sequential.swift
+++ b/Sources/TensorFlow/Layers/Sequential.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// A layer that sequentially composes two other layers.
-public struct Sequential<Layer1: Layer, Layer2: Layer>: Layer
+public struct Sequential<Layer1: XXX, Layer2: Layer>: XXX
     where Layer1.Output == Layer2.Input,
           Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar {
     public var layer1: Layer1
@@ -24,7 +24,7 @@ public struct Sequential<Layer1: Layer, Layer2: Layer>: Layer
         self.layer2 = layer2
     }
 
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Layer1.Input) -> Layer2.Output {
         layer2(layer1(input))
     }
@@ -34,15 +34,22 @@ public struct Sequential<Layer1: Layer, Layer2: Layer>: Layer
     }
 }
 
+extension Sequential: Layer where Layer1: Layer {
+    @differentiable
+    public func callAsFunction(_ input: Layer1.Input) -> Layer2.Output {
+        layer2(layer1(input))
+    }
+}
+
 @_functionBuilder
 public struct LayerBuilder {
-    public static func buildBlock<L1: Layer, L2: Layer>(_ l1: L1, _ l2: L2) -> Sequential<L1, L2>
+    public static func buildBlock<L1: XXX, L2: Layer>(_ l1: L1, _ l2: L2) -> Sequential<L1, L2>
         where L1.Output == L2.Input {
         Sequential(l1, l2)
     }
 
     public static func buildBlock<
-        L1: Layer,
+        L1: XXX,
         L2: Layer,
         L3: Layer
     >(_ l1: L1, _ l2: L2, _ l3: L3)
@@ -56,7 +63,7 @@ public struct LayerBuilder {
     }
 
     public static func buildBlock<
-        L1: Layer,
+        L1: XXX,
         L2: Layer,
         L3: Layer,
         L4: Layer
@@ -73,7 +80,7 @@ public struct LayerBuilder {
     }
 
     public static func buildBlock<
-        L1: Layer,
+        L1: XXX,
         L2: Layer,
         L3: Layer,
         L4: Layer,
@@ -93,7 +100,7 @@ public struct LayerBuilder {
     }
 
     public static func buildBlock<
-        L1: Layer,
+        L1: XXX,
         L2: Layer,
         L3: Layer,
         L4: Layer,
@@ -116,7 +123,7 @@ public struct LayerBuilder {
     }
 
     public static func buildBlock<
-        L1: Layer,
+        L1: XXX,
         L2: Layer,
         L3: Layer,
         L4: Layer,
@@ -142,7 +149,7 @@ public struct LayerBuilder {
     }
 
     public static func buildBlock<
-        L1: Layer,
+        L1: XXX,
         L2: Layer,
         L3: Layer,
         L4: Layer,
@@ -171,7 +178,7 @@ public struct LayerBuilder {
     }
 
     public static func buildBlock<
-        L1: Layer,
+        L1: XXX,
         L2: Layer,
         L3: Layer,
         L4: Layer,
@@ -203,7 +210,7 @@ public struct LayerBuilder {
     }
 
     public static func buildBlock<
-        L1: Layer,
+        L1: XXX,
         L2: Layer,
         L3: Layer,
         L4: Layer,

--- a/Sources/TensorFlow/Layers/Sequential.swift.gyb
+++ b/Sources/TensorFlow/Layers/Sequential.swift.gyb
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// A layer that sequentially composes two other layers.
-public struct Sequential<Layer1: Layer, Layer2: Layer>: Layer
+public struct Sequential<Layer1: XXX, Layer2: Layer>: XXX
     where Layer1.Output == Layer2.Input,
           Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar {
     public var layer1: Layer1
@@ -24,7 +24,7 @@ public struct Sequential<Layer1: Layer, Layer2: Layer>: Layer
         self.layer2 = layer2
     }
 
-    @differentiable
+    @differentiable(wrt: self)
     public func callAsFunction(_ input: Layer1.Input) -> Layer2.Output {
         layer2(layer1(input))
     }
@@ -34,16 +34,24 @@ public struct Sequential<Layer1: Layer, Layer2: Layer>: Layer
     }
 }
 
+extension Sequential: Layer where Layer1: Layer {
+    @differentiable
+    public func callAsFunction(_ input: Layer1.Input) -> Layer2.Output {
+        layer2(layer1(input))
+    }
+}
+
 @_functionBuilder
 public struct LayerBuilder {
-    public static func buildBlock<L1: Layer, L2: Layer>(_ l1: L1, _ l2: L2) -> Sequential<L1, L2>
+    public static func buildBlock<L1: XXX, L2: Layer>(_ l1: L1, _ l2: L2) -> Sequential<L1, L2>
         where L1.Output == L2.Input {
         Sequential(l1, l2)
     }
 
     %for n in range(3, 11):
     public static func buildBlock<
-        ${",\n        ".join(["L{}: Layer".format(i) for i in range(1, n+1)])}
+        L1: XXX,
+        ${",\n        ".join(["L{}: Layer".format(i) for i in range(2, n+1)])}
     >(${", ".join(["_ l{}: L{}".format(i, i) for i in range(1, n+1)])})
         -> ${"".join(["Sequential<L{}, ".format(i) for i in range(1, n)])}L${n}${"".join([">" for i in range(1, n)])} where
         ${",\n        ".join(["L{}.Output == L{}.Input".format(i, i+1)

--- a/Sources/TensorFlow/Layers/Sequential.swift.gyb
+++ b/Sources/TensorFlow/Layers/Sequential.swift.gyb
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// A layer that sequentially composes two other layers.
-public struct Sequential<Layer1: XXX, Layer2: Layer>: XXX
+public struct Sequential<Layer1: Module, Layer2: Layer>: Module
     where Layer1.Output == Layer2.Input,
           Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar {
     public var layer1: Layer1
@@ -43,14 +43,14 @@ extension Sequential: Layer where Layer1: Layer {
 
 @_functionBuilder
 public struct LayerBuilder {
-    public static func buildBlock<L1: XXX, L2: Layer>(_ l1: L1, _ l2: L2) -> Sequential<L1, L2>
+    public static func buildBlock<L1: Module, L2: Layer>(_ l1: L1, _ l2: L2) -> Sequential<L1, L2>
         where L1.Output == L2.Input {
         Sequential(l1, l2)
     }
 
     %for n in range(3, 11):
     public static func buildBlock<
-        L1: XXX,
+        L1: Module,
         ${",\n        ".join(["L{}: Layer".format(i) for i in range(2, n+1)])}
     >(${", ".join(["_ l{}: L{}".format(i, i) for i in range(1, n+1)])})
         -> ${"".join(["Sequential<L{}, ".format(i) for i in range(1, n)])}L${n}${"".join([">" for i in range(1, n)])} where

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -322,17 +322,15 @@ final class LayerTests: XCTestCase {
 
     func testEmbedding() {
         var layer = Embedding<Float>(vocabularySize: 3, embeddingSize: 5)
-        var data = Tensor<Int32>(shape: [2, 3], scalars: [0, 1, 2, 1, 2, 2])
-        var input = EmbeddingInput(indices: data)
-        var output = layer.inferring(from: input)
+        var input = Tensor<Int32>(shape: [2, 3], scalars: [0, 1, 2, 1, 2, 2])
+        var output = layer(input)
         let expectedShape = TensorShape([2, 3, 5])
         XCTAssertEqual(output.shape, expectedShape)
 
         let pretrained = Tensor<Float>(shape:[2, 2], scalars: [0.4, 0.3, 0.2, 0.1])
         layer = Embedding<Float>(embeddings: pretrained)
-        data = Tensor<Int32>(shape: [2, 2], scalars: [0, 1, 1, 1])
-        input = EmbeddingInput(indices: data)
-        output = layer.inferring(from: input)
+        input = Tensor<Int32>(shape: [2, 2], scalars: [0, 1, 1, 1])
+        output = layer(input)
         let expected = Tensor<Float>([[[0.4, 0.3], [0.2, 0.1]], [[0.2, 0.1],[0.2, 0.1]]])
         XCTAssertEqual(output, expected)
     }

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -20,7 +20,7 @@ fileprivate struct Sigmoid<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer 
 
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return sigmoid(input)
+        sigmoid(input)
     }
 }
 


### PR DESCRIPTION
`Layer` currently requires `Input: Differentiable`. This results in boilerplate code for layers with non-differentiable inputs (e.g., embedding layers that take integer tensors as input). However, the constraint is required for chaining together layers (e.g., as done in the `Sequential` layer). This PR includes the following changes:

- Introduced a new `Module` protocol that is equivalent to the current `Layer` with the `Input: Differentiable` constraint removed and `callAsFunction` annotated with `@differentiable(wrt: self)` as opposed to `@differentiable(wrt: (self, input))`.
- Conformed `Layer` to `Module` with the additional `@differentiable(wrt: (self, input))` attribute on `callAsFunction`.
- Switched `Embedding` from conforming to `Layer` to conforming to `Module` and removed the boilerplate `EmbeddingInput` struct.
- Adapted `Sequential` so that it can work with both `Module`s and `Layer`s, with the constraint that `Module`s can only appear in the beginning of a sequential layer chain.