### PR TITLE
Explore learning phase as a layer parameter.

### DIFF
--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -119,6 +119,34 @@ public extension Layer {
     }
 }
 
+
+
+public extension Layer where Self: KeyPathIterable {
+    var allLearningPhases: LearningPhase? {
+        get {
+            let allPhases = self.recursivelyAllKeyPaths(to: LearningPhase.self)
+            if allPhases.isEmpty {
+                return nil
+            }
+            let first = self[keyPath: allPhases[0]]
+            for kp in allPhases {
+                if self[keyPath: kp] != first {
+                    return nil
+                }
+            }
+            return first
+        }
+        set {
+            guard let phase = newValue else {
+                fatalError("Cannot set allLearningPhases to nil!")
+            }
+            for kp in self.recursivelyAllWritableKeyPaths(to: LearningPhase.self) {
+                self[keyPath: kp] = phase
+            }
+        }
+    }
+}
+
 public extension Differentiable {
     /// Returns the output computed by applying a sequence of layers to the previous layer's output,
     /// except that the first layer's input is `self`.


### PR DESCRIPTION
Instead of tracking learning phase as an implicit (thread-local) parameter to
certain layers, this PR proposes managing the learning phase as an explicit
parameter on layers.

This PR explores this design, and shows that it can be done with a minimum of
fuss. By building on top of the KeyPathIterable infrastructure, we can ensure
there's a minimum amount of boilerplate, but retain full functionality.
Although this has not been benchmarked in a large model, it is expected to not
have significant performance implications.

Advantages of this approach are:
 1. The phase can be easily changed with straight-forward, imperative code.
 2. Different parts of the model can have different states. This can be useful
    when performing certain kinds of research or other experimentation.
 3. No spooky-action-at-a-distance with thread-local and/or implicit
    parameters.

If this direction is a good one, we should consider making the following
changes:

 1. Make Module extend KeyPathIterable
 2. Build some sort of smooth bridge between this new API and the existing API.
    (Potentially by searching for all key paths to both LearningPhase.self and
    Optional<LearningPhase>.self.)
 3. Add more tests.