### PR TITLE
Added support for computing tensor moments.

### DIFF
--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -1195,6 +1195,29 @@ public func root<T: TensorFlowFloatingPoint>(_ x: Tensor<T>, _ n: Int) -> Tensor
     sign(x) * pow(abs(x), Tensor(T(1) / T(n)))
 }
 
+/// Returns the squared difference between `x` and `y`.
+/// - Returns: `(x - y) ^ 2`.
+@inlinable
+@differentiable(vjp: _vjpSquaredDifference where T: TensorFlowFloatingPoint)
+public func squaredDifference<T: TensorFlowNumeric>(_ x: Tensor<T>, _ y: Tensor<T>) -> Tensor<T> {
+    Raw.squaredDifference(x, y)
+}
+
+@inlinable
+internal func _vjpSquaredDifference<T: TensorFlowFloatingPoint>(
+    _ x: Tensor<T>,
+    _ y: Tensor<T>
+) -> (Tensor<T>, (Tensor<T>) -> (Tensor<T>, Tensor<T>)) {
+    (squaredDifference(x, y), { seed in
+        let lhsGrad = 2 * seed * (x - y)
+        let rhsGrad = -lhsGrad
+        let (lhsShape, rhsShape) = (x.shapeTensor, y.shapeTensor)
+        let (lhsAxes, rhsAxes) = Raw.broadcastGradientArgs(s0: lhsShape, s1: rhsShape)
+        return (lhsGrad.sum(squeezingAxes: lhsAxes).reshaped(toShape: lhsShape),
+                rhsGrad.sum(squeezingAxes: rhsAxes).reshaped(toShape: rhsShape))
+    })
+}
+
 /// Returns the element-wise maximum of two tensors.
 /// - Note: `max` supports broadcasting.
 @inlinable
@@ -2033,7 +2056,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
     @differentiable(wrt: self)
     func logSumExp(squeezingAxes axes: Int...) -> Tensor {
-        return logSumExp(squeezingAxes: axes)
+        logSumExp(squeezingAxes: axes)
     }
 
     /// Returns `log(exp(self).sum())`. The result is a scalar.
@@ -2044,7 +2067,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
     @differentiable(wrt: self)
     func logSumExp() -> Tensor {
-        return logSumExp(squeezingAxes: Array(0..<shape.rank))
+        logSumExp(squeezingAxes: Array(0..<shape.rank))
     }
 
     /// Returns `log(exp(self).sum(alongAxes: axes))`. The reduced dimensions are retained with 
@@ -2098,7 +2121,67 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
     @differentiable(wrt: self)
     func logSumExp(alongAxes axes: Int...) -> Tensor {
-        return logSumExp(alongAxes: axes)
+        logSumExp(alongAxes: axes)
+    }
+}
+
+/// Pair of first and second moments (i.e., mean and variance).
+/// - Note: This is needed because tuple types are not differentiable.
+public struct Moments<Scalar: TensorFlowFloatingPoint>: Differentiable {
+    public var mean: Tensor<Scalar>
+    public var variance: Tensor<Scalar>
+
+    @differentiable
+    public init(mean: Tensor<Scalar>, variance: Tensor<Scalar>) {
+        self.mean = mean
+        self.variance = variance
+    }
+}
+
+public extension Tensor where Scalar: TensorFlowFloatingPoint {
+    /// Returns the mean and variance of this tensor along the specified axes. The reduced
+    /// dimensions are removed.
+    @inlinable
+    @differentiable(wrt: self)
+    func moments(squeezingAxes axes: [Int]) -> Moments<Scalar> {
+        let mean = self.mean(alongAxes: axes)
+        let variance = squaredDifference(self, mean).mean(alongAxes: axes)
+        return Moments<Scalar>(
+            mean: mean.squeezingShape(at: axes),
+            variance: variance.squeezingShape(at: axes))
+    }
+
+    /// Returns the mean and variance of this tensor along the specified axes. The reduced
+    /// dimensions are removed.
+    @inlinable
+    @differentiable(wrt: self)
+    func moments(squeezingAxes axes: Int...) -> Moments<Scalar> {
+        moments(squeezingAxes: axes)
+    }
+
+    /// Returns the mean and variance of this tensor's elements.
+    @inlinable
+    @differentiable(wrt: self)
+    func moments() -> Moments<Scalar> {
+        moments(squeezingAxes: Array(0..<shape.rank))
+    }
+
+    /// Returns the mean and variance of this tensor along the specified axes. The reduced
+    /// dimensions are retained with value `1`.
+    @inlinable
+    @differentiable(wrt: self)
+    func moments(alongAxes axes: [Int]) -> Moments<Scalar> {
+        let mean = self.mean(alongAxes: axes)
+        let variance = squaredDifference(self, mean).mean(alongAxes: axes)
+        return Moments<Scalar>(mean: mean, variance: variance)
+    }
+
+    /// Returns the mean and variance of this tensor along the specified axes. The reduced
+    /// dimensions are retained with value `1`.
+    @inlinable
+    @differentiable(wrt: self)
+    func moments(alongAxes axes: Int...) -> Moments<Scalar> {
+        moments(alongAxes: axes)
     }
 }
 
