### PR TITLE
Use control flow AD in layers and add leak checking utility.

### DIFF
--- a/Sources/TensorFlow/Context.swift
+++ b/Sources/TensorFlow/Context.swift
@@ -66,6 +66,8 @@ public struct Context {
     internal var randomNumberGenerator: AnyRandomNumberGenerator =
         AnyRandomNumberGenerator(PhiloxRandomNumberGenerator(uint64Seed: UInt64(time(nil))))
 
+    internal var globalTensorCount: Int = 0
+
     /// Creates a context with default properties.
     public init() {}
 

--- a/Sources/TensorFlow/Core/TensorHandle.swift
+++ b/Sources/TensorFlow/Core/TensorHandle.swift
@@ -39,12 +39,14 @@ public class TFETensorHandle: _AnyTensorHandle {
     public var _tfeTensorHandle: TFETensorHandle { return self }
 
     public init(_owning base: CTensorHandle) {
+        Context.local.globalTensorCount += 1
         self._cTensorHandle = base
     }
 
     deinit {
         debugLog("De-initializing TensorHandle.")
         TFE_DeleteTensorHandle(_cTensorHandle)
+        Context.local.globalTensorCount -= 1
         debugLog("Returning from deinit of TensorHandle.")
     }
 }

--- a/Sources/TensorFlow/Layers/Core.swift
+++ b/Sources/TensorFlow/Layers/Core.swift
@@ -52,29 +52,13 @@ public struct Dropout<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable(vjp: _vjpApplied(to:))
+    @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         switch Context.local.learningPhase {
         case .training:
             return applyingTraining(to: input)
         case .inference:
             return applyingInference(to: input)
-        }
-    }
-
-    @usableFromInline
-    func _vjpApplied(
-        to input: Tensor<Scalar>
-    ) -> (Tensor<Scalar>, (Tensor<Scalar>) -> (Dropout<Scalar>.TangentVector, Tensor<Scalar>)) {
-        switch Context.local.learningPhase {
-        case .training:
-            return valueWithPullback(at: input) {
-                $0.applyingTraining(to: $1)
-            }
-        case .inference:
-            return valueWithPullback(at: input) {
-                $0.applyingInference(to: $1)
-            }
         }
     }
 }

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -65,51 +65,27 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
         self.runningVariance = Parameter(runningVariance)
     }
 
-    @differentiable
-    private func applyingTraining(to input: Tensor<Scalar>) -> Tensor<Scalar> {
-        let positiveAxis = (input.rank + axis) % input.rank
-        var normalizedAxes = Array(0..<input.rank)
-        normalizedAxes.remove(at: positiveAxis)
-        let moments = input.moments(alongAxes: normalizedAxes)
-        runningMean.value += (moments.mean - runningMean.value) * (1 - momentum)
-        runningVariance.value += (moments.variance - runningVariance.value) * (1 - momentum)
-        let inv = rsqrt(moments.variance + epsilon) * scale.reshaped(to: moments.variance.shape)
-        return (input - moments.mean) * inv + offset.reshaped(to: moments.mean.shape)
-    }
-
-    @differentiable
-    private func applyingInference(to input: Tensor<Scalar>) -> Tensor<Scalar> {
-        let scaleShape = runningVariance.value.shape
-        let offsetShape = runningMean.value.shape
-        let inv = rsqrt(runningVariance.value + epsilon) * scale.reshaped(to: scaleShape)
-        return (input - runningMean.value) * inv + offset.reshaped(to: offsetShape)
-    }
-
     /// Returns the output obtained from applying the layer to the given input.
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The output.
-    @differentiable(vjp: _vjpApplied(to:))
+    @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         switch Context.local.learningPhase {
-        case .training: return applyingTraining(to: input)
-        case .inference: return applyingInference(to: input)
-        }
-    }
-
-    @usableFromInline
-    func _vjpApplied(to input: Tensor<Scalar>) ->
-        (Tensor<Scalar>, (Tensor<Scalar>) ->
-            (BatchNorm<Scalar>.TangentVector, Tensor<Scalar>)) {
-        switch Context.local.learningPhase {
         case .training:
-            return valueWithPullback(at: input) {
-                $0.applyingTraining(to: $1)
-            }
+          let positiveAxis = (input.rank + axis) % input.rank
+          var normalizedAxes = Array(0..<input.rank)
+          normalizedAxes.remove(at: positiveAxis)
+          let moments = input.moments(alongAxes: normalizedAxes)
+          runningMean.value += (moments.mean - runningMean.value) * (1 - momentum)
+          runningVariance.value += (moments.variance - runningVariance.value) * (1 - momentum)
+          let inv = rsqrt(moments.variance + epsilon) * scale.reshaped(to: moments.variance.shape)
+          return (input - moments.mean) * inv + offset.reshaped(to: moments.mean.shape)
         case .inference:
-            return valueWithPullback(at: input) {
-                $0.applyingInference(to: $1)
-            }
+          let scaleShape = runningVariance.value.shape
+          let offsetShape = runningMean.value.shape
+          let inv = rsqrt(runningVariance.value + epsilon) * scale.reshaped(to: scaleShape)
+          return (input - runningMean.value) * inv + offset.reshaped(to: offsetShape)
         }
     }
 

