### PR TITLE
Minor tweak: materialize inputs on demand in lazy tensor

### DIFF
--- a/Sources/TensorFlow/Core/LazyTensorOperation.swift
+++ b/Sources/TensorFlow/Core/LazyTensorOperation.swift
@@ -848,7 +848,7 @@ extension LazyTensorOperation {
 
     /// Converts symbolic tensor inputs to concrete inputs if the
     /// associated `LazyTensorOperation` has been materialized.
-    private func maybeMaterializeInputs() {
+    func maybeMaterializeInputs() {
         /// If `lazyTensor` is symbolic and the associated `LazyTensorOperation`
         /// has been materialized, return the corresponding concrete `LazyTensorHandle`.
         /// Otherwise, return `lazyTensor` untouched.
@@ -893,9 +893,5 @@ extension LazyTensorOperation {
             lazyOp.outputShapes = lazyOp.outputs!.map { $0.shape }
             start = end
         }
-
-        // On all the live operations rewrite the inputs so that we drop references
-        // to the LazyTensorOperations.
-        LazyTensorHandle.forEachOperation { $0.maybeMaterializeInputs() }
     }
 }

--- a/Sources/TensorFlow/Core/LazyTensorOperation.swift
+++ b/Sources/TensorFlow/Core/LazyTensorOperation.swift
@@ -846,8 +846,8 @@ extension LazyTensorOperation {
         return outputs!
     }
 
-    /// Converts symbolic tensor inputs to concrete inputs if the
-    /// associated `LazyTensorOperation` has been materialized.
+    /// Converts symbolic tensor inputs to concrete inputs if the associated `LazyTensorOperation`
+    /// has been materialized.
     func maybeMaterializeInputs() {
         /// If `lazyTensor` is symbolic and the associated `LazyTensorOperation`
         /// has been materialized, return the corresponding concrete `LazyTensorHandle`.

--- a/Sources/TensorFlow/Core/LazyTensorTrace.swift
+++ b/Sources/TensorFlow/Core/LazyTensorTrace.swift
@@ -235,6 +235,7 @@ class LazyTensorTraceBuilder {
         if let cachedLazyOp = lazyOpsCache[id] {
             return cachedLazyOp
         }
+        lazyOp.maybeMaterializeInputs()
         precondition(
             lazyOp.name != "Placeholder",
             "The operation cannot already be a placeholder.")


### PR DESCRIPTION
Instead of iterating over all the lazy tensor operations and converting symbolic inputs that are materialized to concrete inputs, this PR triggers the conversion on demand only when it is needed during trace generation.