@@ -2212,4 +2295,3 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
         return Raw.diagPart(self)
     }
 }
-

--- a/Sources/TensorFlow/Operators/NN.swift
+++ b/Sources/TensorFlow/Operators/NN.swift
@@ -28,51 +28,16 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     ///   - scale: The scale, also known as gamma.
     ///   - epsilon: A small value added to the denominator for numerical stability.
     @inlinable
-    @differentiable(wrt: (self, offset, scale), vjp: _vjpBatchNormalized)
+    @differentiable(wrt: (self, offset, scale))
     func batchNormalized(
         alongAxis axis: Int,
         offset: Tensor = Tensor(0),
         scale: Tensor = Tensor(1),
         epsilon: Scalar = 0.001
     ) -> Tensor {
-        let mean = self.mean(alongAxes: axis)
-        let squaredDiff: Tensor = Raw.squaredDifference(self, mean)
-        let variance = squaredDiff.mean(alongAxes: axis)
-        let inv = rsqrt(variance + epsilon) * scale
-        return self * inv + offset - mean * inv
-    }
-
-    // TODO: Verify that these calculations are correct.
-    @inlinable
-    internal func _vjpBatchNormalized(
-        alongAxis axis: Int,
-        offset: Tensor,
-        scale: Tensor,
-        epsilon: Scalar
-    ) -> (Tensor, (Tensor) -> (Tensor, Tensor, Tensor)) {
-        let value = batchNormalized(alongAxis: axis, offset: offset, scale: scale, epsilon: epsilon)
-        return (value, { v in
-            let mean = self.mean(alongAxes: axis)
-            let squaredDiff: Tensor = Raw.squaredDifference(self, mean)
-            let variance = squaredDiff.mean(alongAxes: axis)
-
-            let diff = self - mean
-            let inv = rsqrt(variance + epsilon)
-            let norm = diff * inv
-
-            let dNorm = v * scale
-            let dVariance = -(dNorm * diff).sum(alongAxes: axis) / 2 * TensorFlow.pow(inv, -3)
-            // Note: `dMean` is split into two lines to avoid the "compiler is unable to type-check
-            // this expression in reasonable time" error.
-            var dMean = (-dNorm * inv).sum(alongAxes: axis)
-            dMean = dMean + dVariance * (-diff * 2).mean(alongAxes: axis)
-            let dOffset = v.sum(alongAxes: axis)
-            let dScale = (norm * v).sum(alongAxes: axis)
-            let dim = Tensor(Tensor<Int32>(self.shapeTensor[axis]))
-            let tmp = (dNorm * inv) + (dVariance * 2 * dMean / dim)
-            let dSelf = tmp + (dMean / dim)
-            return (dSelf, dOffset, dScale)
-        })
+        let moments = self.moments(alongAxes: axis)
+        let inv = rsqrt(moments.variance + epsilon) * scale
+        return self * inv + offset - moments.mean * inv
     }
 }
 


### PR DESCRIPTION
This also removes the need for a custom VJP for batch normalization.