--- a/Tests/TensorFlowTests/Helpers.swift
+++ b/Tests/TensorFlowTests/Helpers.swift
@@ -37,9 +37,11 @@ internal func assertEqual<T: TensorFlowFloatingPoint>(
     assertEqual(x.scalars, y.scalars, accuracy: accuracy, message, file: file, line: line)
 }
 
-func withTensorLeakChecking(file: StaticString = #file,
-                            line: UInt = #line,
-                            _ body: () throws -> Void) rethrows {
+func withTensorLeakChecking(
+    file: StaticString = #file,
+    line: UInt = #line,
+    _ body: () throws -> Void
+) rethrows {
     let initialTensorCount = Context.local.globalTensorCount
     try body()
     let tensorCountDifference = Context.local.globalTensorCount - initialTensorCount

--- a/Tests/TensorFlowTests/Helpers.swift
+++ b/Tests/TensorFlowTests/Helpers.swift
@@ -36,3 +36,13 @@ internal func assertEqual<T: TensorFlowFloatingPoint>(
 ) {
     assertEqual(x.scalars, y.scalars, accuracy: accuracy, message, file: file, line: line)
 }
+
+func withTensorLeakChecking(file: StaticString = #file,
+                            line: UInt = #line,
+                            _ body: () throws -> Void) rethrows {
+    let initialTensorCount = Context.local.globalTensorCount
+    try body()
+    let tensorCountDifference = Context.local.globalTensorCount - initialTensorCount
+    XCTAssertGreaterThanOrEqual(tensorCountDifference, 0, "Negative tensor count?")
+    XCTAssertEqual(tensorCountDifference, 0, "Memory leaks found", file: file, line: line)
+}

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -43,12 +43,15 @@ final class LayerTests: XCTestCase {
             let optimizer = SGD(for: model)
             let x = Tensor<Float>([[0, 0], [0, 1], [1, 0], [1, 1]])
             let y = Tensor<Float>([0, 1, 1, 0])
-            let initialLoss = meanSquaredError(predicted: model(x).squeezingShape(at: 1),
-                                               expected: y)
+            let initialLoss = meanSquaredError(
+                predicted: model(x).squeezingShape(at: 1),
+                expected: y)
             withTensorLeakChecking {
                 for _ in 0..<10 {
                     let 𝛁model = model.gradient { model -> Tensor<Float> in
-                        meanSquaredError(predicted: model(x).squeezingShape(at: 1), expected: y)
+                        meanSquaredError(
+                            predicted: model(x).squeezingShape(at: 1),
+                            expected: y)
                     }
                     optimizer.update(&model, along: 𝛁model)
                 }

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -56,8 +56,9 @@ final class LayerTests: XCTestCase {
                     optimizer.update(&model, along: 𝛁model)
                 }
             }
-            let updatedLoss = meanSquaredError(predicted: model(x).squeezingShape(at: 1),
-                                               expected: y)
+            let updatedLoss = meanSquaredError(
+                predicted: model(x).squeezingShape(at: 1),
+                expected: y)
             XCTAssertLessThan(updatedLoss, initialLoss)
         }
     }
@@ -306,8 +307,8 @@ final class LayerTests: XCTestCase {
       let layer = UpSampling3D<Float>(size: size)
       let input = Tensor<Float>(shape: [1, 4, 3, 2, 1], scalars: (0..<24).map(Float.init))
       let output = layer.inferring(from: input)
-      let expected = TensorShape([1, input.shape[1] * size, input.shape[2] * size,
-                                  input.shape[3] * size, 1])
+      let expected = TensorShape(
+          [1, input.shape[1] * size, input.shape[2] * size, input.shape[3] * size, 1])
       XCTAssertEqual(output.shape, expected)
       XCTAssertEqual(output.shape, expected)
     }

--- a/Tests/TensorFlowTests/SequentialTests.swift
+++ b/Tests/TensorFlowTests/SequentialTests.swift
@@ -45,25 +45,27 @@ final class SequentialTests: XCTestCase {
         let x: Tensor<Float> = [[0, 0], [0, 1], [1, 0], [1, 1]]
         let y: Tensor<Float> = [0, 1, 1, 0]
         Context.local.learningPhase = .training
-        for _ in 0..<1000 {
-            let 𝛁model = model.gradient { model -> Tensor<Float> in
-                let ŷ = model(x)
-                return meanSquaredError(predicted: ŷ, expected: y)
+        withTensorLeakChecking {
+            for _ in 0..<1000 {
+                let 𝛁model = model.gradient { model -> Tensor<Float> in
+                    let ŷ = model(x)
+                    return meanSquaredError(predicted: ŷ, expected: y)
+                }
+                sgd.update(&model, along: 𝛁model)
+                sgd.update(&model.allDifferentiableVariables, along: 𝛁model)
+                rmsprop.update(&model, along: 𝛁model)
+                rmsprop.update(&model.allDifferentiableVariables, along: 𝛁model)
+                adam.update(&model, along: 𝛁model)
+                adam.update(&model.allDifferentiableVariables, along: 𝛁model)
+                adamax.update(&model, along: 𝛁model)
+                adamax.update(&model.allDifferentiableVariables, along: 𝛁model)
+                amsgrad.update(&model, along: 𝛁model)
+                amsgrad.update(&model.allDifferentiableVariables, along: 𝛁model)
+                adagrad.update(&model, along: 𝛁model)
+                adagrad.update(&model.allDifferentiableVariables, along: 𝛁model)
+                adadelta.update(&model, along: 𝛁model)
+                adadelta.update(&model.allDifferentiableVariables, along: 𝛁model)
             }
-            sgd.update(&model, along: 𝛁model)
-            sgd.update(&model.allDifferentiableVariables, along: 𝛁model)
-            rmsprop.update(&model, along: 𝛁model)
-            rmsprop.update(&model.allDifferentiableVariables, along: 𝛁model)
-            adam.update(&model, along: 𝛁model)
-            adam.update(&model.allDifferentiableVariables, along: 𝛁model)
-            adamax.update(&model, along: 𝛁model)
-            adamax.update(&model.allDifferentiableVariables, along: 𝛁model)
-            amsgrad.update(&model, along: 𝛁model)
-            amsgrad.update(&model.allDifferentiableVariables, along: 𝛁model)
-            adagrad.update(&model, along: 𝛁model)
-            adagrad.update(&model.allDifferentiableVariables, along: 𝛁model)
-            adadelta.update(&model, along: 𝛁model)
-            adadelta.update(&model.allDifferentiableVariables, along: 𝛁model)
         }
         XCTAssertEqual(model.inferring(from: [[0, 0], [0, 1], [1, 0], [1, 1]]),
                        [[0.52508783], [0.52508783], [0.52508783], [0.52508783]])

--- a/Tests/TensorFlowTests/TrivialModelTests.swift
+++ b/Tests/TensorFlowTests/TrivialModelTests.swift
@@ -43,12 +43,14 @@ final class TrivialModelTests: XCTestCase {
         let y: Tensor<Float> = [[0], [1], [1], [0]]
 
         Context.local.learningPhase = .training
-        for _ in 0..<3000 {
-            let 𝛁model = classifier.gradient { classifier -> Tensor<Float> in
-                let ŷ = classifier(x)
-                return meanSquaredError(predicted: ŷ, expected: y)
+        withTensorLeakChecking {
+            for _ in 0..<3000 {
+                let 𝛁model = classifier.gradient { classifier -> Tensor<Float> in
+                    let ŷ = classifier(x)
+                    return meanSquaredError(predicted: ŷ, expected: y)
+                }
+                optimizer.update(&classifier, along: 𝛁model)
             }
-            optimizer.update(&classifier, along: 𝛁model)
         }
         let ŷ = classifier.inferring(from: x)
         XCTAssertEqual(round(ŷ), y)


### PR DESCRIPTION
Remove custom VJPs from all layers so that they go through control flow differentiation. This applies to `BatchNorm` and `Dropout`. `Dense` was already using control flow differentiation.

Introduce a tensor leak checking test utility `withTensorLeakChecking { ... }` and use it in tests. A `globalTensorCount` variable is added to the thread-local `Context` to keep track of the number of live tensors, and `TFETensorHandle`'s `init(_owning:)` and `deinit` increases and decreases `globalTensorCount`, respectively.

Resolves #389.