### PR TITLE
Suppress comparable operator warning

### DIFF
--- a/Tests/TensorFlowTests/OperatorTests/ComparisonTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/ComparisonTests.swift
@@ -25,7 +25,7 @@ final class ComparisonOperatorTests: XCTestCase {
     func testLexicographicalComparison() {
         let x = Tensor<Float>([0, 1, 2, 3, 4])
         let y = Tensor<Float>([2, 3, 4, 5, 6])
-        XCTAssertTrue(x < y)
+        XCTAssertTrue((x .< y).all())
     }
 
     func testIsAlmostEqual() {


### PR DESCRIPTION
#477 deprecates `<`. Just updating the test so that the build doesn't throw this warning.
```
/mnt/g/code/swift-apis/Tests/TensorFlowTests/OperatorTests/ComparisonTests.swift:28:25: warning: '<' is deprecated: This API will be removed after Swift for TensorFlow 0.4.
Use `(lhs .< rhs).all()` instead.
        XCTAssertTrue(x < y)   
```
