### PR TITLE
Introduce renaming of method transpose(withPermutations:)

### DIFF
--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -280,7 +280,7 @@ public extension Tensor {
     @inlinable
     @differentiable(
         wrt: self,
-        vjp: _vjpTransposed(withPermutations:) where Scalar: TensorFlowFloatingPoint)
+        vjp: _vjpTransposed(permutation:) where Scalar: TensorFlowFloatingPoint)
     func transposed(permutation: Tensor<Int32>) -> Tensor {
         Raw.transpose(self, perm: permutation)
     }
@@ -288,9 +288,7 @@ public extension Tensor {
     /// Returns a transposed tensor, with dimensions permuted in the specified order.
     @available(*, deprecated, renamed: "transposed(permutation:)")
     @inlinable
-    @differentiable(
-        wrt: self,
-        vjp: _vjpTransposed(withPermutations:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func transposed(withPermutations permutations: Tensor<Int32>) -> Tensor {
         transposed(permutation: permutations)
     }
@@ -299,18 +297,34 @@ public extension Tensor {
     @inlinable
     @differentiable(
         wrt: self,
-        vjp: _vjpTransposed(withPermutations:) where Scalar: TensorFlowFloatingPoint)
+        vjp: _vjpTransposed(permutation:) where Scalar: TensorFlowFloatingPoint)
+    func transposed(permutation: [Int]) -> Tensor {
+        let permutation = permutation.map(Int32.init)
+        return transposed(permutation: Tensor<Int32>(permutation))
+    }
+
+    /// Returns a transposed tensor, with dimensions permuted in the specified order.
+    @available(*, deprecated, renamed: "transposed(permutation:)")
+    @inlinable
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func transposed(withPermutations permutations: [Int]) -> Tensor {
-        let permutations = permutations.map(Int32.init)
-        return transposed(withPermutations: Tensor<Int32>(permutations))
+        transposed(permutation: permutations)
     }
 
     /// Returns a transposed tensor, with dimensions permuted in the specified order.
     @inlinable
     @differentiable(
-        wrt: self, vjp: _vjpTransposed(withPermutations:) where Scalar: TensorFlowFloatingPoint)
+        wrt: self, vjp: _vjpTransposed(permutation:) where Scalar: TensorFlowFloatingPoint)
+    func transposed(permutation: Int...) -> Tensor {
+        transposed(permutation: permutation)
+    }
+
+    /// Returns a transposed tensor, with dimensions permuted in the specified order.
+    @available(*, deprecated, renamed: "transposed(permutation:)")
+    @inlinable
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func transposed(withPermutations permutations: Int...) -> Tensor {
-        return transposed(withPermutations: permutations)
+        transposed(permutation: permutations)
     }
 
     /// Returns a transposed tensor, with dimensions permuted in reverse order.
@@ -547,23 +561,22 @@ public extension Tensor {
 
 internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
-    func _vjpTransposed(
-        withPermutations permutations: Tensor<Int32>
+    func _vjpTransposed(permutation: Tensor<Int32>
     ) -> (Tensor, (Tensor) -> Tensor) {
-        let value = transposed(withPermutations: permutations)
-        return (value, { $0.transposed(withPermutations: permutations) })
+        let value = transposed(permutation: permutation)
+        return (value, { $0.transposed(permutation: permutation) })
     }
 
     @inlinable
-    func _vjpTransposed(withPermutations permutations: [Int]) -> (Tensor, (Tensor) -> Tensor) {
-        let value = transposed(withPermutations: permutations)
-        return (value, { $0.transposed(withPermutations: permutations) })
+    func _vjpTransposed(permutation: [Int]) -> (Tensor, (Tensor) -> Tensor) {
+        let value = transposed(permutation: permutation)
+        return (value, { $0.transposed(permutation: permutation) })
     }
 
     @inlinable
-    func _vjpTransposed(withPermutations permutations: Int...) -> (Tensor, (Tensor) -> Tensor) {
-        let value = transposed(withPermutations: permutations)
-        return (value, { $0.transposed(withPermutations: permutations) })
+    func _vjpTransposed(permutation: Int...) -> (Tensor, (Tensor) -> Tensor) {
+        let value = transposed(permutation: permutation)
+        return (value, { $0.transposed(permutation: permutation) })
     }
 
     @inlinable

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -333,7 +333,7 @@ public extension Tensor {
     func transposed() -> Tensor {
         let defaultPermutations = rankTensor - 1 - Tensor<Int32>(
             rangeFrom: 0, to: Int32(rank), stride: 1)
-        return transposed(withPermutations: Tensor<Int32>(defaultPermutations))
+        return transposed(permutation: Tensor<Int32>(defaultPermutations))
     }
 
     /// Returns a concatenated tensor along the specified axis.
@@ -462,7 +462,7 @@ public extension Tensor {
                 Tensor<Int32>(Int32(axis)).rankLifted(),
                 Tensor<Int32>(rangeFrom: Int32(batchDimensionCount), to: Int32(posAxis), stride: 1),
                 Tensor<Int32>(rangeFrom: Int32(axis) + 1, to: Int32(rank), stride: 1)])
-            let tensor = transposed(withPermutations: permutation)
+            let tensor = transposed(permutation: permutation)
             let result = tensor.batchGathering(
                 atIndices: indices,
                 alongAxis: batchDimensionCount,
@@ -479,7 +479,7 @@ public extension Tensor {
                     to: Int32(indices.rank),
                     stride: 1),
                 Tensor<Int32>(rangeFrom: Int32(start), to: Int32(result.rank), stride: 1)])
-            return result.transposed(withPermutations: resultPermutation)
+            return result.transposed(permutation: resultPermutation)
         }
 
         let batchIndices: Tensor<Index> = withoutDerivative(at: {
@@ -643,7 +643,7 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
                 Tensor<Int32>([Int32(outerSize)]),
                 outerIndices,
                 innerIndices])
-            let transposedValues = values.transposed(withPermutations: permutations)
+            let transposedValues = values.transposed(permutation: permutations)
             let gradient = Raw.unsortedSegmentSum(
                 data: transposedValues,
                 segmentIds: valueIndices,
@@ -655,7 +655,7 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
                 outerIndices + 1,
                 Tensor<Int32>([0]),
                 innerIndices])
-            return gradient.transposed(withPermutations: inversePermutations)
+            return gradient.transposed(permutation: inversePermutations)
         })
     }
 }

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -281,8 +281,18 @@ public extension Tensor {
     @differentiable(
         wrt: self,
         vjp: _vjpTransposed(withPermutations:) where Scalar: TensorFlowFloatingPoint)
+    func transposed(permutation: Tensor<Int32>) -> Tensor {
+        Raw.transpose(self, perm: permutation)
+    }
+
+    /// Returns a transposed tensor, with dimensions permuted in the specified order.
+    @available(*, deprecated, renamed: "transposed(permutation:)")
+    @inlinable
+    @differentiable(
+        wrt: self,
+        vjp: _vjpTransposed(withPermutations:) where Scalar: TensorFlowFloatingPoint)
     func transposed(withPermutations permutations: Tensor<Int32>) -> Tensor {
-        return Raw.transpose(self, perm: permutations)
+        transposed(permutation: permutations)
     }
 
     /// Returns a transposed tensor, with dimensions permuted in the specified order.

--- a/Tests/TensorFlowTests/TensorAutoDiffTests.swift
+++ b/Tests/TensorFlowTests/TensorAutoDiffTests.swift
@@ -325,10 +325,10 @@ final class TensorAutoDiffTests: XCTestCase {
         let transposed = Tensor<Float>(ones: [3, 2])
         let transposedPullback = pullback(at: input) { (a: Tensor<Float>) in a.transposed() }
         let transposedPermutationsPullback = pullback(at: input) { (a: Tensor<Float>) in
-            a.transposed(withPermutations: [1, 0])
+            a.transposed(permutation: [1, 0])
         }
         let transposedVariadicsPullback = pullback(at: input) { (a: Tensor<Float>) in
-            a.transposed(withPermutations: 1, 0)
+            a.transposed(permutation: 1, 0)
         }
 
         XCTAssertEqual(input, transposedPullback(transposed))


### PR DESCRIPTION
Following the recommendation of @rxwei in https://github.com/tensorflow/swift-apis/pull/526#pullrequestreview-297762689. This is a PR that introduces the renaming of method transposed(withPermutations:) to transposed(permutation:).

Resolves #524 .