### PR TITLE
Correcting argument order in assertEqual and XCTAssertEqual

### DIFF
--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -365,8 +365,8 @@ final class LayerTests: XCTestCase {
 
         let weightBatched = Tensor<Float>(shape: [2, 2, 3], scalars: (0..<12).map(Float.init))
         let biasBatched = Tensor<Float>([[1.0, 2.0, 3.0]])
-        let layerBatched = Dense<Float>(weight: weightBatched, 
-                                        bias: biasBatched, 
+        let layerBatched = Dense<Float>(weight: weightBatched,
+                                        bias: biasBatched,
                                         activation: identity)
         let inputBatched = Tensor<Float>(shape: [2, 2], scalars: (0..<4).map(Float.init))
         let outputBatched = layerBatched.inferring(from: inputBatched)
@@ -410,7 +410,7 @@ final class LayerTests: XCTestCase {
         let expected = Tensor<Float>([[0.0], [0.7615942], [0.9640276], [0.9950547], [0.9993292]])
         XCTAssertEqual(output, expected)
     }
-    
+
     func testBatchNorm() {
         let x = Tensor<Float>([
             [  -1.0474433,  -0.11914538,  -0.08634827,   0.15446888,    1.0572497],
@@ -447,7 +447,7 @@ final class LayerTests: XCTestCase {
             [-0.44139984,  1.2124169 ,  0.60574806,  0.3150888 , -1.6918538 ],
             [ 0.9507547 ,  0.04595902, -1.9072568 ,  0.31947452,  0.5910686 ],
             [ 1.5834246 ,  0.02224666, -0.8476793 , -1.2244489 ,  0.46645695]])
-        
+
         let expectedInputGradient = Tensor<Float>([
             [-1.0127544e-02, -1.0807812e-03, -7.6115131e-04,  1.5857220e-03,  1.0383606e-02],
             [ 2.0323221e-03,  6.2976527e-04, -2.1077941e-04, -2.1265696e-04, -2.2384699e-03],
@@ -456,12 +456,12 @@ final class LayerTests: XCTestCase {
             [ 1.2142579e-01,  1.7060755e-03, -6.5005139e-02, -9.3897656e-02,  3.5770576e-02]])
         let expectedScaleGradient = Tensor<Float>([9.977925, 9.992161, 9.986738, 9.990202, 9.886292])
         let expectedOffsetGradient = Tensor<Float>([0.0, 0.0, 0.0, 0.0, 0.0])
-        assertEqual(expectedTrainingValue, trainingValue, accuracy: 1e-5)
-        assertEqual(expectedInputGradient, grad.0, accuracy: 1e-5)
-        assertEqual(expectedScaleGradient, grad.1.scale, accuracy: 1e-5)
-        assertEqual(expectedOffsetGradient, grad.1.offset, accuracy: 1e-5)
+        assertEqual(trainingValue, expectedTrainingValue, accuracy: 1e-5)
+        assertEqual(grad.0, expectedInputGradient, accuracy: 1e-5)
+        assertEqual(grad.1.scale, expectedScaleGradient, accuracy: 1e-5)
+        assertEqual(grad.1.offset, expectedOffsetGradient, accuracy: 1e-5)
     }
-    
+
     func testLayerNorm() {
         let x = Tensor<Float>([
             [  -1.0474433,  -0.11914538,  -0.08634827,   0.15446888,    1.0572497],
@@ -480,7 +480,7 @@ final class LayerTests: XCTestCase {
             [-0.44139984,  1.2124169 ,  0.60574806,  0.3150888 , -1.6918538 ],
             [ 0.9507547 ,  0.04595902, -1.9072568 ,  0.31947452,  0.5910686 ],
             [ 1.5834246 ,  0.02224666, -0.8476793 , -1.2244489 ,  0.46645695]])
-        
+
         let expectedInputGradient = Tensor<Float>([
             [-1.0127544e-02, -1.0807812e-03, -7.6115131e-04,  1.5857220e-03,  1.0383606e-02],
             [ 2.0323221e-03,  6.2976527e-04, -2.1077941e-04, -2.1265696e-04, -2.2384699e-03],
@@ -489,10 +489,10 @@ final class LayerTests: XCTestCase {
             [ 1.2142579e-01,  1.7060755e-03, -6.5005139e-02, -9.3897656e-02,  3.5770576e-02]])
         let expectedScaleGradient = Tensor<Float>([9.977925, 9.992161, 9.986738, 9.990202, 9.886292])
         let expectedOffsetGradient = Tensor<Float>([0.0, 0.0, 0.0, 0.0, 0.0])
-        assertEqual(expectedValue, value, accuracy: 1e-5)
-        assertEqual(expectedInputGradient, grad.0, accuracy: 1e-5)
-        assertEqual(expectedScaleGradient, grad.1.scale, accuracy: 1e-5)
-        assertEqual(expectedOffsetGradient, grad.1.offset, accuracy: 1e-5)
+        assertEqual(value, expectedValue, accuracy: 1e-5)
+        assertEqual(grad.0, expectedInputGradient, accuracy: 1e-5)
+        assertEqual(grad.1.scale, expectedScaleGradient, accuracy: 1e-5)
+        assertEqual(grad.1.offset, expectedOffsetGradient, accuracy: 1e-5)
     }
 
     static var allTests = [

--- a/Tests/TensorFlowTests/LazyTensorTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTests.swift
@@ -61,7 +61,7 @@ final class LazyTensorTests: XCTestCase {
             let expectedLiveOps = Set<LazyTensorOperationRef>(
                 expectedLive.map { LazyTensorOperationRef($0) }
             )
-            XCTAssertEqual(expectedLiveOps, actualLiveOps)
+            XCTAssertEqual(actualLiveOps, expectedLiveOps)
         }
 
         func assertAll(_ expectedAll: [LazyTensorOperation]) {
@@ -72,7 +72,7 @@ final class LazyTensorTests: XCTestCase {
             let expectedAllOps = Set<LazyTensorOperationRef>(
                 expectedAll.map { LazyTensorOperationRef($0) }
             )
-            XCTAssertEqual(expectedAllOps, actualAllOps)
+            XCTAssertEqual(actualAllOps, expectedAllOps)
         }
 
         let op0 = LazyTensorOperation(

--- a/Tests/TensorFlowTests/OperatorTests/BasicTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/BasicTests.swift
@@ -289,7 +289,7 @@ final class BasicOperatorTests: XCTestCase {
         XCTAssertEqual(array3D.scalars, Array(stride(from: 40.0, to: 60, by: 1)))
         XCTAssertEqual(
             array2D.scalars,
-            Array(stride(from: 20.0, to: 25, by: 1)) + 
+            Array(stride(from: 20.0, to: 25, by: 1)) +
             Array(stride(from: 30.0, to: 35, by: 1)))
         XCTAssertEqual(array1D.scalars, Array(stride(from: 1.0, to: 5, by: 2)))
     }
@@ -310,7 +310,7 @@ final class BasicOperatorTests: XCTestCase {
         let array3D = slice3D.array
         let array2D = slice2D.array
         let array1D = slice1D.array
-		
+
         /// Test shapes
         XCTAssertEqual(array3D.shape, [1, 4, 5])
         XCTAssertEqual(array2D.shape, [2, 5])
@@ -362,7 +362,7 @@ final class BasicOperatorTests: XCTestCase {
         XCTAssertEqual(concatenated.array, ShapedArray(shape: [4, 3], scalars: Array(0..<12)))
         XCTAssertEqual(concatenated0.array, ShapedArray(shape: [4, 3], scalars: Array(0..<12)))
         XCTAssertEqual(
-            concatenated1.array, 
+            concatenated1.array,
             ShapedArray(shape: [2, 6], scalars: [0, 1, 2, 6, 7, 8, 3, 4, 5, 9, 10, 11]))
     }
 
@@ -457,12 +457,12 @@ final class BasicOperatorTests: XCTestCase {
         let z = x.unbroadcasted(like: y)
         XCTAssertEqual(z.array, ShapedArray<Float>(repeating: 8, shape: [3, 1, 5]))
     }
-    
+
     func testUnbroadcast3x3To1x3() {
         func foo(tensor: Tensor<Float>, shape: Tensor<Int32>) -> Tensor<Float> {
             tensor.unbroadcasted(toShape: shape)
         }
-        
+
         // [3,3] -> [1,3]
         let atTensor: Tensor<Float> = [
             [1, 2, 3],
@@ -471,26 +471,26 @@ final class BasicOperatorTests: XCTestCase {
         let pb: (Tensor<Float>) -> Tensor<Float> = pullback(at: atTensor) { x in
             foo(tensor: x, shape: [1, 3])
         }
-        
+
         // Same shape as parameter of pullback
         var inputTensor: Tensor<Float> = [[1, 2, 3]]
         var expected: Tensor<Float> = atTensor
-        XCTAssertEqual(expected, pb(inputTensor))
+        XCTAssertEqual(pb(inputTensor), expected)
         // Different shape than parameter of pullback
         inputTensor = [2]
         expected = [
             [2, 2, 2],
             [2, 2, 2],
             [2, 2, 2]]
-        XCTAssertEqual(expected, pb(inputTensor))
-        
+        XCTAssertEqual(pb(inputTensor), expected)
+
         // Same shape as tensor we are differentiating at
         inputTensor = [
             [8, 1, 3],
             [8, 1, 3],
             [8, 1, 3]]
         expected = inputTensor
-        XCTAssertEqual(expected, pb(inputTensor))
+        XCTAssertEqual(pb(inputTensor), expected)
     }
 
     func testSliceUpdate() {
@@ -518,25 +518,25 @@ final class BasicOperatorTests: XCTestCase {
         target .= Tensor(repeating: 1, shape: [1, 3, 1])
         XCTAssertEqual(target, Tensor(repeating: 1, shape: [2, 3, 4]))
     }
-  
+
     func testBroadcast3x0To3x3() {
         func foo(tensor: Tensor<Float>, shape: Tensor<Int32>) -> Tensor<Float> {
             tensor.broadcasted(toShape: shape)
         }
-        
+
         // [3,] -> [3,3]
         let pb: (Tensor<Float>) -> Tensor<Float> = pullback(at: [99, 33, 55]) { x in
             foo(tensor: x, shape: [3, 3])
         }
-        
+
         // Same shape as parameter of pullback
         var inputTensor: Tensor<Float> = [
             [1, 2, 3],
             [1, 2, 3],
             [1, 2, 3]]
         var expected: Tensor<Float> = [3, 6, 9]
-        XCTAssertEqual(expected, pb(inputTensor))
-        
+        XCTAssertEqual(pb(inputTensor), expected)
+
         // Different shape than parameter of pullback
         inputTensor = [
             [1, 2, 3],
@@ -544,37 +544,37 @@ final class BasicOperatorTests: XCTestCase {
             [1, 2, 3],
             [1, 2, 3]]
         expected = [4, 8, 12]
-        XCTAssertEqual(expected, pb(inputTensor))
-        
+        XCTAssertEqual(pb(inputTensor), expected)
+
         // Same shape as tensor we are differentiating at
         inputTensor = [1, 2, 3]
         expected = [1, 2, 3]
-        XCTAssertEqual(expected, pb(inputTensor))
-        
+        XCTAssertEqual(pb(inputTensor), expected)
+
         // Extremely padded shape as tensor we are differentiating at
         inputTensor = [[[[[[1, 2, 3]]]]]]
         expected = [1, 2, 3]
-        XCTAssertEqual(expected, pb(inputTensor))
+        XCTAssertEqual(pb(inputTensor), expected)
     }
-    
+
     func testBroadcast3x1To3x3() {
         func foo(tensor: Tensor<Float>, shape: Tensor<Int32>) -> Tensor<Float> {
             tensor.broadcasted(toShape: shape)
         }
-    
+
         // [3,1] -> [3x3]
         let pb: (Tensor<Float>) -> Tensor<Float> = pullback(at: [[99, 33, 55]]) { x in
             foo(tensor: x, shape: [3, 3])
         }
-        
+
         // Same shape as parameter of pullback
         var inputTensor: Tensor<Float> = [
             [1, 2, 3],
             [1, 2, 3],
             [1, 2, 3]]
         var expected: Tensor<Float> = [[3, 6, 9]]
-        XCTAssertEqual(expected, pb(inputTensor))
-        
+        XCTAssertEqual(pb(inputTensor), expected)
+
         // Different shape than parameter of pullback
         inputTensor = [
             [1, 2, 3],
@@ -582,17 +582,17 @@ final class BasicOperatorTests: XCTestCase {
             [1, 2, 3],
             [1, 2, 3]]
         expected = [[4, 8, 12]]
-        XCTAssertEqual(expected, pb(inputTensor))
-        
+        XCTAssertEqual(pb(inputTensor), expected)
+
         // Same shape as tensor we are differentiating at
         inputTensor = [[1, 2, 3]]
         expected = [[1, 2, 3]]
-        XCTAssertEqual(expected, pb(inputTensor))
-        
+        XCTAssertEqual(pb(inputTensor), expected)
+
         // Extremely padded shape of tensor we are differentiating at
         inputTensor = [[[[[[1, 2, 3]]]]]]
         expected = [[1, 2, 3]]
-        XCTAssertEqual(expected, pb(inputTensor))
+        XCTAssertEqual(pb(inputTensor), expected)
     }
 
     static var allTests = [

--- a/Tests/TensorFlowTests/OperatorTests/MathTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/MathTests.swift
@@ -81,8 +81,8 @@ final class MathOperatorTests: XCTestCase {
         let target = Tensor<Double>([1, 2, 3, 4, 5]).sum()
         let gradTarget = Tensor<Double>([-0.5,  -4.0, -13.5, -32.0, -62.5])
         let (value, grad) = valueWithGradient(at: x) { rsqrt($0).sum() }
-        XCTAssertEqual(target, value)       
-        XCTAssertEqual(gradTarget, grad)
+        XCTAssertEqual( value, target)
+        XCTAssertEqual( grad, gradTarget)
     }
 
     func testLog1p() {
@@ -463,11 +463,11 @@ final class MathOperatorTests: XCTestCase {
             let a = Tensor<Float>(randomNormal: TensorShape(shape))
             let (q, r) = a.qrDecomposition()
             let aReconstituted = matmul(q,r)
-            assertEqual(a, aReconstituted, accuracy: 1e-5)
+            assertEqual(aReconstituted, a, accuracy: 1e-5)
 
             let (qFull, rFull) = a.qrDecomposition(fullMatrices: true)
             let aReconstitutedFull = matmul(qFull, rFull)
-            assertEqual(a, aReconstitutedFull, accuracy: 1e-5)
+            assertEqual(aReconstitutedFull, a, accuracy: 1e-5)
         }
     }
 
@@ -475,7 +475,7 @@ final class MathOperatorTests: XCTestCase {
         // Test on 2-D matrix.
         let t1 = Tensor<Float>(shape: [4, 4], scalars: (1...16).map(Float.init))
         let target1 = Tensor<Float>([1, 6, 11, 16])
-        XCTAssertEqual(target1, t1.diagonalPart())
+        XCTAssertEqual(t1.diagonalPart(), target1)
 
         // Test on 4-D tensor.
         let t2 = Tensor<Float>([[[[1.0, 0.0, 0.0, 0.0],
@@ -495,7 +495,7 @@ final class MathOperatorTests: XCTestCase {
                                  [[0.0, 0.0, 0.0, 0.0],
                                   [0.0, 0.0, 0.0, 8.0]]]])
         let target2 = Tensor<Float>([[1, 2, 3, 4], [5, 6, 7, 8]])
-        XCTAssertEqual(target2, t2.diagonalPart())
+        XCTAssertEqual(t2.diagonalPart(), target2)
     }
 
     func testBroadcastedAddGradient() {

--- a/Tests/TensorFlowTests/OperatorTests/MathTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/MathTests.swift
@@ -81,8 +81,8 @@ final class MathOperatorTests: XCTestCase {
         let target = Tensor<Double>([1, 2, 3, 4, 5]).sum()
         let gradTarget = Tensor<Double>([-0.5,  -4.0, -13.5, -32.0, -62.5])
         let (value, grad) = valueWithGradient(at: x) { rsqrt($0).sum() }
-        XCTAssertEqual( value, target)
-        XCTAssertEqual( grad, gradTarget)
+        XCTAssertEqual(value, target)
+        XCTAssertEqual(grad, gradTarget)
     }
 
     func testLog1p() {

--- a/Tests/TensorFlowTests/TensorAutoDiffTests.swift
+++ b/Tests/TensorFlowTests/TensorAutoDiffTests.swift
@@ -30,15 +30,15 @@ final class TensorAutoDiffTests: XCTestCase {
         func square(_ x: Tensor<Float>) -> Tensor<Float> {
             return (x * x).sum()
         }
-        XCTAssertEqual(gradient(at: [0.1, 0.2, 0.3], [0.2, 0.4, 0.6], in: square))
-        XCTAssertEqual(gradient(at: [[10], [20]], [[20], [40]], in: square))
+        XCTAssertEqual(gradient(at: [0.1, 0.2, 0.3]), [0.2, 0.4, 0.6], in: square))
+        XCTAssertEqual(gradient(at: [[10], [20]]), [[20], [40]], in: square))
     }
 
     func testGenericGrad() {
         func square<T : TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
             return (x * x).sum()
         }
-        XCTAssertEqual(gradient(at: Tensor([0.1, 0.2, 0.3]), [0.2, 0.4, 0.6], in: square))
+        XCTAssertEqual(gradient(at: Tensor([0.1, 0.2, 0.3])), [0.2, 0.4, 0.6], in: square))
     }
 
     func testScalarGenericGrad() {
@@ -46,7 +46,7 @@ final class TensorAutoDiffTests: XCTestCase {
         func negate<T : TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
             return (1 - x).sum()
         }
-        XCTAssertEqual(gradient(at: Tensor([0.1, 0.2, 0.3]), Tensor(-1), in: negate))
+        XCTAssertEqual(gradient(at: Tensor([0.1, 0.2, 0.3])), Tensor(-1), in: negate))
     }
 
     func testScalarized() {
@@ -95,13 +95,13 @@ final class TensorAutoDiffTests: XCTestCase {
 
     func testNegate() {
         func f(a: Tensor<Float>) -> Tensor<Float> { (-a).sum() }
-        XCTAssertEqual(gradient(at: [0], [-1], in: f))
-        XCTAssertEqual(gradient(at: [10], [-1], in: f))
+        XCTAssertEqual(gradient(at: [0]), [-1], in: f))
+        XCTAssertEqual(gradient(at: [10]), [-1], in: f))
     }
 
     func testAbs() {
         func f(a: Tensor<Float>) -> Tensor<Float> { abs(a).sum() }
-        XCTAssertEqual(gradient(at: [3.0, -3.0, 0], [1, -1, 0], in: f))
+        XCTAssertEqual(gradient(at: [3.0, -3.0, 0]), [1, -1, 0], in: f))
     }
 
     func testSum() {

--- a/Tests/TensorFlowTests/TensorAutoDiffTests.swift
+++ b/Tests/TensorFlowTests/TensorAutoDiffTests.swift
@@ -30,15 +30,15 @@ final class TensorAutoDiffTests: XCTestCase {
         func square(_ x: Tensor<Float>) -> Tensor<Float> {
             return (x * x).sum()
         }
-        XCTAssertEqual([0.2, 0.4, 0.6], gradient(at: [0.1, 0.2, 0.3], in: square))
-        XCTAssertEqual([[20], [40]], gradient(at: [[10], [20]], in: square))
+        XCTAssertEqual(gradient(at: [0.1, 0.2, 0.3], [0.2, 0.4, 0.6], in: square))
+        XCTAssertEqual(gradient(at: [[10], [20]], [[20], [40]], in: square))
     }
 
     func testGenericGrad() {
         func square<T : TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
             return (x * x).sum()
         }
-        XCTAssertEqual([0.2, 0.4, 0.6], gradient(at: Tensor([0.1, 0.2, 0.3]), in: square))
+        XCTAssertEqual(gradient(at: Tensor([0.1, 0.2, 0.3]), [0.2, 0.4, 0.6], in: square))
     }
 
     func testScalarGenericGrad() {
@@ -46,14 +46,14 @@ final class TensorAutoDiffTests: XCTestCase {
         func negate<T : TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
             return (1 - x).sum()
         }
-        XCTAssertEqual(Tensor(-1), gradient(at: Tensor([0.1, 0.2, 0.3]), in: negate))
+        XCTAssertEqual(gradient(at: Tensor([0.1, 0.2, 0.3]), Tensor(-1), in: negate))
     }
 
     func testScalarized() {
         let grad = gradient(at: Tensor<Float>([3.0, 4.0])) { x in
             logSoftmax(x).mean().scalarized()
         }
-        XCTAssertEqual(Tensor([0.23105857, -0.2310586]), grad)
+        XCTAssertEqual(grad, Tensor([0.23105857, -0.2310586]))
     }
 
     func testPlus() {
@@ -67,7 +67,7 @@ final class TensorAutoDiffTests: XCTestCase {
         XCTAssertTrue((Tensor(1), Tensor(-1)) == gradient(at: Tensor(0), Tensor(0), in: f))
         XCTAssertTrue(([1], [-1]) == pullback(at: [1], [10], in: f)([1]))
     }
-    
+
     func testMultiply() {
         func f(a: Tensor<Float>, b: Tensor<Float>) -> Tensor<Float> { (a * b).sum() }
         XCTAssertTrue(([0], [0]) == gradient(at: [0], [0], in: f))
@@ -95,13 +95,13 @@ final class TensorAutoDiffTests: XCTestCase {
 
     func testNegate() {
         func f(a: Tensor<Float>) -> Tensor<Float> { (-a).sum() }
-        XCTAssertEqual([-1], gradient(at: [0], in: f))
-        XCTAssertEqual([-1], gradient(at: [10], in: f))
+        XCTAssertEqual(gradient(at: [0], [-1], in: f))
+        XCTAssertEqual(gradient(at: [10], [-1], in: f))
     }
 
     func testAbs() {
         func f(a: Tensor<Float>) -> Tensor<Float> { abs(a).sum() }
-        XCTAssertEqual([1, -1, 0], gradient(at: [3.0, -3.0, 0], in: f))
+        XCTAssertEqual(gradient(at: [3.0, -3.0, 0], [1, -1, 0], in: f))
     }
 
     func testSum() {
@@ -115,12 +115,12 @@ final class TensorAutoDiffTests: XCTestCase {
         }
 
         let expected = Tensor<Float>(ones: [2, 2])
-        XCTAssertEqual(expected, sumPullbackScalar(Tensor(1)))
-        XCTAssertEqual(expected, sumPullbackSqueezingAxes(Tensor(1)))
-        XCTAssertEqual(expected, sumPullbackAlongAxes(Tensor(1)))
-        XCTAssertEqual(expected * 3, sumPullbackScalar(Tensor(3)))
-        XCTAssertEqual(expected * 3, sumPullbackSqueezingAxes(Tensor(3)))
-        XCTAssertEqual(expected * 3, sumPullbackAlongAxes(Tensor(3)))
+        XCTAssertEqual(sumPullbackScalar(Tensor(1)), expected)
+        XCTAssertEqual(sumPullbackSqueezingAxes(Tensor(1)), expected)
+        XCTAssertEqual(sumPullbackAlongAxes(Tensor(1)), expected)
+        XCTAssertEqual(sumPullbackScalar(Tensor(3)), expected * 3)
+        XCTAssertEqual(sumPullbackSqueezingAxes(Tensor(3)), expected * 3)
+        XCTAssertEqual(sumPullbackAlongAxes(Tensor(3)), expected * 3)
     }
 
     func testMean() {
@@ -132,9 +132,9 @@ final class TensorAutoDiffTests: XCTestCase {
 
         let input = Tensor<Float>(ones: [2, 2])
         let expected = Tensor<Float>(repeating: 0.25, shape: [2, 2])
-        XCTAssertEqual(expected, meanGradScalar(input))
-        XCTAssertEqual(expected, meanGradSqueezingAxes(input))
-        XCTAssertEqual(expected, meanGradAlongAxes(input))
+        XCTAssertEqual(meanGradScalar(input), expected)
+        XCTAssertEqual(meanGradSqueezingAxes(input), expected)
+        XCTAssertEqual(meanGradAlongAxes(input), expected)
     }
 
     func testVariance() {
@@ -148,30 +148,30 @@ final class TensorAutoDiffTests: XCTestCase {
 
         let input: Tensor<Float> = [[1, 2], [3, 4]]
         let expected: Tensor<Float> = [[-0.75, -0.25], [0.25, 0.75]]
-        XCTAssertEqual(expected, varianceGradScalar(input))
-        XCTAssertEqual(expected, varianceGradSqueezingAxes(input))
-        XCTAssertEqual(expected, varianceGradAlongAxes(input))
+        XCTAssertEqual(varianceGradScalar(input), expected)
+        XCTAssertEqual(varianceGradSqueezingAxes(input), expected)
+        XCTAssertEqual(varianceGradAlongAxes(input), expected)
     }
 
     func testExpandingShape() {
         func f1(a: Tensor<Float>) -> Tensor<Float> { a.expandingShape(at: 0).squared() }
         func f2(a: Tensor<Float>) -> Tensor<Float> { a.squared().expandingShape(at: 0) }
-        XCTAssertEqual([6, 10], pullback(at: [3, 5], in: f1)([[1, 1]]))
-        XCTAssertEqual([6, 10], pullback(at: [3, 5], in: f2)([[1, 1]]))
+        XCTAssertEqual(pullback(at: [3, 5], in: f1)([[1, 1]]), [6, 10])
+        XCTAssertEqual(pullback(at: [3, 5], in: f2)([[1, 1]]), [6, 10])
     }
 
     func testSqueezingShape() {
         func f1(a: Tensor<Float>) -> Tensor<Float> { a.squeezingShape(at: 0).squared() }
         func f2(a: Tensor<Float>) -> Tensor<Float> { a.squared().squeezingShape(at: 0) }
-        XCTAssertEqual([[6, 10]], pullback(at: [[3, 5]], in: f1)([1, 1]))
-        XCTAssertEqual([[6, 10]], pullback(at: [[3, 5]], in: f2)([1, 1]))
+        XCTAssertEqual(pullback(at: [[3, 5]], in: f1)([1, 1]), [[6, 10]])
+        XCTAssertEqual(pullback(at: [[3, 5]], in: f2)([1, 1]), [[6, 10]])
     }
 
     func testReshapedBackprop() {
         func f1(a: Tensor<Float>) -> Tensor<Float> { a.reshaped(toShape: Tensor<Int32>([2, 1])).squared() }
         func f2(a: Tensor<Float>) -> Tensor<Float> { a.squared().reshaped(toShape: Tensor<Int32>([2, 1])) }
-        XCTAssertEqual([[6, 10]], pullback(at: [[3, 5]], in: f1)([[1], [1]]))
-        XCTAssertEqual([[6, 10]], pullback(at: [[3, 5]], in: f2)([[1], [1]]))
+        XCTAssertEqual(pullback(at: [[3, 5]], in: f1)([[1], [1]]), [[6, 10]])
+        XCTAssertEqual(pullback(at: [[3, 5]], in: f2)([[1], [1]]), [[6, 10]])
     }
 
     func testReshaped() {
@@ -229,26 +229,26 @@ final class TensorAutoDiffTests: XCTestCase {
         XCTAssertEqual(input, transposedPermutationsPullback(transposed))
         XCTAssertEqual(input, transposedVariadicsPullback(transposed))
     }
-    
+
     func testSigmoid() {
         func f(a: Tensor<Float>) -> Tensor<Float> { sigmoid(a).sum() }
-        assertEqual([0.1966119, 0.25, 0.1966119], gradient(at: [-1, 0, 1], in: f), accuracy: 0.0001)
+        assertEqual(gradient(at: [-1, 0, 1], in: f), [0.1966119, 0.25, 0.1966119], accuracy: 0.0001)
     }
-    
+
     func testRelu() {
         func f(a: Tensor<Float>) -> Tensor<Float> { relu(a).sum() }
-        XCTAssertEqual([1, 0, 0], gradient(at: [5, -5, 0], in: f))
+        XCTAssertEqual(gradient(at: [5, -5, 0], in: f), [1, 0, 0])
     }
-    
+
     func testSoftmax() {
         let pb = pullback(at: Tensor(ones: [2, 2])) { (a: Tensor<Float>) in softmax(a) }
-        XCTAssertEqual([[0, 0], [0, 0]], pb([[1, 1], [1, 1]]))
-        XCTAssertEqual([[-0.25, 0.25], [0.75, -0.75]], pb([[1, 2], [4, 1]]))
+        XCTAssertEqual(pb([[1, 1], [1, 1]]), [[0, 0], [0, 0]])
+        XCTAssertEqual(pb([[1, 2], [4, 1]]), [[-0.25, 0.25], [0.75, -0.75]])
     }
 
     func testLogSoftmax() {
         let pb = pullback(at: Tensor(ones: [3, 3])) { (a: Tensor<Float>) in logSoftmax(a) }
-        XCTAssertEqual(Tensor(repeating: 5.9604645e-08, shape: [3, 3]), pb(Tensor(ones: [3, 3])))
+        XCTAssertEqual(pb(Tensor(ones: [3, 3])), Tensor(repeating: 5.9604645e-08, shape: [3, 3]))
     }
 
     // SR-9345
@@ -256,7 +256,7 @@ final class TensorAutoDiffTests: XCTestCase {
         func body(_ x: Tensor<Float>) -> Tensor<Float> {
             return foo(foo(x))
         }
-        
+
         let pb = pullback(at: Tensor(Float(10)), in: body)
         XCTAssertEqual(Tensor(1), pb(Tensor(1)))
     }

--- a/Tests/TensorFlowTests/TensorAutoDiffTests.swift
+++ b/Tests/TensorFlowTests/TensorAutoDiffTests.swift
@@ -30,15 +30,15 @@ final class TensorAutoDiffTests: XCTestCase {
         func square(_ x: Tensor<Float>) -> Tensor<Float> {
             return (x * x).sum()
         }
-        XCTAssertEqual(gradient(at: [0.1, 0.2, 0.3]), [0.2, 0.4, 0.6], in: square))
-        XCTAssertEqual(gradient(at: [[10], [20]]), [[20], [40]], in: square))
+        XCTAssertEqual(gradient(at: [0.1, 0.2, 0.3], in: square), [0.2, 0.4, 0.6])
+        XCTAssertEqual(gradient(at: [[10], [20]], in: square), [[20], [40]])
     }
 
     func testGenericGrad() {
         func square<T : TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
             return (x * x).sum()
         }
-        XCTAssertEqual(gradient(at: Tensor([0.1, 0.2, 0.3])), [0.2, 0.4, 0.6], in: square))
+        XCTAssertEqual(gradient(at: Tensor([0.1, 0.2, 0.3]), in: square), [0.2, 0.4, 0.6])
     }
 
     func testScalarGenericGrad() {
@@ -46,7 +46,7 @@ final class TensorAutoDiffTests: XCTestCase {
         func negate<T : TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
             return (1 - x).sum()
         }
-        XCTAssertEqual(gradient(at: Tensor([0.1, 0.2, 0.3])), Tensor(-1), in: negate))
+        XCTAssertEqual(gradient(at: Tensor([0.1, 0.2, 0.3]), in: negate), Tensor(-1))
     }
 
     func testScalarized() {
@@ -95,13 +95,13 @@ final class TensorAutoDiffTests: XCTestCase {
 
     func testNegate() {
         func f(a: Tensor<Float>) -> Tensor<Float> { (-a).sum() }
-        XCTAssertEqual(gradient(at: [0]), [-1], in: f))
-        XCTAssertEqual(gradient(at: [10]), [-1], in: f))
+        XCTAssertEqual(gradient(at: [0], in: f), [-1])
+        XCTAssertEqual(gradient(at: [10], in: f), [-1])
     }
 
     func testAbs() {
         func f(a: Tensor<Float>) -> Tensor<Float> { abs(a).sum() }
-        XCTAssertEqual(gradient(at: [3.0, -3.0, 0]), [1, -1, 0], in: f))
+        XCTAssertEqual(gradient(at: [3.0, -3.0, 0], in: f), [1, -1, 0])
     }
 
     func testSum() {

--- a/Tests/TensorFlowTests/TensorTests.swift
+++ b/Tests/TensorFlowTests/TensorTests.swift
@@ -25,7 +25,7 @@ final class TensorTests: XCTestCase {
             }
             return b
         }
-        XCTAssertEqual(0, selectValue(true).scalar)
+        XCTAssertEqual(selectValue(true).scalar, 0)
     }
 
     func testRankGetter() {
@@ -33,10 +33,10 @@ final class TensorTests: XCTestCase {
         let matrix = Tensor<Float>([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         let ones = Tensor<Int32>(ones: [1, 2, 2, 2, 2, 2, 1])
         let tensor = Tensor<Int32>(shape: [3, 4, 5], scalars: Array(0..<60))
-        XCTAssertEqual(1, vector.rank)
-        XCTAssertEqual(2, matrix.rank)
-        XCTAssertEqual(7, ones.rank)
-        XCTAssertEqual(3, tensor.rank)
+        XCTAssertEqual(vector.rank, 1)
+        XCTAssertEqual(matrix.rank, 2)
+        XCTAssertEqual(ones.rank, 7)
+        XCTAssertEqual(tensor.rank, 3)
     }
 
     func testShapeGetter() {
@@ -44,15 +44,15 @@ final class TensorTests: XCTestCase {
         let matrix = Tensor<Float>([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         let ones = Tensor<Int32>(ones: [1, 2, 2, 2, 2, 2, 1])
         let tensor = Tensor<Int32>(shape: [3, 4, 5], scalars: Array(0..<60))
-        XCTAssertEqual([1], vector.shape)
-        XCTAssertEqual([2, 3], matrix.shape)
-        XCTAssertEqual([1, 2, 2, 2, 2, 2, 1], ones.shape)
-        XCTAssertEqual([3, 4, 5], tensor.shape)
+        XCTAssertEqual(vector.shape, [1])
+        XCTAssertEqual(matrix.shape, [2, 3])
+        XCTAssertEqual(ones.shape, [1, 2, 2, 2, 2, 2, 1])
+        XCTAssertEqual(tensor.shape, [3, 4, 5])
     }
 
     func testTensorShapeDescription() {
-        XCTAssertEqual("[2, 2]", Tensor<Int32>(ones: [2, 2]).shape.description)
-        XCTAssertEqual("[]", Tensor(1).shape.description)
+        XCTAssertEqual(Tensor<Int32>(ones: [2, 2]).shape.description, "[2, 2]")
+        XCTAssertEqual(Tensor(1).shape.description, "[]")
     }
 
     static var allTests = [


### PR DESCRIPTION
~There are some spacing issues in a few of the changes, I'll fix that soon.~ Done. 

A doubt I had was all XCTAssertEquals in LossTests have the expected before actual, Should i update that as well? 
I'd just like to get it right this time and reflect the changes across all files needed, So that we shouldn't have to refactor this repeatedly. 

Fix: #390 
cc: @rxwei 