### PR TITLE
Documentation update for gradient computation

### DIFF
--- a/Tests/TensorFlowTests/TensorAutoDiffTests.swift
+++ b/Tests/TensorFlowTests/TensorAutoDiffTests.swift
@@ -416,13 +416,12 @@ final class TensorAutoDiffTests: XCTestCase {
         let computedGradient = gradient(at: x) { $0.batchNormalized(alongAxis: 1).squared().sum() }
         // The expected value of the gradient was computed using the following Python code:
         // ```
-        //   with tf.session():
-        //     with tf.GradientTape() as t:
-        //       t.watch(x)
-        //       mean, var = tf.nn.moments(x, axes=1, keepdims=True)
-        //       y = tf.reduce_sum(tf.square(tf.nn.batch_normalization(
-        //       x, mean, var, offset=0, scale=1, variance_epsilon=0.001)))
-        //     tf.Tensor.eval(t.gradient(y, x))
+        //   with tf.GradientTape() as t:
+        //     t.watch(x)
+        //     mean, var = tf.nn.moments(x, axes=1, keepdims=True)
+        //     y = tf.reduce_sum(tf.square(tf.nn.batch_normalization(
+        //     x, mean, var, offset=0, scale=1, variance_epsilon=0.001)))
+        //   print(tf.Tensor.eval(t.gradient(y, x)))
         // ```
         let expectedGradient = Tensor<Float>([
             [-1.0127544e-02, -1.0807812e-03, -7.6115131e-04,  1.5857220e-03,  1.0383606e-02],

--- a/Tests/TensorFlowTests/TensorAutoDiffTests.swift
+++ b/Tests/TensorFlowTests/TensorAutoDiffTests.swift
@@ -416,12 +416,13 @@ final class TensorAutoDiffTests: XCTestCase {
         let computedGradient = gradient(at: x) { $0.batchNormalized(alongAxis: 1).squared().sum() }
         // The expected value of the gradient was computed using the following Python code:
         // ```
-        //   with tf.GradientTape() as t:
-        //     t.watch(x)
-        //     mean, var = tf.nn.moments(x, axes=1, keepdims=True)
-        //     y = tf.reduce_sum(tf.square(tf.nn.batch_normalization(
-        //     x, mean, var, offset=0, scale=1, variance_epsilon=0.001)))
-        //   print(t.gradient(y, x))
+        //   with tf.session():
+        //     with tf.GradientTape() as t:
+        //       t.watch(x)
+        //       mean, var = tf.nn.moments(x, axes=1, keepdims=True)
+        //       y = tf.reduce_sum(tf.square(tf.nn.batch_normalization(
+        //       x, mean, var, offset=0, scale=1, variance_epsilon=0.001)))
+        //     tf.Tensor.eval(t.gradient(y, x))
         // ```
         let expectedGradient = Tensor<Float>([
             [-1.0127544e-02, -1.0807812e-03, -7.6115131e-04,  1.5857220e-03,  1.0383606e-02],


### PR DESCRIPTION
Sorry for being meticulous about it, but the docs mention that `print(t.gradient(y,x))` directly would give you the value, whereas you would get `Tensor("AddN_45:0", shape=(5, 5), dtype=float32)`. This change allows for the values to be printed.