### PR TITLE
Change all tabs to four spaces.

### DIFF
--- a/Sources/TensorFlow/Core/DataTypes.swift
+++ b/Sources/TensorFlow/Core/DataTypes.swift
@@ -23,8 +23,8 @@ public struct TensorDataType: Equatable {
     public var _cDataType: TF_DataType
 
     @usableFromInline
-	internal init(_ cDataType: TF_DataType) {
-	    self._cDataType = cDataType
+    internal init(_ cDataType: TF_DataType) {
+        self._cDataType = cDataType
     }
 }
 

--- a/Sources/TensorFlow/Core/StringTensor.swift
+++ b/Sources/TensorFlow/Core/StringTensor.swift
@@ -100,8 +100,8 @@ public extension StringTensor {
     /// Creates a 1-D `StringTensor` in from contiguous scalars.
     @inlinable
     init(_ scalars: [String]) {
-	    self.init(shape: [scalars.count], scalars: scalars)
-	}
+        self.init(shape: [scalars.count], scalars: scalars)
+    }
 }
 
 //===------------------------------------------------------------------------------------------===//

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -711,10 +711,10 @@ public extension Tensor where Scalar: Numeric {
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func unbroadcasted(toShape otherShape: Tensor<Int32>) -> Tensor {
         // TODO: Simplify this once differentiating control flow is supported.
-	    return unbroadcasted(to: {
-	      precondition(otherShape.rank == 1)
-	      return TensorShape(otherShape.scalars.map(Int.init))
-	    }())
+        return unbroadcasted(to: {
+            precondition(otherShape.rank == 1)
+            return TensorShape(otherShape.scalars.map(Int.init))
+        }())
     }
 
     @inlinable
@@ -727,24 +727,24 @@ public extension Tensor where Scalar: Numeric {
     @differentiable(wrt: self, vjp: _vjpUnbroadcasted(to:) where Scalar: TensorFlowFloatingPoint)
     func unbroadcasted(to shape: TensorShape) -> Tensor {
         let dimensions = self.shape.dimensions
-	    var otherDimensions = shape.dimensions
-	    let rankDifference = dimensions.count - otherDimensions.count
-	    precondition(rankDifference >= 0, """
-	        The rank of 'self' must be greater than or equal to the number of \
-	        dimensions in the destination shape
-	        """)
-	    if rankDifference > 0 {
+        var otherDimensions = shape.dimensions
+        let rankDifference = dimensions.count - otherDimensions.count
+        precondition(rankDifference >= 0, """
+            The rank of 'self' must be greater than or equal to the number of \
+            dimensions in the destination shape
+            """)
+        if rankDifference > 0 {
             otherDimensions.insert(contentsOf: repeatElement(1, count: rankDifference), at: 0)
-	    }
-	    assert(dimensions.count == otherDimensions.count)
-	    var axes: [Int] = []
-	    axes.reserveCapacity(dimensions.count)
-	    for (i, (dim, otherDim)) in zip(dimensions, otherDimensions).enumerated() {
-	        if dim == otherDim { continue }
-	        if otherDim == 1 { axes.append(i); continue }
-	        preconditionFailure("Cannot unbroadcast \(self.shape) to \(shape)")
-	    }
-	    return sum(alongAxes: axes).reshaped(to: shape)
+        }
+        assert(dimensions.count == otherDimensions.count)
+        var axes: [Int] = []
+        axes.reserveCapacity(dimensions.count)
+        for (i, (dim, otherDim)) in zip(dimensions, otherDimensions).enumerated() {
+            if dim == otherDim { continue }
+            if otherDim == 1 { axes.append(i); continue }
+            preconditionFailure("Cannot unbroadcast \(self.shape) to \(shape)")
+        }
+        return sum(alongAxes: axes).reshaped(to: shape)
     }
 }
 

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -2193,9 +2193,9 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
         let value = mean(squeezingAxes: axes)
         let count = Raw.gather(params: shapeTensor, indices: axes).product()
         return (value, { [shape = shapeTensor] v in
-	      let unsqueezed = v.expandingShape(at: axes.scalars.map { Int($0) })
-	      return unsqueezed.broadcasted(toShape: shape) / Tensor(count)
-	    })
+            let unsqueezed = v.expandingShape(at: axes.scalars.map { Int($0) })
+            return unsqueezed.broadcasted(toShape: shape) / Tensor(count)
+        })
     }
 
     @inlinable


### PR DESCRIPTION
Verified no remaining uses via `grep -nr '\t' **/*.swift`.