### PR TITLE
[Runtime] Merge '_ThreadLocalState' into 'Context'.

### DIFF
--- a/Sources/TensorFlow/Core/LazyTensorContext.swift
+++ b/Sources/TensorFlow/Core/LazyTensorContext.swift
@@ -63,8 +63,8 @@ class LazyTensorOperationsTracker {
 struct LazyTensorContext {
     private var operationsTracker = LazyTensorOperationsTracker()
 
-    static private var threadLocalContext: LazyTensorContext {
-        _ThreadLocalState.local.lazyTensorContext
+    private static var threadLocalContext: LazyTensorContext {
+        Context.local.lazyTensorContext
     }
 
     static var operationsTracker: LazyTensorOperationsTracker {

--- a/Sources/TensorFlow/Core/LazyTensorTrace.swift
+++ b/Sources/TensorFlow/Core/LazyTensorTrace.swift
@@ -91,7 +91,7 @@ class LazyTensorTraceBuilder {
 
     /// Returns a trace obtained by tracing the given function.
     static func trace<In: TensorGroup, Out: TensorGroup>(_ fn: (In) -> Out) -> LazyTensorTrace {
-        precondition(_ThreadLocalState.useLazyTensor, "Lazy tensor is not enabled for tracing.")
+        precondition(Context.local.useLazyTensor, "Lazy tensor is not enabled for tracing.")
 
         // Set up inputs for running `fn`.
         let inputOps = In._typeList.map { Self.makePlaceholder(dataType: $0) }


### PR DESCRIPTION
`Context` is effectively a user-oriented thread-local state, same as the internal-facing `_ThreadLocalState`. We don't need two thread-local states. This PR moves properties of `_ThreadLocalState` into `Context` as `internal` and `private` properties and removes `_ThreadLocalState`.