### PR TITLE
[Tensor] Add a VJP for 'Tensor.scalars'.

### DIFF
--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -162,8 +162,18 @@ public extension Tensor {
     }
 
     @inlinable
+    @differentiable(vjp: _vjpScalars where Scalar: TensorFlowFloatingPoint)
     var scalars: [Scalar] {
         return array.scalars
+    }
+}
+
+extension Tensor where Scalar: TensorFlowFloatingPoint {
+    @usableFromInline
+    func _vjpScalars() -> (value: [Scalar], pullback: (Array<Scalar>.TangentVector) -> Tensor) {
+        (value: scalars, pullback: { [shape = self.shape] v in
+            Tensor(shape: shape, scalars: v.base)
+        })
     }
 }
 

--- a/Tests/TensorFlowTests/TensorAutoDiffTests.swift
+++ b/Tests/TensorFlowTests/TensorAutoDiffTests.swift
@@ -56,6 +56,13 @@ final class TensorAutoDiffTests: XCTestCase {
         XCTAssertEqual(grad, Tensor([0.23105857, -0.2310586]))
     }
 
+    func testScalars() {
+        let grad = gradient(at: Tensor<Float>([3, 4])) { x in
+            x.scalars.differentiableReduce(0, { $0 + $1 })
+        }
+        XCTAssertEqual(grad, Tensor([1, 1]))
+    }
+
     func testPlus() {
         func f(a: Tensor<Float>, b: Tensor<Float>) -> Tensor<Float> { a + b }
         XCTAssertTrue((Tensor(1), Tensor(1)) == gradient(at: Tensor(0), Tensor(0), in: f))


### PR DESCRIPTION
Add a VJP for property `Tensor.scalars`. The VJP merely returns the original value and a transpose because `scalars` is linear w.r.t. `self`.

Resolves #508.