### PR TITLE
add __owned in _vjpScalarInit

### DIFF
--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -196,7 +196,7 @@ public extension Tensor {
 
 internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
-    static func _vjpScalarInit(_ value: Scalar) -> (Tensor, (Tensor) -> Scalar) {
+    static func _vjpScalarInit(_ value: __owned Scalar) -> (Tensor, (Tensor) -> Scalar) {
         return (Tensor(value), { $0.scalarized() })
     }
 }


### PR DESCRIPTION
Workaround for [TF-677](https://bugs.swift.org/browse/TF-667) as in #378.