### PR TITLE
Expose the available devices from the `_ExecutionContext`.

### DIFF
--- a/Sources/TensorFlow/Core/Runtime.swift
+++ b/Sources/TensorFlow/Core/Runtime.swift
@@ -550,7 +550,7 @@ public final class _ExecutionContext {
     /// List of devices available to this execution context.
     /// Devices are represented by their names in TensorFlow notation.
     /// See documentation for `withDevice(named:perform:)` to learn about device names.
-    private var deviceNames: [String] = []
+    public private(set) var deviceNames: [String] = []
 
     /// The buffer storing a serialized TensorFlow config proto.
     public let tensorFlowConfig: UnsafeMutablePointer<TF_Buffer>

--- a/Tests/TensorFlowTests/RuntimeTests.swift
+++ b/Tests/TensorFlowTests/RuntimeTests.swift
@@ -1,0 +1,31 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import TensorFlow  // Note: not imported as @testable in order to test the public API
+
+final class RuntimeTests: XCTestCase {
+  func testDeviceNames() {
+    let deviceNames = _ExecutionContext.global.deviceNames
+    XCTAssert(deviceNames.count > 0, "Missing CPU device, got: \(deviceNames)")
+    let cpu0 = deviceNames.filter { $0.hasSuffix("/device:CPU:0") }
+    XCTAssertEqual(cpu0.count, 1, "All devices: \(deviceNames)")
+  }
+}
+
+extension RuntimeTests {
+  static var allTests = [
+    ("testDeviceNames", testDeviceNames),
+  ]
+}

--- a/Tests/TensorFlowTests/RuntimeTests.swift
+++ b/Tests/TensorFlowTests/RuntimeTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import XCTest
-import TensorFlow  // Note: not imported as @testable in order to test the public API
+import TensorFlow  // Note: not imported as @testable in order to test the public API.
 
 final class RuntimeTests: XCTestCase {
   func testDeviceNames() {

--- a/Tests/TensorFlowTests/XCTestManifests.swift
+++ b/Tests/TensorFlowTests/XCTestManifests.swift
@@ -16,25 +16,27 @@ import XCTest
 
 #if !os(macOS)
 public func allTests() -> [XCTestCaseEntry] {
+    // Please ensure the test cases remain alphabetized.
     return [
-        testCase(UtilitiesTests.allTests),
-        testCase(LossTests.allTests),
-        testCase(PRNGTests.allTests),
-        testCase(TrivialModelTests.allTests),
-        testCase(SequentialTests.allTests),
-        testCase(LayerTests.allTests),
-        testCase(TensorTests.allTests),
-        testCase(TensorGroupTests.allTests),
         testCase(BasicOperatorTests.allTests),
         testCase(ComparisonOperatorTests.allTests),
         testCase(DatasetTests.allTests),
-        testCase(MathOperatorTests.allTests),
+        testCase(LayerTests.allTests),
         testCase(LazyTensorTests.allTests),
         testCase(LazyTensorTraceTests.allTests),
         testCase(LazyTensorExplicitTraceTests.allTests),
         testCase(LazyTensorOperationTests.allTests),
         testCase(LazyTensorTFFunctionBuilderTests.allTests),
         testCase(LazyTensorEvaluationTests.allTests),
+        testCase(LossTests.allTests),
+        testCase(MathOperatorTests.allTests),
+        testCase(PRNGTests.allTests),
+        testCase(RuntimeTests.allTests),
+        testCase(SequentialTests.allTests),
+        testCase(TensorTests.allTests),
+        testCase(TensorGroupTests.allTests),
+        testCase(TrivialModelTests.allTests),
+        testCase(UtilitiesTests.allTests),
     ]
 }
 #endif


### PR DESCRIPTION
In order for code to determine what sort of parallelism strategies make sense,
we need to expose the list of available devices on the host. This change makes
the list of available devices publicly readable.

This change also orders the list of test suites alphabetically.