### PR TITLE
Resolves TF-479 (Unexpected tensor printing)

### DIFF
--- a/Sources/TensorFlow/Core/ShapedArray.swift
+++ b/Sources/TensorFlow/Core/ShapedArray.swift
@@ -372,7 +372,7 @@ fileprivate extension _ShapedArrayProtocol
 
         // Return lines joined with separators.
         let lineSeparator = "," +
-            String(repeating: "\n", count: rank - 1) +
+            String(repeating: "\n", count: 1) +
             String(repeating: " ", count: indentLevel + 1)
         return elementDescriptions.enumerated().reduce(into: "[") { result, entry in
             let (i, elementDescription) = entry


### PR DESCRIPTION
Updated ShapedArray.swift file.

This resolved [TF-479 (Unexpected tensor printing)](https://bugs.swift.org/browse/TF-479).

Following is the result after the update :

2> import TensorFlow

3> let z: Tensor<Float> = [[[1,  2], [ 4,  5]], [[7,  8], [10, 11]]]
z: TensorFlow.Tensor<Float> =
[[[ 1.0,  2.0],
  [ 4.0,  5.0]],
 [[ 7.0,  8.0],
  [10.0, 11.0]]]

4> print(z)
[[[ 1.0,  2.0],
  [ 4.0,  5.0]],
 [[ 7.0,  8.0],
  [10.0, 11.0]]]