### PR TITLE
Rename Raw to _Raw, and provide a deprecated typealias.

### DIFF
--- a/Sources/TensorFlow/Bindings/RawOpsGenerated.swift
+++ b/Sources/TensorFlow/Bindings/RawOpsGenerated.swift
@@ -21,7 +21,11 @@ func makeOp(_ name: String, _ nOutputs: Int) -> TFTensorOperation {
     _ExecutionContext.makeOp(name, nOutputs)
 }
 
-public enum Raw {
+@available(*, deprecated, renamed: "_Raw",
+           message: "Raw has been renamed to _Raw to indicate it is not a guaranteed / stable API.")
+public typealias Raw = _Raw
+
+public enum _Raw {
 
 static let generatedTensorFlowVersion = "1.14.1-dev20190421"
 static let generatedTensorFlowGitVersion = "v1.12.1-149-gd57b65578c"

--- a/Sources/TensorFlow/Bindings/RawOpsGenerated.swift
+++ b/Sources/TensorFlow/Bindings/RawOpsGenerated.swift
@@ -21,8 +21,9 @@ func makeOp(_ name: String, _ nOutputs: Int) -> TFTensorOperation {
     _ExecutionContext.makeOp(name, nOutputs)
 }
 
-@available(*, deprecated, renamed: "_Raw",
-           message: "Raw has been renamed to _Raw to indicate it is not a guaranteed / stable API.")
+@available(*, deprecated, renamed: "_Raw", message: """
+  'Raw' has been renamed to '_Raw' to indicate that it is not a guaranteed/stable API.
+  """)
 public typealias Raw = _Raw
 
 public enum _Raw {


### PR DESCRIPTION
Part of the work to [layer our APIs](https://docs.google.com/document/d/1HO_sMhZJHxlDqw4Pjz4qva2s5yzgwxel-82yoK8O6L4/edit#)
is to set up S4TF to have pluggable "backends" or runtimes. While exposing the
Raw ops is powerful, it is not portable. This change renames Raw to _Raw to
indicate it is an unstable / not-forever-guaranteed API.