### PR TITLE
Deprecate Tensor.droppingOut

### DIFF
--- a/Sources/TensorFlow/Layers/Core.swift
+++ b/Sources/TensorFlow/Layers/Core.swift
@@ -15,7 +15,7 @@
 fileprivate extension Tensor where Scalar: TensorFlowFloatingPoint {
     /// Computes dropout given a probability.
     @differentiable(wrt: self where Scalar: Differentiable)
-    fileprivate func _droppingOut(probability: Double) -> Tensor {
+    func _droppingOut(probability: Double) -> Tensor {
         let noise = Tensor(randomUniform: shape)
         let keepMask = noise .>= Scalar(probability)
         let keepProbability = Scalar(1.0 - probability)

--- a/Sources/TensorFlow/Layers/Core.swift
+++ b/Sources/TensorFlow/Layers/Core.swift
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 fileprivate extension Tensor where Scalar: TensorFlowFloatingPoint {
-    /// Computes dropout given a probability.
+     /// Computes dropout given a probability.
+     // TODO: Remove the underscore once `droppingOut(probability:)` has been removed.
     @differentiable(wrt: self where Scalar: Differentiable)
     func _droppingOut(probability: Double) -> Tensor {
         let noise = Tensor(randomUniform: shape)


### PR DESCRIPTION
It's public, but it doesn't check the learning phase, which might lead to unexpected behavior!