### PR TITLE
Cleanup: replace stack of `operationsTracker` in `LazyTensorContext` into a single tracker.

### DIFF
--- a/Sources/TensorFlow/Core/LazyTensorContext.swift
+++ b/Sources/TensorFlow/Core/LazyTensorContext.swift
@@ -61,13 +61,13 @@ class LazyTensorOperationsTracker {
 }
 
 struct LazyTensorContext {
-    private var _operationsTracker = LazyTensorOperationsTracker()
+    private var operationsTracker = LazyTensorOperationsTracker()
 
     static private var threadLocalContext: LazyTensorContext {
         _ThreadLocalState.local.lazyTensorContext
     }
 
     static var operationsTracker: LazyTensorOperationsTracker {
-        return threadLocalContext._operationsTracker
+        return threadLocalContext.operationsTracker
     }
 }

--- a/Sources/TensorFlow/Core/LazyTensorContext.swift
+++ b/Sources/TensorFlow/Core/LazyTensorContext.swift
@@ -61,13 +61,13 @@ class LazyTensorOperationsTracker {
 }
 
 struct LazyTensorContext {
-    var scopes = [LazyTensorOperationsTracker()]
+    private var _operationsTracker = LazyTensorOperationsTracker()
 
     static private var threadLocalContext: LazyTensorContext {
         _ThreadLocalState.local.lazyTensorContext
     }
 
     static var operationsTracker: LazyTensorOperationsTracker {
-        return threadLocalContext.scopes.last!
+        return threadLocalContext._operationsTracker
     }
 }


### PR DESCRIPTION
We don't need a stack of `operationsTracker` at this point.