### PR TITLE
fix _vjpRsqrt and add test

### DIFF
--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -855,7 +855,7 @@ internal func _vjpRsqrt<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
     let value = rsqrt(x)
-    return (value, { v in -v / (2 * pow(x, 3 / 2)) })
+    return (value, { v in -v * 0.5 * pow(value, 3) })
 }
 
 /// Returns the exponential of the specified tensor element-wise.

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -855,7 +855,7 @@ internal func _vjpRsqrt<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
     let value = rsqrt(x)
-    return (value, { v in -v * 0.5 * pow(value, 3) })
+    return (value, { v in Raw.rsqrtGrad(value, dy: v) })
 }
 
 /// Returns the exponential of the specified tensor element-wise.

--- a/Tests/TensorFlowTests/OperatorTests/MathTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/MathTests.swift
@@ -59,6 +59,15 @@ final class MathOperatorTests: XCTestCase {
                                { x in root(x, 3) }, { x in Float.root(x, 3) })
     }
 
+    func testRsqrt() {
+        let x = Tensor<Double>([1, 0.25, 1.0 / 9.0, 0.0625, 0.04])
+        let target = Tensor<Double>([1, 2, 3, 4, 5]).sum()
+        let gradTarget = Tensor<Double>([-0.5,  -4.0, -13.5, -32.0, -62.5])
+        let (value, grad) = valueWithGradient(at: x) { rsqrt($0).sum() }
+        XCTAssertEqual(target, value)       
+        XCTAssertEqual(gradTarget, grad)
+    }
+
     func testLog1p() {
         let x = Tensor<Float>([1, 2, 3, 4, 5])
         let y = log1p(x)
@@ -410,6 +419,7 @@ final class MathOperatorTests: XCTestCase {
 
     static var allTests = [
         ("testElementaryFunctions", testElementaryFunctions),
+        ("testRsqrt", testRsqrt),
         ("testLog1p", testLog1p),
         ("testLog1mexp", testLog1mexp),
         ("testExpm1", testExpm1),


### PR DESCRIPTION
This fixes `_vjpRsqrt` again and adds a test.  The previous fix had `pow(x, 3 / 2)` which was doing division of integers and rounding 3 divided by 2 down to 1.

Rather than just make those floating point I changed the formula to match the [documentation of `Raw.rsqrtGrad` ](https://github.com/tensorflow/swift-apis/blob/master/Sources/TensorFlow/Bindings/RawOpsGenerated.swift).