### PR TITLE
Standardized the loss functions.

### DIFF
--- a/Sources/TensorFlow/Loss.swift
+++ b/Sources/TensorFlow/Loss.swift
@@ -17,6 +17,7 @@
 /// - Parameters:
 ///   - predicted: Predicted outputs from a neural network.
 ///   - expected: Expected values, i.e. targets, that correspond to the correct output.
+///   - reduction: Reduction to apply on the computed element-wise loss values.
 @differentiable(wrt: predicted)
 public func l1Loss<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>,
@@ -31,6 +32,7 @@ public func l1Loss<Scalar: TensorFlowFloatingPoint>(
 /// - Parameters:
 ///   - predicted: Predicted outputs from a neural network.
 ///   - expected: Expected values, i.e. targets, that correspond to the correct output.
+///   - reduction: Reduction to apply on the computed element-wise loss values.
 @differentiable(wrt: predicted)
 public func l2Loss<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>,
@@ -102,6 +104,7 @@ public func meanAbsolutePercentageError<Scalar: TensorFlowFloatingPoint>(
 /// - Parameters:
 ///   - predicted: Predicted outputs from a neural network.
 ///   - expected: Expected values, i.e. targets, that correspond to the correct output.
+///   - reduction: Reduction to apply on the computed element-wise loss values.
 @differentiable(wrt: predicted)
 public func hingeLoss<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>,
@@ -116,6 +119,7 @@ public func hingeLoss<Scalar: TensorFlowFloatingPoint>(
 /// - Parameters:
 ///   - predicted: Predicted outputs from a neural network.
 ///   - expected: Expected values, i.e. targets, that correspond to the correct output.
+///   - reduction: Reduction to apply on the computed element-wise loss values.
 @differentiable(wrt: predicted)
 public func squaredHingeLoss<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>,
@@ -130,6 +134,7 @@ public func squaredHingeLoss<Scalar: TensorFlowFloatingPoint>(
 /// - Parameters:
 ///   - predicted: Predicted outputs from a neural network.
 ///   - expected: Expected values, i.e. targets, that correspond to the correct output.
+///   - reduction: Reduction to apply on the computed element-wise loss values.
 @differentiable(wrt: predicted)
 public func categoricalHingeLoss<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>,
@@ -141,11 +146,13 @@ public func categoricalHingeLoss<Scalar: TensorFlowFloatingPoint>(
     return reduction(max(Tensor(0), negative - positive + Tensor(1)))
 }
 
-/// Returns the logarithm of the hyperbolic cosine of the error between predictions and expectations.
+/// Returns the logarithm of the hyperbolic cosine of the error between predictions and
+/// expectations.
 ///
 /// - Parameters:
 ///   - predicted: Predicted outputs from a neural network.
 ///   - expected: Expected values, i.e. targets, that correspond to the correct output.
+///   - reduction: Reduction to apply on the computed element-wise loss values.
 @differentiable(wrt: predicted)
 public func logCoshLoss<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>,
@@ -161,6 +168,7 @@ public func logCoshLoss<Scalar: TensorFlowFloatingPoint>(
 /// - Parameters:
 ///   - predicted: Predicted outputs from a neural network.
 ///   - expected: Expected values, i.e. targets, that correspond to the correct output.
+///   - reduction: Reduction to apply on the computed element-wise loss values.
 @differentiable(wrt: predicted)
 public func poissonLoss<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>,
@@ -170,12 +178,13 @@ public func poissonLoss<Scalar: TensorFlowFloatingPoint>(
     reduction(predicted - expected * log(predicted))
 }
 
-/// Returns the Kullback-Leibler divergence (KL divergence) between between expectations and predictions.
-/// Given two distributions `p` and `q`, KL divergence computes `p * log(p / q)`.
+/// Returns the Kullback-Leibler divergence (KL divergence) between between expectations and
+/// predictions. Given two distributions `p` and `q`, KL divergence computes `p * log(p / q)`.
 ///
 /// - Parameters:
 ///   - predicted: Predicted outputs from a neural network.
 ///   - expected: Expected values, i.e. targets, that correspond to the correct output.
+///   - reduction: Reduction to apply on the computed element-wise loss values.
 @differentiable(wrt: predicted)
 public func kullbackLeiblerDivergence<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>,
@@ -190,6 +199,7 @@ public func kullbackLeiblerDivergence<Scalar: TensorFlowFloatingPoint>(
 /// - Parameters:
 ///   - logits: One-hot encoded outputs from a neural network.
 ///   - labels: Indices (zero-indexed) of the correct outputs.
+///   - reduction: Reduction to apply on the computed element-wise loss values.
 @differentiable(wrt: logits)
 public func softmaxCrossEntropy<Scalar: TensorFlowFloatingPoint>(
     logits: Tensor<Scalar>,
@@ -223,6 +233,7 @@ func _vjpSoftmaxCrossEntropyHelper<Scalar: TensorFlowFloatingPoint>(
 ///   - logits: Unscaled log probabilities from a neural network.
 ///   - probabilities: Probability values that correspond to the correct output. Each row must be a
 ///                    valid probability distribution.
+///   - reduction: Reduction to apply on the computed element-wise loss values.
 @differentiable(wrt: logits)
 public func softmaxCrossEntropy<Scalar: TensorFlowFloatingPoint>(
     logits: Tensor<Scalar>,
@@ -258,6 +269,7 @@ func _vjpSoftmaxCrossEntropyHelper<Scalar: TensorFlowFloatingPoint>(
 /// - Parameters:
 ///   - logits: The unscaled output of a neural network.
 ///   - labels: Integer values that correspond to the correct output.
+///   - reduction: Reduction to apply on the computed element-wise loss values.
 @differentiable(wrt: logits)
 public func sigmoidCrossEntropy<Scalar: TensorFlowFloatingPoint>(
     logits: Tensor<Scalar>,

--- a/Sources/TensorFlow/Loss.swift
+++ b/Sources/TensorFlow/Loss.swift
@@ -50,7 +50,7 @@ public func meanAbsoluteError<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>,
     expected: Tensor<Scalar>
 ) -> Tensor<Scalar> {
-    l1Loss(predicted: predicted, expected: expected).mean()
+    l1Loss(predicted: predicted, expected: expected, reduction: { $0.mean() })
 }
 
 /// Returns the mean squared error between predictions and expectations.
@@ -63,7 +63,7 @@ public func meanSquaredError<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>,
     expected: Tensor<Scalar>
 ) -> Tensor<Scalar> {
-    l2Loss(predicted: predicted, expected: expected).mean()
+    l2Loss(predicted: predicted, expected: expected, reduction: { $0.mean() })
 }
 
 /// Returns the mean squared logarithmic error between predictions and expectations.
@@ -81,7 +81,7 @@ public func meanSquaredLogarithmicError<Scalar: TensorFlowFloatingPoint>(
 ) -> Tensor<Scalar> {
     let logPredicted = log(max(predicted, Tensor(0)) + 1)
     let logExpected = log(max(expected, Tensor(0)) + 1)
-    return l2Loss(predicted: logPredicted, expected: logExpected).mean()
+    return l2Loss(predicted: logPredicted, expected: logExpected, reduction: { $0.mean() })
 }
 
 /// Returns the mean absolute percentage error between predictions and expectations.

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -1522,8 +1522,10 @@ public extension Tensor where Scalar: Numeric & Comparable {
     /// - Parameter axes: The dimensions to reduce.
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func min(alongAxes axes: [Int]) -> Tensor {
-        let axes = axes.map(Int32.init)
+        // TODO(TF-433): Remove workaround for differentiating `map`.
+        let axes = {axes.map(Int32.init)}()
         return min(alongAxes: Tensor<Int32>(axes))
     }
 
@@ -1532,6 +1534,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
     /// - Parameter axes: The dimensions to reduce.
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func min(alongAxes axes: Int...) -> Tensor {
         min(alongAxes: axes)
     }
@@ -1551,8 +1554,10 @@ public extension Tensor where Scalar: Numeric & Comparable {
     /// - Parameter axes: The dimensions to reduce.
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func max(alongAxes axes: [Int]) -> Tensor {
-        let axes = axes.map(Int32.init)
+        // TODO(TF-433): Remove workaround for differentiating `map`.
+        let axes = {axes.map(Int32.init)}()
         return max(alongAxes: Tensor<Int32>(axes))
     }
 
@@ -1561,6 +1566,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
     /// - Parameter axes: The dimensions to reduce.
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func max(alongAxes axes: Int...) -> Tensor {
         max(alongAxes: axes)
     }

--- a/Tests/TensorFlowTests/LossTests.swift
+++ b/Tests/TensorFlowTests/LossTests.swift
@@ -19,17 +19,17 @@ final class LossTests: XCTestCase {
     func testL1Loss() {
         let predicted = Tensor<Float>([1, 2, 3, 4])
         let expected = Tensor<Float>([0.1, 0.2, 0.3, 0.4])
-        let loss = l1Loss(predicted: predicted, expected: expected)
+        let loss = l1Loss(predicted: predicted, expected: expected).sum()
         let expectedLoss: Float = 9.0
-        assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
+        assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
 
     func testL2Loss() {
         let predicted = Tensor<Float>([1, 2, 3, 4])
         let expected = Tensor<Float>([0.5, 1.5, 2.5, 3.5])
-        let loss = l2Loss(predicted: predicted, expected: expected)
+        let loss = l2Loss(predicted: predicted, expected: expected).sum()
         let expectedLoss: Float = 1.0
-        assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
+        assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
 
     func testMeanSquaredErrorLoss() {
@@ -40,7 +40,7 @@ final class LossTests: XCTestCase {
 
         let loss = meanSquaredError(predicted: predicted, expected: expected)
         let expectedLoss: Float = 23.324999
-        assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
+        assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
 
     func testMeanSquaredLogarithmicError() {
@@ -51,7 +51,7 @@ final class LossTests: XCTestCase {
 
         let loss = meanSquaredLogarithmicError(predicted: predicted, expected: expected)
         let expectedLoss: Float = 2.1312442
-        assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
+        assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
 
     func testMeanAbsoluteError() {
@@ -62,7 +62,7 @@ final class LossTests: XCTestCase {
 
         let loss = meanAbsoluteError(predicted: predicted, expected: expected)
         let expectedLoss: Float = 4.25
-        assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
+        assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
 
     func testMeanAbsolutePercentageError() {
@@ -71,7 +71,7 @@ final class LossTests: XCTestCase {
 
         let loss = meanAbsolutePercentageError(predicted: predicted, expected: expected)
         let expectedLoss: Float = 900.0
-        assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
+        assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
 
     func testMeanSquaredErrorGrad() {
@@ -90,7 +90,7 @@ final class LossTests: XCTestCase {
             at: predicted,
             in: { meanSquaredError(predicted: $0, expected: expected) })
 
-        assertElementsEqual(expected: expectedGradients, actual: gradients)
+        assertEqual(gradients, expectedGradients, accuracy: 1e-6)
     }
 
     func testHingeLoss() {
@@ -99,50 +99,50 @@ final class LossTests: XCTestCase {
             shape: [2, 4],
             scalars: [0.1, 0.2, 0.3, 0.4, 0.4, 0.3, 0.2, 0.1])
 
-        let loss = hingeLoss(predicted: predicted, expected: expected)
+        let loss = hingeLoss(predicted: predicted, expected: expected).mean()
         let expectedLoss: Float = 0.225
-        assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
+        assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
 
     func testSquaredHingeLoss() {
         let predicted = Tensor<Float>([1, 2, 3, 4, 5, 6, 7, 8])
         let expected = Tensor<Float>([0.5, 1, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0])
-        let loss = squaredHingeLoss(predicted: predicted, expected: expected)
+        let loss = squaredHingeLoss(predicted: predicted, expected: expected).mean()
         let expectedLoss: Float = 0.03125
-        assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
+        assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
 
     func testCategoricalHingeLoss() {
         let predicted = Tensor<Float>([3, 4 ,5])
         let expected = Tensor<Float>([0.3, 0.4, 0.3])
 
-        let loss = categoricalHingeLoss(predicted: predicted, expected: expected)
+        let loss = categoricalHingeLoss(predicted: predicted, expected: expected).mean()
         let expectedLoss: Float = 0.5
-        assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
+        assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
 
     func testLogCoshLoss() {
         let predicted = Tensor<Float>([0.2, 0.3, 0.4])
         let expected = Tensor<Float>([1.0, 4.0, 3.0])
-        let loss = logCoshLoss(predicted: predicted, expected: expected)
+        let loss = logCoshLoss(predicted: predicted, expected: expected).mean()
         let expectedLoss: Float = 1.7368573
-        assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
+        assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
 
     func testPoissonLoss() {
         let predicted = Tensor<Float>([0.1, 0.2, 0.3])
         let expected = Tensor<Float>([1, 2, 3])
-        let loss = poissonLoss(predicted: predicted, expected: expected)
+        let loss = poissonLoss(predicted: predicted, expected: expected).mean()
         let expectedLoss: Float = 3.2444599
-        assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
+        assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
 
     func testKullbackLeiblerDivergence() {
         let predicted = Tensor<Float>([0.2, 0.3, 0.4])
         let expected = Tensor<Float>([1.0, 4.0, 3.0])
-        let loss = kullbackLeiblerDivergence(predicted: predicted, expected: expected)
+        let loss = kullbackLeiblerDivergence(predicted: predicted, expected: expected).sum()
         let expectedLoss: Float = 18.015217
-        assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
+        assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
 
     func testSoftmaxCrossEntropyWithProbabilitiesLoss() {
@@ -151,10 +151,10 @@ final class LossTests: XCTestCase {
             shape: [2, 4],
             scalars: [0.1, 0.2, 0.3, 0.4, 0.4, 0.3, 0.2, 0.1])
 
-        let loss = softmaxCrossEntropy(logits: logits, probabilities: labels)
+        let loss = softmaxCrossEntropy(logits: logits, probabilities: labels).mean()
         // Loss for two rows are 1.44019 and 2.44019 respectively.
         let expectedLoss: Float = (1.44019 + 2.44019) / 2.0
-        assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
+        assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
 
     func testSoftmaxCrossEntropyWithProbabilitiesGrad() {
@@ -178,8 +178,8 @@ final class LossTests: XCTestCase {
         let expectedGradients = expectedGradientsBeforeMean / Float(logits.shape[0])
         let gradients = gradient(
             at: logits,
-            in: { softmaxCrossEntropy(logits: $0, probabilities: labels) })
-        assertElementsEqual(expected: expectedGradients, actual: gradients)
+            in: { softmaxCrossEntropy(logits: $0, probabilities: labels).mean() })
+        assertEqual(gradients, expectedGradients, accuracy: 1e-6)
     }
 
     func testSigmoidCrossEntropyLoss() {
@@ -191,9 +191,9 @@ final class LossTests: XCTestCase {
             shape: [2, 4],
             scalars: [0, 0, 1, 0, 0, 1, 0.5, 1])
 
-        let loss = sigmoidCrossEntropy(logits: logits, labels: labels)
+        let loss = sigmoidCrossEntropy(logits: logits, labels: labels).mean()
         let expectedLoss: Float = 0.7909734
-        assertElementsEqual(expected: Tensor(expectedLoss), actual: loss)
+        assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
 
     func testSigmoidCrossEntropyGrad() {
@@ -215,23 +215,8 @@ final class LossTests: XCTestCase {
         let expectedGradients = expectedGradientsBeforeMean / Float(logits.scalars.count)
         let gradients = gradient(
             at: logits,
-            in: { sigmoidCrossEntropy(logits: $0, labels: labels) })
-        assertElementsEqual(expected: expectedGradients, actual: gradients)
-    }
-
-    func assertElementsEqual(
-        expected: Tensor<Float>,
-        actual: Tensor<Float>,
-        accuracy: Float = 1e-6
-    ) {
-        XCTAssertEqual(expected.shape, actual.shape, "Shape mismatch.")
-        for (index, expectedElement) in expected.scalars.enumerated() {
-            let actualElement = actual.scalars[index]
-            XCTAssertEqual(
-                expectedElement, actualElement, accuracy: accuracy,
-                "Found difference at \(index), " +
-                "expected: \(expectedElement), actual: \(actualElement).")
-        }
+            in: { sigmoidCrossEntropy(logits: $0, labels: labels).mean() })
+        assertEqual(gradients, expectedGradients, accuracy: 1e-6)
     }
 
     static var allTests = [

--- a/Tests/TensorFlowTests/LossTests.swift
+++ b/Tests/TensorFlowTests/LossTests.swift
@@ -19,7 +19,7 @@ final class LossTests: XCTestCase {
     func testL1Loss() {
         let predicted = Tensor<Float>([1, 2, 3, 4])
         let expected = Tensor<Float>([0.1, 0.2, 0.3, 0.4])
-        let loss = l1Loss(predicted: predicted, expected: expected).sum()
+        let loss = l1Loss(predicted: predicted, expected: expected)
         let expectedLoss: Float = 9.0
         assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
@@ -27,7 +27,7 @@ final class LossTests: XCTestCase {
     func testL2Loss() {
         let predicted = Tensor<Float>([1, 2, 3, 4])
         let expected = Tensor<Float>([0.5, 1.5, 2.5, 3.5])
-        let loss = l2Loss(predicted: predicted, expected: expected).sum()
+        let loss = l2Loss(predicted: predicted, expected: expected)
         let expectedLoss: Float = 1.0
         assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
@@ -99,7 +99,7 @@ final class LossTests: XCTestCase {
             shape: [2, 4],
             scalars: [0.1, 0.2, 0.3, 0.4, 0.4, 0.3, 0.2, 0.1])
 
-        let loss = hingeLoss(predicted: predicted, expected: expected).mean()
+        let loss = hingeLoss(predicted: predicted, expected: expected)
         let expectedLoss: Float = 0.225
         assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
@@ -107,7 +107,7 @@ final class LossTests: XCTestCase {
     func testSquaredHingeLoss() {
         let predicted = Tensor<Float>([1, 2, 3, 4, 5, 6, 7, 8])
         let expected = Tensor<Float>([0.5, 1, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0])
-        let loss = squaredHingeLoss(predicted: predicted, expected: expected).mean()
+        let loss = squaredHingeLoss(predicted: predicted, expected: expected)
         let expectedLoss: Float = 0.03125
         assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
@@ -116,7 +116,7 @@ final class LossTests: XCTestCase {
         let predicted = Tensor<Float>([3, 4 ,5])
         let expected = Tensor<Float>([0.3, 0.4, 0.3])
 
-        let loss = categoricalHingeLoss(predicted: predicted, expected: expected).mean()
+        let loss = categoricalHingeLoss(predicted: predicted, expected: expected)
         let expectedLoss: Float = 0.5
         assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
@@ -124,7 +124,7 @@ final class LossTests: XCTestCase {
     func testLogCoshLoss() {
         let predicted = Tensor<Float>([0.2, 0.3, 0.4])
         let expected = Tensor<Float>([1.0, 4.0, 3.0])
-        let loss = logCoshLoss(predicted: predicted, expected: expected).mean()
+        let loss = logCoshLoss(predicted: predicted, expected: expected)
         let expectedLoss: Float = 1.7368573
         assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
@@ -132,7 +132,7 @@ final class LossTests: XCTestCase {
     func testPoissonLoss() {
         let predicted = Tensor<Float>([0.1, 0.2, 0.3])
         let expected = Tensor<Float>([1, 2, 3])
-        let loss = poissonLoss(predicted: predicted, expected: expected).mean()
+        let loss = poissonLoss(predicted: predicted, expected: expected)
         let expectedLoss: Float = 3.2444599
         assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
@@ -140,7 +140,7 @@ final class LossTests: XCTestCase {
     func testKullbackLeiblerDivergence() {
         let predicted = Tensor<Float>([0.2, 0.3, 0.4])
         let expected = Tensor<Float>([1.0, 4.0, 3.0])
-        let loss = kullbackLeiblerDivergence(predicted: predicted, expected: expected).sum()
+        let loss = kullbackLeiblerDivergence(predicted: predicted, expected: expected)
         let expectedLoss: Float = 18.015217
         assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
@@ -151,7 +151,7 @@ final class LossTests: XCTestCase {
             shape: [2, 4],
             scalars: [0.1, 0.2, 0.3, 0.4, 0.4, 0.3, 0.2, 0.1])
 
-        let loss = softmaxCrossEntropy(logits: logits, probabilities: labels).mean()
+        let loss = softmaxCrossEntropy(logits: logits, probabilities: labels)
         // Loss for two rows are 1.44019 and 2.44019 respectively.
         let expectedLoss: Float = (1.44019 + 2.44019) / 2.0
         assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
@@ -178,7 +178,7 @@ final class LossTests: XCTestCase {
         let expectedGradients = expectedGradientsBeforeMean / Float(logits.shape[0])
         let gradients = gradient(
             at: logits,
-            in: { softmaxCrossEntropy(logits: $0, probabilities: labels).mean() })
+            in: { softmaxCrossEntropy(logits: $0, probabilities: labels) })
         assertEqual(gradients, expectedGradients, accuracy: 1e-6)
     }
 
@@ -191,7 +191,7 @@ final class LossTests: XCTestCase {
             shape: [2, 4],
             scalars: [0, 0, 1, 0, 0, 1, 0.5, 1])
 
-        let loss = sigmoidCrossEntropy(logits: logits, labels: labels).mean()
+        let loss = sigmoidCrossEntropy(logits: logits, labels: labels)
         let expectedLoss: Float = 0.7909734
         assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
@@ -215,7 +215,7 @@ final class LossTests: XCTestCase {
         let expectedGradients = expectedGradientsBeforeMean / Float(logits.scalars.count)
         let gradients = gradient(
             at: logits,
-            in: { sigmoidCrossEntropy(logits: $0, labels: labels).mean() })
+            in: { sigmoidCrossEntropy(logits: $0, labels: labels) })
         assertEqual(gradients, expectedGradients, accuracy: 1e-6)
     }
 

--- a/Tests/TensorFlowTests/LossTests.swift
+++ b/Tests/TensorFlowTests/LossTests.swift
@@ -108,7 +108,7 @@ final class LossTests: XCTestCase {
         let predicted = Tensor<Float>([1, 2, 3, 4, 5, 6, 7, 8])
         let expected = Tensor<Float>([0.5, 1, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0])
         let loss = squaredHingeLoss(predicted: predicted, expected: expected)
-        let expectedLoss: Float = 0.03125
+        let expectedLoss: Float = 0.00390625
         assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
     }
 


### PR DESCRIPTION
This PR makes the following changes:

1. Removed reductions (i.e., `mean()` or `sum()`) from the loss functions. The are two main reasons for that: (i) they were being used inconsistently (sometimes sum was used and sometimes mean) and users might run into issues with their learning rates expecting mean or sum (it's better for them to be explicitly aware of what reduction they're using to reduce the chance of bugs), and (ii) they are irreversible but sometimes the user may want the element-wise loss (e.g., `softmaxCrossEntropy` is also the probability density function of the Categorical distribution and we might want to use it as such -- in this case the reduction does not make sense).
2. Added `@differentiable` to some instances of `Tensor.max(...)` and `Tensor.min(...)` where it was missing.
3. Removed the `assertElementsEqual` helper from the loss tests file and switched to using the standard helper we have for all our test suites.

Note that I kept the `mean()` reduction only for `meanAbsoluteError`, `meanSquaredError`, `meanSquaredLogarithmicError`, and `meanAbsolutePercentageError` where it is explicit from the name.

After this PR, the `squaredHingeLoss` function is rendered kind of useless as it is just defined as `hingeLoss(...).squared()` so we may want to remove it. Also, for a lot of these functions, I'm not sure if `Loss.swift` is the right place; maybe we should move all of them to `Math.swift` since they are pretty general math computations, some of which can be used for many other things than losses (e.g., the example mentioned above about `softmaxCrossEntropy`).

This will require a minimal set of changes to existing code. Namely, wherever a loss function is used, `.mean()` or `.sum()` will need to be added, depending on which loss function that is. This will allow behavior to stay the same after the update.

@rxwei @dan-zheng what do you guys think about this?