### PR TITLE
Fix: ZeroPadding*D are different from Keras

### DIFF
--- a/Sources/TensorFlow/Layers/Convolutional.swift
+++ b/Sources/TensorFlow/Layers/Convolutional.swift
@@ -564,7 +564,7 @@ public struct ZeroPadding1D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        input.padded(forSizes: [(padding.0, padding.1)])
+        input.padded(forSizes: [(0, 0), padding, (0, 0)])
     }
 }
 
@@ -596,7 +596,7 @@ public struct ZeroPadding2D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.padded(forSizes: [padding.0, padding.1])
+        input.padded(forSizes: [(0, 0), padding.0, padding.1, (0, 0)])
     }
 }
 
@@ -628,7 +628,7 @@ public struct ZeroPadding3D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer
     /// - Returns: The output.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.padded(forSizes: [padding.0, padding.1, padding.2])
+        input.padded(forSizes: [(0, 0), padding.0, padding.1, padding.2, (0, 0)])
     }
 }
 

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -251,6 +251,22 @@ final class LayerTests: XCTestCase {
                                      scalars: [0.0, 0.0, 0.0, 1.0, 2.0, 0.0, 0.0])
         XCTAssertEqual(output, expected)
     }
+    
+    func testZeroPadding1DGradient() {
+        let input = Tensor<Float>(shape: [1, 3, 1], scalars: [0.0, 1.0, 2.0])
+        let layer = ZeroPadding1D<Float>(padding: 2)
+        let computedGradient = gradient(at: input, layer) { $1($0).sum() }
+        // The expected value of the gradient was computed using the following Python code:
+        // ```
+        // layer = tf.keras.layers.ZeroPadding1D(2)
+        // with tf.GradientTape() as t:
+        //     t.watch(x)
+        //     y = tf.reduce_sum(layer(x))
+        // print(t.gradient(y, x))
+        // ```
+        let expectedGradient = Tensor<Float>(onesLike: input)
+        XCTAssertEqual(computedGradient.0, expectedGradient)
+    }
 
     func testZeroPadding2D() {
         let input = Tensor<Float>(shape: [1, 3, 1, 1], scalars: [0.0, 1.0, 2.0])
@@ -260,6 +276,22 @@ final class LayerTests: XCTestCase {
                                      scalars: [0.0, 0.0, 1.0, 0.0, 2.0, 0.0])
         XCTAssertEqual(output, expected)
     }
