### PR TITLE
Use multiple `TFE_OpAddInput` calls instead of one `TFE_OpAddIputList`

### DIFF
--- a/Sources/TensorFlow/Bindings/EagerExecution.swift
+++ b/Sources/TensorFlow/Bindings/EagerExecution.swift
@@ -70,8 +70,8 @@ internal struct TFE_Op: TFTensorOperation {
         defer { buffer.deallocate() }
         let pointer = UnsafeMutablePointer<OpaquePointer?>(buffer.baseAddress)
         input._unpackTensorHandles(into: buffer.baseAddress)
-        for i in 0..<count {
-            TFE_OpAddInput(op, buffer[Int(i)], status)
+        for i in 0..<Int(count) {
+            TFE_OpAddInput(op, buffer[i], status)
             checkOk(status)
         }
     }

--- a/Sources/TensorFlow/Bindings/EagerExecution.swift
+++ b/Sources/TensorFlow/Bindings/EagerExecution.swift
@@ -70,8 +70,10 @@ internal struct TFE_Op: TFTensorOperation {
         defer { buffer.deallocate() }
         let pointer = UnsafeMutablePointer<OpaquePointer?>(buffer.baseAddress)
         input._unpackTensorHandles(into: buffer.baseAddress)
-        TFE_OpAddInputList(op, pointer, count, status)
-        // TODO: checkOk(status)
+        for i in 0..<count {
+            TFE_OpAddInput(op, buffer[Int(i)], status)
+            checkOk(status)
+        }
     }
 
     @inlinable @inline(__always)

--- a/Sources/TensorFlow/Bindings/EagerExecution.swift.gyb
+++ b/Sources/TensorFlow/Bindings/EagerExecution.swift.gyb
@@ -70,8 +70,8 @@ internal struct TFE_Op: TFTensorOperation {
         defer { buffer.deallocate() }
         let pointer = UnsafeMutablePointer<OpaquePointer?>(buffer.baseAddress)
         input._unpackTensorHandles(into: buffer.baseAddress)
-        for i in 0..<count {
-            TFE_OpAddInput(op, buffer[Int(i)], status)
+        for i in 0..<Int(count) {
+            TFE_OpAddInput(op, buffer[i], status)
             checkOk(status)
         }
     }

--- a/Sources/TensorFlow/Bindings/EagerExecution.swift.gyb
+++ b/Sources/TensorFlow/Bindings/EagerExecution.swift.gyb
@@ -70,8 +70,10 @@ internal struct TFE_Op: TFTensorOperation {
         defer { buffer.deallocate() }
         let pointer = UnsafeMutablePointer<OpaquePointer?>(buffer.baseAddress)
         input._unpackTensorHandles(into: buffer.baseAddress)
-        TFE_OpAddInputList(op, pointer, count, status)
-        // TODO: checkOk(status)
+        for i in 0..<count {
+            TFE_OpAddInput(op, buffer[Int(i)], status)
+            checkOk(status)
+        }
     }
 
     @inlinable @inline(__always)
@@ -271,7 +273,12 @@ internal struct TFE_Op: TFTensorOperation {
         _ name: String,
         _ value: (In) -> Out
     ) {
-        _tffunc(value).utf8CString.withUnsafeBufferPointer { buffer in
+        updateAttribute(name, _TensorFunctionPointer(name: _tffunc(value)))
+    }
+
+    @inlinable @inline(__always)
+    internal func updateAttribute(_ name: String, _ value: _TensorFunctionPointer) {
+        value.name.utf8CString.withUnsafeBufferPointer { buffer in
             // utf8CString is null-terminated; TFE_OpSetAttrFunctionName wants
             // non-null-terminated.
             TFE_OpSetAttrFunctionName(op, name, buffer.baseAddress, buffer.count - 1)

--- a/Tests/TensorFlowTests/OperatorTests/DatasetTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/DatasetTests.swift
@@ -125,7 +125,6 @@ final class DatasetTests: XCTestCase {
         XCTAssertEqual(iterator.next()!.scalars, [4])
     }
 
-/*
     func testDoubleValueDatasetIteration() {
         let scalars1 = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
         let scalars2 = Tensor<Int32>(rangeFrom: 5, to: 10, stride: 1)
@@ -138,7 +137,6 @@ final class DatasetTests: XCTestCase {
             i += 1
         }
     }
-*/
 
     static var allTests = [
         ("testMultiValue", testMultiValue),
@@ -149,8 +147,6 @@ final class DatasetTests: XCTestCase {
         ("testParallelMap", testParallelMap),
         ("testMapToDifferentType", testMapToDifferentType),
         ("testSingleValueBatched", testSingleValueBatched),
-        // Currently broken even in TensorFlow ...
-        // This will be easier to fix once everything is moved ...
-        // ("testDoubleValueDatasetIteration", testDoubleValueDatasetIteration),
+        ("testDoubleValueDatasetIteration", testDoubleValueDatasetIteration),
     ]
 }


### PR DESCRIPTION
A bug in `TFE_OpAddInputList` implementation is causing `Raw.ZipDataset` test to fail. This PR replaces a single call to `TFE_OpAddInputList` with a  sequence of calls to `TFE_OpAddInput`, which has the same effect as `TFE_OpAddInput` implementation works for `Raw.ZipDataset`.

This PR also fixes the inconsistency between `EagerExecution.swift.gyb` and `EagerExecution.swift`.