### PR TITLE
Fix a compiler warning in lazy tensor.

### DIFF
--- a/Sources/TensorFlow/Core/LazyTensorOperation.swift
+++ b/Sources/TensorFlow/Core/LazyTensorOperation.swift
@@ -95,7 +95,7 @@ class LazyTensorHandle: _AnyTensorHandle {
     var lazyTensorOperation: LazyTensorOperation? {
         switch handle {
         case .symbolic(let op, _, _): return op
-        case .concrete(_, _): return nil
+        case .concrete: return nil
         }
     }
 

--- a/Sources/TensorFlow/Core/LazyTensorOperation.swift
+++ b/Sources/TensorFlow/Core/LazyTensorOperation.swift
@@ -95,7 +95,7 @@ class LazyTensorHandle: _AnyTensorHandle {
     var lazyTensorOperation: LazyTensorOperation? {
         switch handle {
         case .symbolic(let op, _, _): return op
-        case .concrete(_): return nil
+        case .concrete(_, _): return nil
         }
     }
 

--- a/Tests/TensorFlowTests/LazyTensorHandleTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorHandleTests.swift
@@ -152,15 +152,15 @@ final class LazyTensorHandleTests: XCTestCase {
     private func isSymbolic(_ t: LazyTensorHandle?) -> Bool {
         guard let t = t else { return false }
         switch t.handle {
-        case .symbolic(_): return true
-        case .concrete(_): return false
+        case .symbolic(_, _, _): return true
+        case .concrete(_, _): return false
         }
     }
 
     private func isMaterializedConcrete(_ t: LazyTensorHandle?) -> Bool {
         guard let t = t else { return false }
         switch t.handle {
-        case .symbolic(_): return true
+        case .symbolic(_, _, _): return true
         case .concrete(_, let isMaterialized): return isMaterialized
         }
     }

--- a/Tests/TensorFlowTests/LazyTensorHandleTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorHandleTests.swift
@@ -152,15 +152,15 @@ final class LazyTensorHandleTests: XCTestCase {
     private func isSymbolic(_ t: LazyTensorHandle?) -> Bool {
         guard let t = t else { return false }
         switch t.handle {
-        case .symbolic(_, _, _): return true
-        case .concrete(_, _): return false
+        case .symbolic: return true
+        case .concrete: return false
         }
     }
 
     private func isMaterializedConcrete(_ t: LazyTensorHandle?) -> Bool {
         guard let t = t else { return false }
         switch t.handle {
-        case .symbolic(_, _, _): return true
+        case .symbolic: return true
         case .concrete(_, let isMaterialized): return isMaterialized
         }
     }


### PR DESCRIPTION
With the latest toolchain, we get the following warning: 
```
warning: cannot match several associated values at once, implicitly tupling the associated values and trying to match that instead
        case .concrete(_): return nil
```

This PR fixes the warning.