### PR TITLE
Add '.swift-format'.

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,14 @@
+{
+    "version": 1,
+    "lineLength": 100,
+    "indentation": {
+        "spaces": 4
+    },
+    "maximumBlankLines": 1,
+    "respectsExistingLineBreaks": true,
+    "blankLineBetweenMembers": {
+        "ignoreSingleLineProperties": true
+    },
+    "lineBreakBeforeControlFlowKeywords": false,
+    "lineBreakBeforeEachArgument": false
+}


### PR DESCRIPTION
Add a `swift-format` configuration.

```json
{
    "version": 1,
    "lineLength": 100,
    "indentation": {
        "spaces": 4
    },
    "maximumBlankLines": 1,
    "respectsExistingLineBreaks": true,
    "blankLineBetweenMembers": {
        "ignoreSingleLineProperties": true
    },
    "lineBreakBeforeControlFlowKeywords": false,
    "lineBreakBeforeEachArgument": false
}
```

Note: `swift-format` built using swift:master currently has weird behavior on functions with tensorflow-branch-only attributes such as `@differentiable`. Use with caution. A potential solution is to build `swift-format` with a Swift for TensorFlow toolchain, but we currently need to update our branch to support building `swift-format`.