### PR TITLE
Revert "Disable shape inference (temporarily) to move tensor commit-id.

### DIFF
--- a/Sources/TensorFlow/Core/LazyTensorShapeInference.swift
+++ b/Sources/TensorFlow/Core/LazyTensorShapeInference.swift
@@ -44,8 +44,6 @@ extension LazyTensorOperation {
     }
 
     func updateOutputShapes() {
-        outputShapes = Array<TensorShape?>(repeating: nil, count: outputCount)
-        /*
         let status = TF_NewStatus()
         defer { TF_DeleteStatus(status) }
 
@@ -100,6 +98,5 @@ extension LazyTensorOperation {
             let hasUnknownDims = dims.contains { $0 == -1 }
             return hasUnknownDims ? nil : TensorShape(dims)
         }
-        */
     }
 }

--- a/Sources/TensorFlow/Core/LazyTensorShapeInference.swift
+++ b/Sources/TensorFlow/Core/LazyTensorShapeInference.swift
@@ -80,7 +80,6 @@ extension LazyTensorOperation {
             tfeOp.op,
             /*input_shapes*/ inputShapeList,
             /*input_tensors*/ nil,
-            /*num_input_tensors*/ 0,
             /*input_tensors_as_shapes*/ nil,
             /*input_resource_shapes_and_types*/ nil,
             /*output_shapes*/ &outputShapeListPtr,

--- a/Tests/TensorFlowTests/XCTestManifests.swift
+++ b/Tests/TensorFlowTests/XCTestManifests.swift
@@ -26,7 +26,7 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(LazyTensorTraceTests.allTests),
         testCase(LazyTensorExplicitTraceTests.allTests),
         testCase(LazyTensorOperationTests.allTests),
-        // testCase(LazyTensorShapeInferenceTests.allTests),
+        testCase(LazyTensorShapeInferenceTests.allTests),
         testCase(LazyTensorTFFunctionBuilderTests.allTests),
         testCase(LazyTensorEvaluationTests.allTests),
         testCase(LossTests.allTests),


### PR DESCRIPTION
…d. (#427)"

This reverts commit 8258171504d505c3fef99641213eeea2d1ba67fa.