### PR TITLE
add explicit conformances to Array.DifferentiableView

### DIFF
--- a/Sources/TensorFlow/StdlibExtensions.swift
+++ b/Sources/TensorFlow/StdlibExtensions.swift
@@ -193,10 +193,14 @@ extension Array.DifferentiableView: ElementaryFunctions
     public static func root(_ x: Self, _ n: Int) -> Self { .init(Array.root(x.base, n)) }
 }
 
-extension Array.DifferentiableView
-    : MutableCollection, RandomAccessCollection, RangeReplaceableCollection
-    where Element: Differentiable
-{
+extension Array.DifferentiableView:
+    BidirectionalCollection,
+    Collection,
+    MutableCollection,
+    RandomAccessCollection,
+    RangeReplaceableCollection,
+    Sequence
+where Element: Differentiable {
     public typealias Element = Array<Element>.Element
     public typealias Index = Array<Element>.Index
     public typealias Indices = Array<Element>.Indices


### PR DESCRIPTION
This fixes some errors caused by https://github.com/apple/swift/pull/27971:

```
/home/swiftci/jenkins/workspace/swift-PR-TensorFlow-Linux-gpu/tensorflow-swift-apis/Sources/TensorFlow/StdlibExtensions.swift:196:1: error: conditional conformance of type 'Array<Element>.DifferentiableView' to protocol 'MutableCollection' does not imply conformance to inherited protocol 'Collection'
extension Array.DifferentiableView
^
/home/swiftci/jenkins/workspace/swift-PR-TensorFlow-Linux-gpu/tensorflow-swift-apis/Sources/TensorFlow/StdlibExtensions.swift:196:1: error: conditional conformance of type 'Array<Element>.DifferentiableView' to protocol 'RandomAccessCollection' does not imply conformance to inherited protocol 'BidirectionalCollection'
extension Array.DifferentiableView
^
/home/swiftci/jenkins/workspace/swift-PR-TensorFlow-Linux-gpu/tensorflow-swift-apis/Sources/TensorFlow/StdlibExtensions.swift:196:1: error: conditional conformance of type 'Array<Element>.DifferentiableView' to protocol 'MutableCollection' does not imply conformance to inherited protocol 'Sequence'
extension Array.DifferentiableView
^
/home/swiftci/jenkins/workspace/swift-PR-TensorFlow-Linux-gpu/tensorflow-swift-apis/Sources/TensorFlow/StdlibExtensions.swift:196:1: note: did you mean to explicitly state the conformance like 'extension DifferentiableView: Sequence where ...'?
extension Array.DifferentiableView
^
```