### PR TITLE
add compilation benchmark

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libicu-dev \
         libncurses5-dev \
         libxml2 \
-        libblocksruntime-dev
+        libblocksruntime-dev \
+        python3 \
+        python3-pip \
+        python3-setuptools \
+        python3-dev
+
+RUN pip3 install psutil junit-xml
 
 # Download and extract S4TF
 WORKDIR /swift-tensorflow-toolchain
@@ -45,6 +51,9 @@ RUN rm /swift-tensorflow-toolchain/usr/lib/swift/linux/x86_64/TensorFlow.swiftin
 RUN rm /swift-tensorflow-toolchain/usr/lib/swift/linux/x86_64/TensorFlow.swiftdoc
 RUN rm /swift-tensorflow-toolchain/usr/lib/swift/linux/x86_64/TensorFlow.swiftmodule
 RUN rm /swift-tensorflow-toolchain/usr/lib/swift/linux/libswiftTensorFlow.so
+
+# Benchmark compile times
+RUN python3 Tools/benchmark_compile.py /swift-tensorflow-toolchain/usr/bin/swift benchmark_results.xml
 
 # Run SwiftPM tests
 RUN /swift-tensorflow-toolchain/usr/bin/swift test

--- a/Tools/benchmark_compile.py
+++ b/Tools/benchmark_compile.py
@@ -1,0 +1,86 @@
+"""
+Runs "swift build" in a variety of configurations, and outputs timing
+information to an xUnit file.
+"""
+
+
+import argparse
+import psutil
+import subprocess
+import tempfile
+import time
+
+
+from junit_xml import TestCase, TestSuite
+
+
+def kill(pid):
+  proc = psutil.Process(pid)
+  for child in proc.children(recursive=True):
+    child.kill()
+  proc.kill()
+
+
+def execute_benchmark(test_case, cmd, timeout):
+  start = time.time()
+  proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  try:
+    stdout, stderr = proc.communicate(timeout=timeout)
+    code = proc.returncode
+  except subprocess.TimeoutExpired as e:
+    kill(proc.pid)
+    stdout, stderr = proc.communicate()
+    code = 0
+    test_case.add_failure_info(str(e))
+
+  end = time.time()
+  test_case.stdout = stdout
+  test_case.stderr = stderr
+  test_case.elapsed_sec = end - start
+
+  if code != 0:
+    test_case.add_failure_info('Nonzero exit code: %d' % code)
+    return test_case
+
+  return test_case
+
+
+def benchmark(test_case, cmd, timeout=300):
+  with tempfile.TemporaryDirectory() as build_path:
+    cmd += ['--build-path', build_path]
+    return execute_benchmark(test_case, cmd, timeout)
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument('swift', help='path to swift executable')
+  parser.add_argument('output', help='where to write xUnit output')
+  args = parser.parse_args()
+
+  test_cases = [
+      benchmark(
+          TestCase('debug build'),
+          [args.swift, 'build', '--product', 'TensorFlow']
+      ),
+      benchmark(
+          TestCase('release build'),
+          [args.swift, 'build', '-c', 'release', '--product', 'TensorFlow']
+      ),
+
+      # The point of "release build -Onone" is to compile TensorFlow in
+      # "-whole-module-optimization" mode without "-O".
+      benchmark(
+          TestCase('release build -Onone'),
+          [args.swift, 'build', '-c', 'release', '--product', 'TensorFlow',
+           '-Xswiftc', '-Onone']
+      ),
+  ]
+
+  test_suite = TestSuite('swift-apis compile time', test_cases)
+
+  with open(args.output, 'w') as f:
+    TestSuite.to_file(f, [test_suite])
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
This runs builds in a few different configurations and writes the results into an xUnit XML file. We should be able to suck this xUnit XML file into some google tools and get a plot of compilation speed over time.