+    
+    func testZeroPadding2DGradient() {
+        let input = Tensor<Float>(shape: [1, 3, 1, 1], scalars: [0.0, 1.0, 2.0])
+        let layer = ZeroPadding2D<Float>(padding: ((0, 0), (0, 1)))
+        let computedGradient = gradient(at: input, layer) { $1($0).sum() }
+        // The expected value of the gradient was computed using the following Python code:
+        // ```
+        // layer = tf.keras.layers.ZeroPadding2D(((0, 0), (0, 1)))
+        // with tf.GradientTape() as t:
+        //     t.watch(x)
+        //     y = tf.reduce_sum(layer(x))
+        // print(t.gradient(y, x))
+        // ```
+        let expectedGradient = Tensor<Float>(onesLike: input)
+        XCTAssertEqual(computedGradient.0, expectedGradient)
+    }
 
     func testZeroPadding3D() {
         let input = Tensor<Float>(shape:[1, 3, 1, 1, 1], scalars: [0.0, 1.0, 2.0])
@@ -267,6 +299,22 @@ final class LayerTests: XCTestCase {
         let output = layer.inferring(from: input)
         let expected = Tensor<Float>(shape: [1, 3, 2, 1, 1], scalars: [0, 0, 1, 0, 2, 0])
         XCTAssertEqual(output, expected)
+    }
+    
+    func testZeroPadding3DGradient() {
+        let input = Tensor<Float>(shape:[1, 3, 1, 1, 1], scalars: [0.0, 1.0, 2.0])
+        let layer = ZeroPadding3D<Float>(padding: ((0, 0), (0, 1), (0, 0)))
+        let computedGradient = gradient(at: input, layer) { $1($0).sum() }
+        // The expected value of the gradient was computed using the following Python code:
+        // ```
+        // layer = tf.keras.layers.ZeroPadding3D(((0, 0), (0, 1), (0, 0))
+        // with tf.GradientTape() as t:
+        //     t.watch(x)
+        //     y = tf.reduce_sum(layer(x))
+        // print(t.gradient(y, x))
+        // ```
+        let expectedGradient = Tensor<Float>(onesLike: input)
+        XCTAssertEqual(computedGradient.0, expectedGradient)
     }
 
     func testMaxPool1D() {
@@ -1067,8 +1115,11 @@ final class LayerTests: XCTestCase {
         ("testSeparableConv1D", testSeparableConv1D),
         ("testSeparableConv2D", testSeparableConv2D),
         ("testZeroPadding1D", testZeroPadding1D),
+        ("testZeroPadding1DGradient", testZeroPadding1DGradient),
         ("testZeroPadding2D", testZeroPadding2D),
+        ("testZeroPadding2DGradient", testZeroPadding2DGradient),
         ("testZeroPadding3D", testZeroPadding3D),
+        ("testZeroPadding3DGradient", testZeroPadding3DGradient),
         ("testMaxPool1D", testMaxPool1D),
         ("testMaxPool1DGradient", testMaxPool1DGradient),
         ("testMaxPool2D", testMaxPool2D),

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -253,18 +253,20 @@ final class LayerTests: XCTestCase {
     }
     
     func testZeroPadding1DGradient() {
-        let input = Tensor<Float>(shape: [1, 3, 1], scalars: [0.0, 1.0, 2.0])
+        let x = Tensor<Float>(shape: [1, 3, 1], scalars: [0.0, 1.0, 2.0])
         let layer = ZeroPadding1D<Float>(padding: 2)
-        let computedGradient = gradient(at: input, layer) { $1($0).sum() }
+        let computedGradient = gradient(at: x, layer) { $1($0).sum() }
         // The expected value of the gradient was computed using the following Python code:
         // ```
+        // import tensorflow as tf
+        // x = tf.reshape(tf.constant([0.0, 1.0, 2.0]), [1, 3, 1])
         // layer = tf.keras.layers.ZeroPadding1D(2)
         // with tf.GradientTape() as t:
         //     t.watch(x)
         //     y = tf.reduce_sum(layer(x))
         // print(t.gradient(y, x))
         // ```
-        let expectedGradient = Tensor<Float>(onesLike: input)
+        let expectedGradient = Tensor<Float>(onesLike: x)
         XCTAssertEqual(computedGradient.0, expectedGradient)
     }
 
@@ -278,18 +280,20 @@ final class LayerTests: XCTestCase {
     }
     
     func testZeroPadding2DGradient() {
-        let input = Tensor<Float>(shape: [1, 3, 1, 1], scalars: [0.0, 1.0, 2.0])
+        let x = Tensor<Float>(shape: [1, 3, 1, 1], scalars: [0.0, 1.0, 2.0])
         let layer = ZeroPadding2D<Float>(padding: ((0, 0), (0, 1)))
-        let computedGradient = gradient(at: input, layer) { $1($0).sum() }
+        let computedGradient = gradient(at: x, layer) { $1($0).sum() }
         // The expected value of the gradient was computed using the following Python code:
         // ```
+        // import tensorflow as tf
+        // x = tf.reshape(tf.constant([0.0, 1.0, 2.0]), [1, 3, 1, 1])
         // layer = tf.keras.layers.ZeroPadding2D(((0, 0), (0, 1)))
         // with tf.GradientTape() as t:
         //     t.watch(x)
         //     y = tf.reduce_sum(layer(x))
         // print(t.gradient(y, x))
         // ```
-        let expectedGradient = Tensor<Float>(onesLike: input)
+        let expectedGradient = Tensor<Float>(onesLike: x)
         XCTAssertEqual(computedGradient.0, expectedGradient)
     }
 
@@ -302,18 +306,20 @@ final class LayerTests: XCTestCase {
     }
     
     func testZeroPadding3DGradient() {
-        let input = Tensor<Float>(shape:[1, 3, 1, 1, 1], scalars: [0.0, 1.0, 2.0])
+        let x = Tensor<Float>(shape:[1, 3, 1, 1, 1], scalars: [0.0, 1.0, 2.0])
         let layer = ZeroPadding3D<Float>(padding: ((0, 0), (0, 1), (0, 0)))
-        let computedGradient = gradient(at: input, layer) { $1($0).sum() }
+        let computedGradient = gradient(at: x, layer) { $1($0).sum() }
         // The expected value of the gradient was computed using the following Python code:
         // ```
-        // layer = tf.keras.layers.ZeroPadding3D(((0, 0), (0, 1), (0, 0))
+        // import tensorflow as tf
+        // x = tf.reshape(tf.constant([0.0, 1.0, 2.0]), [1, 3, 1, 1, 1])
+        // layer = tf.keras.layers.ZeroPadding3D(((0, 0), (0, 1), (0, 0)))
         // with tf.GradientTape() as t:
         //     t.watch(x)
         //     y = tf.reduce_sum(layer(x))
         // print(t.gradient(y, x))
         // ```
-        let expectedGradient = Tensor<Float>(onesLike: input)
+        let expectedGradient = Tensor<Float>(onesLike: x)
         XCTAssertEqual(computedGradient.0, expectedGradient)
     }
 

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -244,26 +244,28 @@ final class LayerTests: XCTestCase {
     }
 
     func testZeroPadding1D() {
-        let input = Tensor<Float>([0.0, 1.0, 2.0])
+        let input = Tensor<Float>(shape: [1, 3, 1], scalars: [0.0, 1.0, 2.0])
         let layer = ZeroPadding1D<Float>(padding: 2)
         let output = layer.inferring(from: input)
-        let expected = Tensor<Float>([0.0, 0.0, 0.0, 1.0, 2.0, 0.0, 0.0])
+        let expected = Tensor<Float>(shape: [1, 7, 1],
+                                     scalars: [0.0, 0.0, 0.0, 1.0, 2.0, 0.0, 0.0])
         XCTAssertEqual(output, expected)
     }
 
     func testZeroPadding2D() {
-        let input = Tensor<Float>(shape: [3, 1], scalars: [0.0, 1.0, 2.0])
+        let input = Tensor<Float>(shape: [1, 3, 1, 1], scalars: [0.0, 1.0, 2.0])
         let layer = ZeroPadding2D<Float>(padding: ((0, 0), (0, 1)))
         let output = layer.inferring(from: input)
-        let expected = Tensor<Float>([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]])
+        let expected = Tensor<Float>(shape: [1, 3, 2, 1],
+                                     scalars: [0.0, 0.0, 1.0, 0.0, 2.0, 0.0])
         XCTAssertEqual(output, expected)
     }
 
     func testZeroPadding3D() {
-        let input = Tensor<Float>(shape:[3, 1, 1], scalars: [0.0, 1.0, 2.0])
+        let input = Tensor<Float>(shape:[1, 3, 1, 1, 1], scalars: [0.0, 1.0, 2.0])
         let layer = ZeroPadding3D<Float>(padding: ((0, 0), (0, 1), (0, 0)))
         let output = layer.inferring(from: input)
-        let expected = Tensor<Float>(shape: [3, 2, 1], scalars: [0, 0, 1, 0, 2, 0])
+        let expected = Tensor<Float>(shape: [1, 3, 2, 1, 1], scalars: [0, 0, 1, 0, 2, 0])
         XCTAssertEqual(output, expected)
     }
 


### PR DESCRIPTION
Resolve #494 
Inputs of `ZeroPadding*D` should have batch and feature dimensions.

Also added these gradient tests for #402.