### PR TITLE
Remove `static var one` from `PointwiseMultiplicative`.

### DIFF
--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -569,10 +569,6 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
 //===------------------------------------------------------------------------------------------===//
 
 extension Tensor: PointwiseMultiplicative where Scalar: Numeric {
-    /// The scalar one tensor.
-    @inlinable
-    public static var one: Tensor { Tensor(1) }
-
     /// Returns the element-wise reciprocal of `self`.
     @inlinable
     public var reciprocal: Tensor { 1 / self }


### PR DESCRIPTION
Friend PR: https://github.com/apple/swift/pull/26120