### PR TITLE
Shape check in `==` and `!=`

### DIFF
--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -396,13 +396,17 @@ extension Tensor: ExpressibleByArrayLiteral {
 extension Tensor: Equatable where Scalar: Equatable {
     @inlinable
     public static func == (lhs: Tensor, rhs: Tensor) -> Bool {
-        // TODO: This is not correct due to broadcasting.
+        guard lhs.shape == rhs.shape else {
+            return false
+        }
         return (lhs .== rhs).all()
     }
 
     @inlinable
     public static func != (lhs: Tensor, rhs: Tensor) -> Bool {
-        // TODO: This is not correct due to broadcasting.
+        guard lhs.shape == rhs.shape else {
+            return true
+        }
         return (lhs .!= rhs).any()
     }
 }

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -282,7 +282,7 @@ final class LayerTests: XCTestCase {
         let layer = GlobalMaxPool1D<Float>()
         let input = Tensor(shape: [1, 10, 1], scalars: (0..<10).map(Float.init))
         let output = layer.inferring(from: input)
-        let expected = Tensor<Float>([9])
+        let expected = Tensor<Float>([[9]])
         XCTAssertEqual(output, expected)
     }
 
@@ -290,7 +290,7 @@ final class LayerTests: XCTestCase {
         let layer = GlobalMaxPool2D<Float>()
         let input = Tensor(shape: [1, 2, 10, 1], scalars: (0..<20).map(Float.init))
         let output = layer.inferring(from: input)
-        let expected = Tensor<Float>([19])
+        let expected = Tensor<Float>([[19]])
         XCTAssertEqual(output, expected)
     }
 
@@ -298,7 +298,7 @@ final class LayerTests: XCTestCase {
         let layer = GlobalMaxPool3D<Float>()
         let input = Tensor<Float>(shape: [1, 2, 3, 5, 1], scalars: (0..<30).map(Float.init))
         let output = layer.inferring(from: input)
-        let expected = Tensor<Float>([29])
+        let expected = Tensor<Float>([[29]])
         XCTAssertEqual(output, expected)
     }
 

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -155,7 +155,7 @@ final class LayerTests: XCTestCase {
         let filter =  Tensor(shape: [2, 2, 2, 2], scalars: (0..<16).map(Float.init))
         let bias = Tensor<Float>([1, 2, 3, 4])
         let layer = DepthwiseConv2D<Float>(filter: filter, bias: bias, activation: identity,
-                                           strides: (2, 2), padding: .valid)
+                                           strides: (2, 2), padding: .same)
         let input = Tensor(shape: [1, 1, 8, 2], scalars: (0..<16).map(Float.init))
         let output = layer.inferring(from: input)
         let expected = Tensor<Float>(shape: [1, 1, 4, 4],

--- a/Tests/TensorFlowTests/OperatorTests/MathTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/MathTests.swift
@@ -149,7 +149,7 @@ final class MathOperatorTests: XCTestCase {
     func testRelu() {
         let x = Tensor<Float>([[-1.0, 2.0, 3.0]])
         let y = relu(x)
-        let expectedY = Tensor<Float>([0.0, 2.0, 3.0])
+        let expectedY = Tensor<Float>([[0.0, 2.0, 3.0]])
         XCTAssertEqual(y, expectedY)
     }
 
@@ -163,7 +163,7 @@ final class MathOperatorTests: XCTestCase {
     func testLeakyRelu() {
         let x = Tensor<Float>([[-1.0, 2.0, 3.0]])
         let y = leakyRelu(x, alpha: 0.4)
-        let expectedY = Tensor<Float>([-0.4, 2.0, 3.0])
+        let expectedY = Tensor<Float>([[-0.4, 2.0, 3.0]])
         XCTAssertEqual(y, expectedY)
     }
 
@@ -236,13 +236,13 @@ final class MathOperatorTests: XCTestCase {
             Tensor(shape: [5], scalars: [1, 2, 3, 4, 5]))
         XCTAssertEqual(
             x.mean(alongAxes: 0),
-            Tensor(shape: [5], scalars: [1, 2, 3, 4, 5]))
+            Tensor(shape: [1, 5], scalars: [1, 2, 3, 4, 5]))
         XCTAssertEqual(
             x.mean(squeezingAxes: 1),
             Tensor(shape: [2], scalars: [3, 3]))
         XCTAssertEqual(
             x.mean(alongAxes: 1),
-            Tensor(shape: [1, 2], scalars: [3, 3]))
+            Tensor(shape: [2, 1], scalars: [3, 3]))
 
         XCTAssertEqual(x.variance(), Tensor(2))
         XCTAssertEqual(
@@ -250,13 +250,13 @@ final class MathOperatorTests: XCTestCase {
             Tensor(shape: [5], scalars: [0, 0, 0, 0, 0]))
         XCTAssertEqual(
             x.variance(alongAxes: 0),
-            Tensor(shape: [5], scalars: [0, 0, 0, 0, 0]))
+            Tensor(shape: [1, 5], scalars: [0, 0, 0, 0, 0]))
         XCTAssertEqual(
             x.variance(squeezingAxes: 1),
             Tensor(shape: [2], scalars: [2, 2]))
         XCTAssertEqual(
             x.variance(alongAxes: 1),
-            Tensor(shape: [1, 2], scalars: [2, 2]))
+            Tensor(shape: [2, 1], scalars: [2, 2]))
     }
 
     func testCumulativeSum() {
@@ -309,7 +309,7 @@ final class MathOperatorTests: XCTestCase {
 
     func testStandardDeviation() {
         XCTAssertEqual(Tensor<Float>([1]).standardDeviation(), Tensor(0))
-        XCTAssertEqual(Tensor<Float>([0, 1]).standardDeviation(alongAxes: 0), Tensor(0.5))
+        XCTAssertEqual(Tensor<Float>([0, 1]).standardDeviation(alongAxes: 0), Tensor([0.5]))
         XCTAssertEqual(Tensor<Float>([0, 1]).standardDeviation(), Tensor(0.5))
         XCTAssertEqual(
             Tensor<Float>(rangeFrom: 0, to: 10, stride: 1).standardDeviation().scalarized(),

--- a/Tests/TensorFlowTests/TensorAutoDiffTests.swift
+++ b/Tests/TensorFlowTests/TensorAutoDiffTests.swift
@@ -46,7 +46,7 @@ final class TensorAutoDiffTests: XCTestCase {
         func negate<T : TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
             return (1 - x).sum()
         }
-        XCTAssertEqual(gradient(at: Tensor([0.1, 0.2, 0.3]), in: negate), Tensor(-1))
+        XCTAssertEqual(gradient(at: Tensor([0.1, 0.2, 0.3]), in: negate), Tensor([-1, -1, -1]))
     }
 
     func testScalarized() {
@@ -318,7 +318,7 @@ final class TensorAutoDiffTests: XCTestCase {
             [1, 2, 3],
             [1, 2, 3]]
         )
-        let expected: Tensor<Float> = Tensor([[4, 8, 12]])
+        let expected: Tensor<Float> = Tensor([4, 8, 12])
         XCTAssertEqual(expected, pb(inputTensor))
     }
 
@@ -342,7 +342,7 @@ final class TensorAutoDiffTests: XCTestCase {
             foo(tensor: x, other: Tensor([[1, 2, 3], [1, 2, 3], [1, 2, 3]]))
         }
         let inputTensor: Tensor<Float> = Tensor([[[[[[1, 2, 3]]]]]])
-        let expected: Tensor<Float> = Tensor([[1, 2, 3]])
+        let expected: Tensor<Float> = Tensor([1, 2, 3])
 
         XCTAssertEqual(expected, pb(inputTensor))
     }

--- a/Tests/TensorFlowTests/TensorTests.swift
+++ b/Tests/TensorFlowTests/TensorTests.swift
@@ -54,11 +54,24 @@ final class TensorTests: XCTestCase {
         XCTAssertEqual(Tensor<Int32>(ones: [2, 2]).shape.description, "[2, 2]")
         XCTAssertEqual(Tensor(1).shape.description, "[]")
     }
+    
+    func testEquality() {
+        let tensor = Tensor<Float>([0, 1, 2, 3, 4, 5])
+        let zeros = Tensor<Float>(zeros: [6])
+        
+        XCTAssertTrue(tensor == tensor)
+        XCTAssertFalse(tensor != tensor)
+        XCTAssertFalse(tensor == zeros)
+        XCTAssertTrue(tensor != zeros)
+        XCTAssertFalse(tensor == tensor.reshaped(to: [2, 3]))
+        XCTAssertTrue(tensor != tensor.reshaped(to: [2, 3]))
+    }
 
     static var allTests = [
         ("testSimpleCond", testSimpleCond),
         ("testRankGetter", testRankGetter),
         ("testShapeGetter", testShapeGetter),
-        ("testTensorShapeDescription", testTensorShapeDescription)
+        ("testTensorShapeDescription", testTensorShapeDescription),
+        ("testEquality", testEquality),
     ]
 }


### PR DESCRIPTION
Resolved TODO in `==` and `!=`.

> // TODO: This is not correct due to broadcasting.

IMO, it doesn't make sense `[1, 2] == [[1, 2], [1, 2]]` is `true`, so I simply disabled broadcasting.

There was some test codes don't check equality strictly. Also fixed them.