### PR TITLE
Fix for bug with `biasInitializer` not being used in `DenseLayer` init

### DIFF
--- a/Sources/TensorFlow/Layers/Core.swift
+++ b/Sources/TensorFlow/Layers/Core.swift
@@ -188,7 +188,7 @@ public extension Dense {
     ) {
         self.init(
             weight: weightInitializer([inputSize, outputSize]),
-            bias: Tensor(zeros: [outputSize]),
+            bias: biasInitializer([outputSize]),
             activation: activation)
     }
 }


### PR DESCRIPTION
here's a simple bug fix for getting the `biasInitializer ` to work.