### PR TITLE
Adds a mechanism to extract traces explicitly using LazyTensor.

### DIFF
--- a/Sources/TensorFlow/Core/LazyTensorTrace.swift
+++ b/Sources/TensorFlow/Core/LazyTensorTrace.swift
@@ -176,7 +176,7 @@ class LazyTensorTraceBuilder {
         return placeholder
     }
 
-    private func makePlaceholderTensor(with handle: TFETensorHandle) -> LazyTensorHandle {
+    private func makePlaceholderTensor(handle: TFETensorHandle) -> LazyTensorHandle {
         let cTensorHandle = handle._cTensorHandle
         let dtype = TensorDataType(TFE_TensorHandleDataType(cTensorHandle))
         let placeholder = Self.makePlaceholder(dataType: dtype)
@@ -195,7 +195,7 @@ class LazyTensorTraceBuilder {
         }
         return asConst || neverPromoteConstants
             ? makeConstTensor(with: handle)
-            : makePlaceholderTensor(with: handle)
+            : makePlaceholderTensor(handle: handle)
     }
 
     /// Return the original tensor or a concrete tensor that is promoted to a

--- a/Sources/TensorFlow/Core/LazyTensorTrace.swift
+++ b/Sources/TensorFlow/Core/LazyTensorTrace.swift
@@ -108,7 +108,8 @@ class LazyTensorTraceBuilder {
             precondition(lazyOp != nil, "Found a non-lazy tensor in output when tracing.")
             return lazyOp!
         }
-        let outputIDs = Set<ObjectIdentifier>(outputLazyOperations.map { ObjectIdentifier($0) })
+        let outputIDs = Set<ObjectIdentifier>(
+            outputLazyOperations.lazy.map { ObjectIdentifier($0) })
 
         // Create the builder and get the trace.
         let builder = LazyTensorTraceBuilder()
@@ -158,7 +159,7 @@ class LazyTensorTraceBuilder {
         return LazyTensorHandle(_lazy: result, index: 0)
     }
 
-    /// Extract the LazyTensorOperation (if any) for this handle.
+    /// Returns the `LazyTensorOperation`, if any, for this handle.
     private static func lazyTensorOperation(_ handle: _AnyTensorHandle) -> LazyTensorOperation? {
         guard let lazyTensorHandle = handle as? LazyTensorHandle else {
             return nil
@@ -198,7 +199,7 @@ class LazyTensorTraceBuilder {
             : makePlaceholderTensor(handle: handle)
     }
 
-    /// Return the original tensor or a concrete tensor that is promoted to a
+    /// Returns the original tensor or a concrete tensor that is promoted to a
     /// placeholder input.
     private func maybePromotedTensor(_ lazyHandle: LazyTensorHandle) -> LazyTensorHandle {
         switch lazyHandle.handle {

--- a/Sources/TensorFlow/Core/LazyTensorTrace.swift
+++ b/Sources/TensorFlow/Core/LazyTensorTrace.swift
@@ -161,10 +161,7 @@ class LazyTensorTraceBuilder {
 
     /// Returns the `LazyTensorOperation`, if any, for this handle.
     private static func lazyTensorOperation(_ handle: _AnyTensorHandle) -> LazyTensorOperation? {
-        guard let lazyTensorHandle = handle as? LazyTensorHandle else {
-            return nil
-        }
-        guard case let .symbolic(lazyOp, _, _)  = lazyTensorHandle.handle else {
+        guard case let .symbolic(lazyOp, _, _)? = (handle as? LazyTensorHandle)?.handle else {
             return nil
         }
         return lazyOp

--- a/Sources/TensorFlow/Core/LazyTensorTrace.swift
+++ b/Sources/TensorFlow/Core/LazyTensorTrace.swift
@@ -121,14 +121,17 @@ class LazyTensorTraceBuilder {
         return LazyTensorHandle(_lazy: result, index: 0)
     }
 
-    private func makePlaceholderTensor(
-        with handle: TFETensorHandle
-    ) -> LazyTensorHandle {
+    private static func makePlaceholder(with dtype: TensorDataType) -> LazyTensorOperation {
+        let placeholder = LazyTensorOperation("Placeholder", 1)
+        let dtypeAttr = LazyTensorOperation.Attribute.tensorDataTypeValue(dtype)
+        placeholder.attributes = ["dtype": dtypeAttr]
+        return placeholder
+    }
+
+    private func makePlaceholderTensor(with handle: TFETensorHandle) -> LazyTensorHandle {
         let cTensorHandle = handle._cTensorHandle
         let dtype = TensorDataType(TFE_TensorHandleDataType(cTensorHandle))
-        let dtypeAttr = LazyTensorOperation.Attribute.tensorDataTypeValue(dtype)
-        let placeholder = LazyTensorOperation("Placeholder", 1)
-        placeholder.attributes = ["dtype": dtypeAttr]
+        let placeholder = Self.makePlaceholder(with: dtype)
         updateOperationAndCache(ObjectIdentifier(handle), placeholder)
         inputs.append(placeholder)
         inputValues.append(handle)

--- a/Tests/TensorFlowTests/LazyTensorExplicitTraceTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorExplicitTraceTests.swift
@@ -1,0 +1,80 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import TensorFlow
+import CTensorFlow
+
+final class LazyTensorExplicitTraceTests: XCTestCase {
+    override class func setUp() {
+        super.setUp()
+        _RuntimeConfig.useLazyTensor = true
+    }
+
+    override class func tearDown() {
+        super.tearDown()
+        _RuntimeConfig.useLazyTensor = false
+    }
+
+    func testSingleInput() {
+        func fn(x: Tensor<Float>) -> Tensor<Float> { return x + x }
+        let trace = LazyTensorTraceBuilder.trace(fn)
+        XCTAssertEqual(trace.description,
+            """
+            lazyTrace_2(%0: float) -> (%1) {
+              %1 = Add[T: float](%0, %0)
+            }
+            """)
+        let outputs = runTrace(trace: trace, input: Tensor<Float>(10.0))
+        XCTAssertEqual(outputs.count, 1)
+        XCTAssertEqual(outputs[0].valueDescription, "20.0")
+    }
+
+    func testTensorGroupInputOutputs() {
+        typealias TensorFloatInt32Pair = Zip2TensorGroup<Tensor<Float>, Tensor<Int32>>
+        typealias TensorInt32FloatPair = Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>
+        func fn(input: TensorFloatInt32Pair) -> TensorInt32FloatPair {
+            return TensorInt32FloatPair(input.second * 4, input.first + 3.0)
+        }
+        let trace = LazyTensorTraceBuilder.trace(fn)
+        XCTAssertEqual(trace.description,
+            """
+            lazyTrace_6(%0: float, %1: int32) -> (%3, %5) {
+              %2 = Const[dtype: int32, value: 4]()
+              %3 = Mul[T: int32](%1, %2)
+              %4 = Const[dtype: float, value: 3.0]()
+              %5 = Add[T: float](%0, %4)
+            }
+            """)
+        let outputs = runTrace(
+            trace: trace,
+            input: TensorFloatInt32Pair(Tensor<Float>(10.0), Tensor<Int32>(5)))
+        XCTAssertEqual(outputs.count, 2)
+        XCTAssertEqual(outputs[0].valueDescription, "20")
+        XCTAssertEqual(outputs[1].valueDescription, "13.0")
+    }
+
+    private func runTrace(trace: LazyTensorTrace, input: TensorGroup) -> [TFETensorHandle] {
+        let tffunc = TFFunction(trace: trace)
+        let inputHandles = input._tensorHandles.map { $0._tfeTensorHandle }
+        let outputHandles = tffunc.execute(inputHandles)
+        return outputHandles
+    }
+
+    static var allTests = [
+        ("testSingleInput", testSingleInput),
+        ("testTensorGroupInputOutputs", testTensorGroupInputOutputs)
+    ]
+}

--- a/Tests/TensorFlowTests/LazyTensorTraceTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTraceTests.swift
@@ -206,19 +206,6 @@ final class LazyTensorTraceTests: XCTestCase {
         XCTAssertEqual(z.scalarized(), 9.0)
     }
 
-    func testTracing() {
-        func fn(x: Tensor<Float>) -> Tensor<Float>{
-            return x + x
-        }
-        let trace = LazyTensorTraceBuilder.trace(fn)
-        XCTAssertEqual(trace.description,
-            """
-            lazyTrace_2(%0: float) -> (%1) {
-              %1 = Add[T: float](%0, %0)
-            }
-            """)
-    }
-
     private func lazyTensorOperation<T: TensorFlowScalar>(
         _ input: Tensor<T>
     ) -> LazyTensorOperation? {
@@ -250,6 +237,5 @@ final class LazyTensorTraceTests: XCTestCase {
         ("testSimpleControlFlow", testSimpleControlFlow),
         ("testManualConstPromotion", testManualConstPromotion),
         ("testConstPromotion", testConstPromotion),
-        ("testTracing", testTracing)
     ]
 }

--- a/Tests/TensorFlowTests/LazyTensorTraceTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTraceTests.swift
@@ -206,6 +206,19 @@ final class LazyTensorTraceTests: XCTestCase {
         XCTAssertEqual(z.scalarized(), 9.0)
     }
 
+    func testTracing() {
+        func fn(x: Tensor<Float>) -> Tensor<Float>{
+            return x + x
+        }
+        let trace = LazyTensorTraceBuilder.trace(fn)
+        XCTAssertEqual(trace.description,
+            """
+            lazyTrace_2(%0: float) -> (%1) {
+              %1 = Add[T: float](%0, %0)
+            }
+            """)
+    }
+
     private func lazyTensorOperation<T: TensorFlowScalar>(
         _ input: Tensor<T>
     ) -> LazyTensorOperation? {
@@ -236,6 +249,7 @@ final class LazyTensorTraceTests: XCTestCase {
         ("testMultipleTargets", testMultipleTargets),
         ("testSimpleControlFlow", testSimpleControlFlow),
         ("testManualConstPromotion", testManualConstPromotion),
-        ("testConstPromotion", testConstPromotion)
+        ("testConstPromotion", testConstPromotion),
+        ("testTracing", testTracing)
     ]
 }

--- a/Tests/TensorFlowTests/LazyTensorTraceTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTraceTests.swift
@@ -236,6 +236,6 @@ final class LazyTensorTraceTests: XCTestCase {
         ("testMultipleTargets", testMultipleTargets),
         ("testSimpleControlFlow", testSimpleControlFlow),
         ("testManualConstPromotion", testManualConstPromotion),
-        ("testConstPromotion", testConstPromotion),
+        ("testConstPromotion", testConstPromotion)
     ]
 }

--- a/Tests/TensorFlowTests/XCTestManifests.swift
+++ b/Tests/TensorFlowTests/XCTestManifests.swift
@@ -31,6 +31,7 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(MathOperatorTests.allTests),
         testCase(LazyTensorTests.allTests),
         testCase(LazyTensorTraceTests.allTests),
+        testCase(LazyTensorExplicitTraceTests.allTests),
         testCase(LazyTensorOperationTests.allTests),
         testCase(LazyTensorTFFunctionBuilderTests.allTests),
         testCase(LazyTensorEvaluationTests.allTests),


### PR DESCRIPTION
This PR uses `LazyTensor` to perform extract traces explicitly. This mechanism will be used to replace the existing tracing mechanism in `Runtime.swift`.