### PR TITLE
Disable failing `TensorFlowAutoDiffTests.testTensorInitStacking` test.

### DIFF
--- a/Tests/TensorFlowTests/TensorAutoDiffTests.swift
+++ b/Tests/TensorFlowTests/TensorAutoDiffTests.swift
@@ -153,7 +153,7 @@ final class TensorAutoDiffTests: XCTestCase {
         XCTAssertEqual(varianceGradAlongAxes(input), expected)
     }
 
-    /*TODO:(https://bugs.swift.org/browse/TF-772): Disabling this case as assertions fail.
+    /*TODO:(https://bugs.swift.org/browse/TF-771): Disabling this case as assertions fail.
     func testTensorInitStacking() {
         let a1 = Tensor<Float>([1, 2, 3, 4, 5])
         let b1 = Tensor<Float>([6, 7, 8, 9, 10])
@@ -449,7 +449,7 @@ final class TensorAutoDiffTests: XCTestCase {
         ("testSum", testSum),
         ("testMean", testMean),
         ("testVariance", testVariance),
-        // TODO(https://bugs.swift.org/browse/TF-772): Disabling the failing test.
+        // TODO(https://bugs.swift.org/browse/TF-771): Disabling the failing test.
         // ("testTensorInitStacking", testTensorInitStacking),
         ("testExpandingShape", testExpandingShape),
         ("testSqueezingShape", testSqueezingShape),

--- a/Tests/TensorFlowTests/TensorAutoDiffTests.swift
+++ b/Tests/TensorFlowTests/TensorAutoDiffTests.swift
@@ -153,6 +153,7 @@ final class TensorAutoDiffTests: XCTestCase {
         XCTAssertEqual(varianceGradAlongAxes(input), expected)
     }
 
+    /*TODO:(https://bugs.swift.org/browse/TF-772): Disabling this case as assertions fail.
     func testTensorInitStacking() {
         let a1 = Tensor<Float>([1, 2, 3, 4, 5])
         let b1 = Tensor<Float>([6, 7, 8, 9, 10])
@@ -164,6 +165,7 @@ final class TensorAutoDiffTests: XCTestCase {
         XCTAssertEqual(a1, grads.0)
         XCTAssertEqual(b1, grads.1)
     }
+    */
 
     func testExpandingShape() {
         func f1(a: Tensor<Float>) -> Tensor<Float> { a.expandingShape(at: 0).squared() }
@@ -447,7 +449,8 @@ final class TensorAutoDiffTests: XCTestCase {
         ("testSum", testSum),
         ("testMean", testMean),
         ("testVariance", testVariance),
-        ("testTensorInitStacking", testTensorInitStacking),
+        // TODO(https://bugs.swift.org/browse/TF-772): Disabling the failing test.
+        // ("testTensorInitStacking", testTensorInitStacking),
         ("testExpandingShape", testExpandingShape),
         ("testSqueezingShape", testSqueezingShape),
         ("testReshapedBackprop", testReshapedBackprop),


### PR DESCRIPTION
(See https://bugs.swift.org/browse/TF-771)
The compiler is not crashing, but the results are not as expected. Disabling this test to unblock nightly builds. 