### PR TITLE
Rewrite tracing utilities in terms of LazyTensor. 

### DIFF
--- a/Sources/TensorFlow/Core/LazyTensorTFFunctionBuilder.swift
+++ b/Sources/TensorFlow/Core/LazyTensorTFFunctionBuilder.swift
@@ -269,7 +269,7 @@ class TFFunction {
         checkOk(status)
     }
 
-    func execute(_ inputs: [TFETensorHandle], useXLA: Bool = false) -> [TFETensorHandle] {
+    func execute(_ inputs: [TFETensorHandle], usingXLA: Bool = false) -> [TFETensorHandle] {
         let status: CTFStatus = TF_NewStatus()
         defer { TF_DeleteStatus(status) }
 
@@ -286,7 +286,7 @@ class TFFunction {
             checkOk(status)
         }
 
-        if useXLA {
+        if usingXLA {
             debugLog("Enabling XLA compilation")
             TFE_OpSetAttrBool(eagerOp, "_XlaCompile", 1)
         }

--- a/Sources/TensorFlow/Core/LazyTensorTFFunctionBuilder.swift
+++ b/Sources/TensorFlow/Core/LazyTensorTFFunctionBuilder.swift
@@ -269,7 +269,7 @@ class TFFunction {
         checkOk(status)
     }
 
-    func execute(_ inputs: [TFETensorHandle]) -> [TFETensorHandle] {
+    func execute(_ inputs: [TFETensorHandle], useXLA: Bool = false) -> [TFETensorHandle] {
         let status: CTFStatus = TF_NewStatus()
         defer { TF_DeleteStatus(status) }
 
@@ -284,6 +284,11 @@ class TFFunction {
             debugLog("Placing the trace func on device \(deviceName).")
             TFE_OpSetDevice(eagerOp, deviceName, status)
             checkOk(status)
+        }
+
+        if useXLA {
+            debugLog("Enabling XLA compilation")
+            TFE_OpSetAttrBool(eagerOp, "_XlaCompile", 1)
         }
 
         for input in inputs {

--- a/Sources/TensorFlow/Core/LazyTensorTFFunctionBuilder.swift
+++ b/Sources/TensorFlow/Core/LazyTensorTFFunctionBuilder.swift
@@ -221,6 +221,7 @@ class TFFunction {
     let cTFFunction: CTFFunction
     let outputCount: Int
     let outputGroupCounts: [Int]
+    var name: String { String(cString: TF_FunctionName(cTFFunction)!) }
 
     init(trace: LazyTensorTrace, name: String? = nil) {
         let status: CTFStatus = TF_NewStatus()

--- a/Sources/TensorFlow/Core/Runtime.swift
+++ b/Sources/TensorFlow/Core/Runtime.swift
@@ -935,9 +935,9 @@ public func _tffunc<State: _TensorArrayProtocolEnhanced, Data: TensorGroup>(
 }
 
 internal func _trace<In: TensorGroup, Out: TensorGroup>(_ fn: (In) -> Out) -> TFFunction {
-    let useLazyTensor = _RuntimeConfig.useLazyTensor
-    defer { _RuntimeConfig.useLazyTensor = useLazyTensor }
-    _RuntimeConfig.useLazyTensor = true
+    let useLazyTensor = _ThreadLocalState.useLazyTensor
+    defer { _ThreadLocalState.useLazyTensor = useLazyTensor }
+    _ThreadLocalState.useLazyTensor = true
     let trace = LazyTensorTraceBuilder.trace(fn)
     return TFFunction(trace: trace)
 }

--- a/Sources/TensorFlow/Core/Runtime.swift
+++ b/Sources/TensorFlow/Core/Runtime.swift
@@ -951,7 +951,7 @@ public func _graph<In: TensorGroup, Out: TensorGroup>(
     let tffunc = _trace(fn)
     return {(input: In) -> Out in
         let inputHandles = input._tensorHandles.map { $0._tfeTensorHandle }
-        let outputHandles = tffunc.execute(inputHandles, useXLA: useXLA)
+        let outputHandles = tffunc.execute(inputHandles, usingXLA: useXLA)
         return Out(_handles: outputHandles)
     }
 }

--- a/Sources/TensorFlow/Core/Runtime.swift
+++ b/Sources/TensorFlow/Core/Runtime.swift
@@ -949,7 +949,7 @@ public func _graph<In: TensorGroup, Out: TensorGroup>(
     useXLA: Bool = false
 ) -> (In) -> Out {
     let tffunc = _trace(fn)
-    return {(input: In) -> Out in
+    return {input in
         let inputHandles = input._tensorHandles.map { $0._tfeTensorHandle }
         let outputHandles = tffunc.execute(inputHandles, usingXLA: useXLA)
         return Out(_handles: outputHandles)

--- a/Tests/TensorFlowTests/LazyTensorEvaluationTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorEvaluationTests.swift
@@ -20,12 +20,12 @@ import CTensorFlow
 final class LazyTensorEvaluationTests: XCTestCase {
     override class func setUp() {
         super.setUp()
-        _RuntimeConfig.useLazyTensor = true
+        _ThreadLocalState.useLazyTensor = true
     }
 
     override class func tearDown() {
         super.tearDown()
-        _RuntimeConfig.useLazyTensor = false
+        _ThreadLocalState.useLazyTensor = false
     }
 
     func testSimpleOperations() {

--- a/Tests/TensorFlowTests/LazyTensorExplicitTraceTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorExplicitTraceTests.swift
@@ -20,12 +20,12 @@ import CTensorFlow
 final class LazyTensorExplicitTraceTests: XCTestCase {
     override class func setUp() {
         super.setUp()
-        _RuntimeConfig.useLazyTensor = true
+        _ThreadLocalState.useLazyTensor = true
     }
 
     override class func tearDown() {
         super.tearDown()
-        _RuntimeConfig.useLazyTensor = false
+        _ThreadLocalState.useLazyTensor = false
     }
 
     func testSingleInput() {

--- a/Tests/TensorFlowTests/LazyTensorExplicitTraceTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorExplicitTraceTests.swift
@@ -135,6 +135,15 @@ final class LazyTensorExplicitTraceTests: XCTestCase {
         XCTAssertEqual(outputs[0].valueDescription, "13.0")
     }
 
+    func testCallableTrace() {
+        func square(input: Tensor<Float>) -> Tensor<Float> {
+            return input * input
+        }
+        let tracedSquare = _graph(square)
+        XCTAssertEqual(tracedSquare(Tensor<Float>(10.0)).scalarized(), 100.0)
+        XCTAssertEqual(tracedSquare(Tensor<Float>(5.0)).scalarized(), 25.0)
+    }
+
     private func runTrace(trace: LazyTensorTrace, input: TensorGroup) -> [TFETensorHandle] {
         let tffunc = TFFunction(trace: trace)
         let inputHandles = input._tensorHandles.map { $0._tfeTensorHandle }
@@ -147,6 +156,7 @@ final class LazyTensorExplicitTraceTests: XCTestCase {
         ("testTensorGroupInputOutputs", testTensorGroupInputOutputs),
         ("testClosureCapturesOfTensors", testClosureCapturesOfTensors),
         ("testClosureCapturesOfNonTensors", testClosureCapturesOfNonTensors),
-        ("testNestedTracing", testNestedTracing)
+        ("testNestedTracing", testNestedTracing),
+        ("testCallableTrace", testCallableTrace)
     ]
 }

--- a/Tests/TensorFlowTests/LazyTensorTFFunctionBuilderTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTFFunctionBuilderTests.swift
@@ -19,12 +19,12 @@ import CTensorFlow
 final class LazyTensorTFFunctionBuilderTests : XCTestCase {
     override class func setUp() {
         super.setUp()
-        _RuntimeConfig.useLazyTensor = true
+        _ThreadLocalState.useLazyTensor = true
     }
 
     override class func tearDown() {
         super.tearDown()
-        _RuntimeConfig.useLazyTensor = false
+        _ThreadLocalState.useLazyTensor = false
     }
 
     func testSingletonInputs() {

--- a/Tests/TensorFlowTests/LazyTensorTraceTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTraceTests.swift
@@ -20,12 +20,12 @@ import CTensorFlow
 final class LazyTensorTraceTests: XCTestCase {
     override class func setUp() {
         super.setUp()
-        _RuntimeConfig.useLazyTensor = true
+        _ThreadLocalState.useLazyTensor = true
     }
 
     override class func tearDown() {
         super.tearDown()
-        _RuntimeConfig.useLazyTensor = false
+        _ThreadLocalState.useLazyTensor = false
     }
 
     func testSingleLiveTensor() {


### PR DESCRIPTION
This PR reimplements `_tffunc` and `_graph` in `Runtime.swift` using the explicit tracing mechanism in LazyTensor.