### PR TITLE
Lazy Tensor: Do not trigger materialization during shape inference

### DIFF
--- a/Sources/TensorFlow/Core/LazyTensorShapeInference.swift
+++ b/Sources/TensorFlow/Core/LazyTensorShapeInference.swift
@@ -47,15 +47,30 @@ extension LazyTensorOperation {
         let status = TF_NewStatus()
         defer { TF_DeleteStatus(status) }
 
-        let inputShapes: [TensorShape] = inputs.lazy.flatMap { (input: Input) -> [TensorShape] in
+        /// Returns shape only if it has already been computed.
+        func shapeIfAvailable(_ handle: LazyTensorHandle) -> TensorShape? {
+            switch handle.handle {
+            case .symbolic(let op, let index, _):
+                if let shape = op.outputShapes[index] { return shape }
+                return nil
+            case .concrete(let tfeHandle, _): return tfeHandle.shape
+            }
+        }
+
+        LazyTensorHandle._materializationCallback("inputshape_start")
+        let inputShapes: [TensorShape?] = inputs.lazy.flatMap { (input: Input) -> [TensorShape?] in
             switch input {
-            case .single(let handle): return [handle.shape]
-            case .list(let values): return values.lazy.map { $0.shape }
+            case .single(let handle): return [shapeIfAvailable(handle)]
+            case .list(let values): return values.lazy.map { shapeIfAvailable($0) }
             }
         }
         let inputShapeList = TF_NewShapeAndTypeList(/*num_shapes*/ Int32(inputShapes.count))
         defer { TF_DeleteShapeAndTypeList(inputShapeList) }
         for (i, shape) in inputShapes.enumerated() {
+            guard let shape = shape else {
+                TF_ShapeAndTypeListSetUnknownShape(inputShapeList, Int32(i))
+                continue
+            }
             let int64_dimensions = shape.dimensions.map { Int64($0) }
             int64_dimensions.withUnsafeBufferPointer { buffer in
                 TF_ShapeAndTypeListSetShape(

--- a/Tests/TensorFlowTests/LazyTensorShapeInferenceTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorShapeInferenceTests.swift
@@ -93,9 +93,25 @@ final class LazyTensorShapeInferenceTests: XCTestCase {
         XCTAssertTrue(cLazyTensorOperation.isMaterialized)
     }
 
+    func testNoMaterialization() {
+        // Compute [2, 2] using another op so that it won't be available unless it is materialized.
+        let a = Tensor<Int32>(shape: [2], scalars: [1, 1])
+        let b = Tensor<Int32>(1)
+        let dims = a + b
+        let m = Raw.fill(dims: dims, value: Tensor<Float>(1.0))
+        let result = Raw.matMul(m, m)
+        let mLazyTensorOperation = m._lazyTensor!.lazyTensorOperation!
+        // Note that we have not triggered materialization yet. So, it should not have happened
+        // implicitly during shape inference.
+        XCTAssertFalse(mLazyTensorOperation.isMaterialized)
+        XCTAssertEqual(result.shape, [2, 2])
+        XCTAssertTrue(mLazyTensorOperation.isMaterialized)
+    }
+
     static var allTests = [
         ("testSimpleShapeComputations", testSimpleShapeComputations),
-        ("testShapeComputationsWithInputTensors", testShapeComputationsWithInputTensors)
+        ("testShapeComputationsWithInputTensors", testShapeComputationsWithInputTensors),
+        ("testNoMaterialization", testNoMaterialization)
     ]
 }
 


### PR DESCRIPTION
This PR avoids triggering materialization during the shape inference process. This tweak avoid reduces the overhead due to shape inference. 