### PR TITLE
Fix deprecation warnings. (Follow-up to #543)

### DIFF
--- a/Sources/TensorFlow/Core/ArrayOps.swift
+++ b/Sources/TensorFlow/Core/ArrayOps.swift
@@ -14,7 +14,7 @@
 
 import CTensorFlow
 
-public extension Raw {
+public extension _Raw {
     /// Saves tensors in V2 checkpoint format.
     ///
     /// By default, saves the named tensors in full.  If the caller wishes to save specific slices

--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -81,7 +81,7 @@ public extension Tensor {
     var rankTensor: Tensor<Int32> {
         @_semantics("autodiff.nonvarying")
         get {
-            return Raw.rank(self)
+            return _Raw.rank(self)
         }
     }
 
@@ -90,7 +90,7 @@ public extension Tensor {
     var shapeTensor: Tensor<Int32> {
         @_semantics("autodiff.nonvarying")
         get {
-            return Raw.shape(self)
+            return _Raw.shape(self)
         }
     }
 
@@ -99,7 +99,7 @@ public extension Tensor {
     var scalarCountTensor: Tensor<Int32> {
         @_semantics("autodiff.nonvarying")
         get {
-            return Raw.size(self)
+            return _Raw.size(self)
         }
     }
 }
@@ -393,7 +393,7 @@ extension _TensorElementLiteral: ExpressibleByArrayLiteral {
     public typealias ArrayLiteralElement = _TensorElementLiteral<Scalar>
     @inlinable
     public init(arrayLiteral elements: _TensorElementLiteral<Scalar>...) {
-        tensor = Raw.pack(elements.map { $0.tensor })
+        tensor = _Raw.pack(elements.map { $0.tensor })
     }
 }
 
@@ -406,7 +406,7 @@ extension Tensor: ExpressibleByArrayLiteral {
     ///   separate method because `ShapedArray` initializers need to call it.
     @inlinable
     internal init(_tensorElementLiterals elements: [_TensorElementLiteral<Scalar>]) {
-        self = Raw.pack(elements.map { $0.tensor })
+        self = _Raw.pack(elements.map { $0.tensor })
     }
 
     /// Creates a tensor initialized with the given elements.
@@ -541,7 +541,7 @@ extension Tensor: AdditiveArithmetic where Scalar: Numeric {
     @inlinable
     @differentiable(vjp: _vjpAdd(lhs:rhs:) where Scalar: TensorFlowFloatingPoint)
     public static func + (lhs: Tensor, rhs: Tensor) -> Tensor {
-        Raw.addV2(lhs, rhs)
+        _Raw.addV2(lhs, rhs)
     }
 
     /// Subtracts one tensor from another and produces their difference.
@@ -549,7 +549,7 @@ extension Tensor: AdditiveArithmetic where Scalar: Numeric {
     @inlinable
     @differentiable(vjp: _vjpSubtract(lhs:rhs:) where Scalar: TensorFlowFloatingPoint)
     public static func - (lhs: Tensor, rhs: Tensor) -> Tensor {
-        Raw.sub(lhs, rhs)
+        _Raw.sub(lhs, rhs)
     }
 }
 
@@ -559,7 +559,7 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
         (lhs + rhs, { [lhsShape = lhs.shapeTensor, rhsShape = rhs.shapeTensor] v in
             let lhsGrad = v
             let rhsGrad = lhsGrad
-            let (lhsAxes, rhsAxes) = Raw.broadcastGradientArgs(s0: lhsShape, s1: rhsShape)
+            let (lhsAxes, rhsAxes) = _Raw.broadcastGradientArgs(s0: lhsShape, s1: rhsShape)
             return (lhsGrad.sum(squeezingAxes: lhsAxes).reshaped(toShape: lhsShape),
                     rhsGrad.sum(squeezingAxes: rhsAxes).reshaped(toShape: rhsShape))
         })
@@ -570,7 +570,7 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
         (lhs - rhs, { [lhsShape = lhs.shapeTensor, rhsShape = rhs.shapeTensor] v in
             let lhsGrad = v
             let rhsGrad = -lhsGrad
-            let (lhsAxes, rhsAxes) = Raw.broadcastGradientArgs(s0: lhsShape, s1: rhsShape)
+            let (lhsAxes, rhsAxes) = _Raw.broadcastGradientArgs(s0: lhsShape, s1: rhsShape)
             return (lhsGrad.sum(squeezingAxes: lhsAxes).reshaped(toShape: lhsShape),
                     rhsGrad.sum(squeezingAxes: rhsAxes).reshaped(toShape: rhsShape))
         })

--- a/Sources/TensorFlow/Initializers.swift
+++ b/Sources/TensorFlow/Initializers.swift
@@ -32,7 +32,7 @@ public extension Tensor {
     @inlinable
     @differentiable(vjp: _vjpInit(repeating:shape:) where Scalar: TensorFlowFloatingPoint)
     init(repeating repeatedValue: Scalar, shape: TensorShape) {
-        self = Raw.fill(
+        self = _Raw.fill(
             dims: Tensor<Int32>(shape.dimensions.map(Int32.init)),
             value: Tensor(repeatedValue))
     }
@@ -74,7 +74,7 @@ public extension Tensor where Scalar: Numeric {
     /// Perform an element-wise type conversion from a `Bool` tensor.
     @inlinable
     init(_ other: Tensor<Bool>) {
-        self = Raw.cast(other)
+        self = _Raw.cast(other)
     }
 
     /// Perform an element-wise conversion from another `Tensor`.
@@ -82,7 +82,7 @@ public extension Tensor where Scalar: Numeric {
     @differentiable(
         vjp: _vjpCast where Scalar: TensorFlowFloatingPoint, OtherScalar: TensorFlowFloatingPoint)
     init<OtherScalar: Numeric>(_ other: Tensor<OtherScalar>) {
-        self = Raw.cast(other)
+        self = _Raw.cast(other)
     }
 }
 
@@ -104,7 +104,7 @@ public extension Tensor {
     @inlinable
     @differentiable(vjp: _vjpInitElements where Scalar: TensorFlowFloatingPoint)
     init(_ elements: [Tensor]) {
-        self = Raw.pack(elements)
+        self = _Raw.pack(elements)
     }
 
     /// Stacks `tensors`, along the `axis` dimension, into a new tensor with rank one higher than
@@ -138,7 +138,7 @@ public extension Tensor {
     @inlinable
     @differentiable(vjp: _vjpStacking where Scalar: TensorFlowFloatingPoint)
     init(stacking tensors: [Tensor], alongAxis axis: Int = 0) {
-        self = Raw.pack(tensors, axis: Int64(axis))
+        self = _Raw.pack(tensors, axis: Int64(axis))
     }
 
     /// Concatenates `tensors` along the `axis` dimension.
@@ -177,7 +177,7 @@ public extension Tensor {
     @differentiable(vjp: _vjpConcatenating where Scalar: TensorFlowFloatingPoint)
     init(concatenating tensors: [Tensor], alongAxis axis: Int = 0) {
         precondition(tensors.count > 0)
-        self = Raw.concatV2(tensors, axis: Tensor<Int32>(Int32(axis)))
+        self = _Raw.concatV2(tensors, axis: Tensor<Int32>(Int32(axis)))
     }
 }
 
@@ -242,7 +242,7 @@ public extension Tensor where Scalar: Numeric {
     /// - Parameter other: Tensor whose shape and data type to use.
     @inlinable
     init(zerosLike other: Tensor) {
-        self = Raw.zerosLike(other)
+        self = _Raw.zerosLike(other)
     }
 
     /// Creates a tensor with all scalars set to one that has the same shape and type as the provided
@@ -251,7 +251,7 @@ public extension Tensor where Scalar: Numeric {
     /// - Parameter other: Tensor whose shape and data type to use.
     @inlinable
     init(onesLike other: Tensor) {
-        self = Raw.onesLike(other)
+        self = _Raw.onesLike(other)
     }
 
     /// Creates a 1-D tensor representing a sequence from a starting value to, but not including,
@@ -266,7 +266,7 @@ public extension Tensor where Scalar: Numeric {
     ///     positive.
     @inlinable
     init(rangeFrom start: Scalar, to end: Scalar, stride: Scalar) {
-        self = Raw.range(start: Tensor(start), limit: Tensor(end), delta: Tensor(stride))
+        self = _Raw.range(start: Tensor(start), limit: Tensor(end), delta: Tensor(stride))
     }
 
     /// Creates a 1-D tensor representing a sequence from a starting value to, but not including, an
@@ -280,7 +280,7 @@ public extension Tensor where Scalar: Numeric {
     ///   - stride: The amount to step by with each iteration. `stride` must be positive.
     @inlinable
     init(rangeFrom start: Tensor<Scalar>, to end: Tensor<Scalar>, stride: Tensor<Scalar>) {
-        self = Raw.range(start: start, limit: end, delta: stride)
+        self = _Raw.range(start: start, limit: end, delta: stride)
     }
 
     /// Creates a one-hot tensor at given indices. The locations represented by
@@ -318,7 +318,7 @@ public extension Tensor where Scalar: Numeric {
         offValue: Scalar = 0,
         axis: Int = -1
     ) {
-        self = Raw.oneHot(
+        self = _Raw.oneHot(
             indices: indices,
             depth: Tensor<Int32>(Int32(depth)),
             onValue: Tensor(onValue),
@@ -339,7 +339,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     ///   - count: The number of values in the resulting sequence. `count` must be positive.
     @inlinable
     init(linearSpaceFrom start: Scalar, to end: Scalar, count: Int) {
-        self = Raw.linSpace(
+        self = _Raw.linSpace(
             start: Tensor(start), stop: Tensor(end), num: Tensor<Int32>(Int32(count)))
     }
 
@@ -356,7 +356,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     /// - Precondition: `start`, `to`, and `count` must be Tensors containing a single Scalar value.
     @inlinable
     init(linearSpaceFrom start: Tensor<Scalar>, to end: Tensor<Scalar>, count: Tensor<Int32>) {
-        self = Raw.linSpace(start: start, stop: end, num: count)
+        self = _Raw.linSpace(start: start, stop: end, num: count)
     }
 }
 
@@ -379,7 +379,7 @@ public extension Tensor where Scalar: TensorFlowIndex {
         upperBound: Tensor<Scalar> = Tensor<Scalar>(1),
         seed: TensorFlowSeed = Context.local.randomSeed
     ) {
-        self = Raw.statelessRandomUniformInt(
+        self = _Raw.statelessRandomUniformInt(
             shape: Tensor<Int32>((0..<shape.rank).map { Int32(shape[$0]) }),
             seed: Tensor<Int32>([seed.graph, seed.op]),
             minval: lowerBound,
@@ -402,7 +402,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
         upperBound: Tensor<Scalar> = Tensor<Scalar>(1),
         seed: TensorFlowSeed = Context.local.randomSeed
     ) {
-        let sample: Tensor<Scalar> = Raw.statelessRandomUniform(
+        let sample: Tensor<Scalar> = _Raw.statelessRandomUniform(
             shape: Tensor<Int32>((0..<shape.rank).map { Int32(shape[$0]) }),
             seed: Tensor<Int32>([seed.graph, seed.op]))
         self = (upperBound - lowerBound) * sample + lowerBound
@@ -422,7 +422,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
         standardDeviation: Tensor<Scalar> = Tensor<Scalar>(1),
         seed: TensorFlowSeed = Context.local.randomSeed
     ) {
-        let sample: Tensor<Scalar> = Raw.statelessRandomNormal(
+        let sample: Tensor<Scalar> = _Raw.statelessRandomNormal(
             shape: Tensor<Int32>((0..<shape.rank).map { Int32(shape[$0]) }),
             seed: Tensor<Int32>([seed.graph, seed.op]))
         self = standardDeviation * sample + mean

--- a/Sources/TensorFlow/Layers/Upsampling.swift
+++ b/Sources/TensorFlow/Layers/Upsampling.swift
@@ -83,7 +83,7 @@ public struct UpSampling3D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer 
     private func repeatingElements(
         _ input: Tensor<Scalar>, alongAxis axis: Int, count: Int
     ) -> Tensor<Scalar> {
-        let splits = Raw.split(
+        let splits = _Raw.split(
             splitDim: Tensor<Int32>(Int32(axis)),
             value: input,
             numSplit: Int64(input.shape[axis]))
@@ -96,7 +96,7 @@ public struct UpSampling3D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer 
     ) -> (Tensor<Scalar>, (Tensor<Scalar>) -> (TangentVector, Tensor<Scalar>)) {
         let value = repeatingElements(input, alongAxis: axis, count: count)
         return (value, { v in
-            let splits = Raw.split(
+            let splits = _Raw.split(
                 splitDim: Tensor<Int32>(Int32(axis)),
                 value: v,
                 numSplit: Int64(input.shape[axis]))

--- a/Sources/TensorFlow/Loss.swift
+++ b/Sources/TensorFlow/Loss.swift
@@ -224,7 +224,7 @@ func softmaxCrossEntropyHelper<Scalar: TensorFlowFloatingPoint>(
     logits: Tensor<Scalar>,
     labels: Tensor<Int32>
 ) -> Tensor<Scalar> {
-    Raw.sparseSoftmaxCrossEntropyWithLogits(features: logits, labels: labels).loss
+    _Raw.sparseSoftmaxCrossEntropyWithLogits(features: logits, labels: labels).loss
 }
 
 @inlinable
@@ -232,7 +232,7 @@ func _vjpSoftmaxCrossEntropyHelper<Scalar: TensorFlowFloatingPoint>(
     logits: Tensor<Scalar>,
     labels: Tensor<Int32>
 ) -> (Tensor<Scalar>, (Tensor<Scalar>) -> Tensor<Scalar>) {
-    let (loss, grad) = Raw.sparseSoftmaxCrossEntropyWithLogits(features: logits, labels: labels)
+    let (loss, grad) = _Raw.sparseSoftmaxCrossEntropyWithLogits(features: logits, labels: labels)
     return (loss, { $0.expandingShape(at: -1) * grad })
 }
 
@@ -258,7 +258,7 @@ func softmaxCrossEntropyHelper<Scalar: TensorFlowFloatingPoint>(
     logits: Tensor<Scalar>,
     probabilities: Tensor<Scalar>
 ) -> Tensor<Scalar> {
-    Raw.softmaxCrossEntropyWithLogits(features: logits, labels: probabilities).loss
+    _Raw.softmaxCrossEntropyWithLogits(features: logits, labels: probabilities).loss
 }
 
 @inlinable
@@ -266,7 +266,7 @@ func _vjpSoftmaxCrossEntropyHelper<Scalar: TensorFlowFloatingPoint>(
     logits: Tensor<Scalar>,
     probabilities: Tensor<Scalar>
 ) -> (Tensor<Scalar>, (Tensor<Scalar>) -> Tensor<Scalar>) {
-    let (loss, grad) = Raw.softmaxCrossEntropyWithLogits(features: logits, labels: probabilities)
+    let (loss, grad) = _Raw.softmaxCrossEntropyWithLogits(features: logits, labels: probabilities)
     return (loss, { $0.expandingShape(at: -1) * grad })
 }
 

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -60,7 +60,7 @@ public extension Tensor {
     @differentiable(vjp: _vjpUnstacked(alongAxis:) where Scalar: TensorFlowFloatingPoint)
     func unstacked(alongAxis axis: Int = 0) -> [Tensor] {
         let posAxis = axis < 0 ? axis + rank : axis
-        return Raw.unpack(value: self, num: Int64(shape[posAxis]), axis: Int64(posAxis))
+        return _Raw.unpack(value: self, num: Int64(shape[posAxis]), axis: Int64(posAxis))
     }
 
     /// Splits a tensor into multiple tensors. The tensor is split along dimension `axis` into
@@ -88,7 +88,7 @@ public extension Tensor {
     @inlinable
     @differentiable(vjp: _vjpSplit(count:alongAxis:) where Scalar: TensorFlowFloatingPoint)
     func split(count: Int, alongAxis axis: Int = 0) -> [Tensor] {
-        Raw.split(splitDim: Tensor<Int32>(Int32(axis)), value: self, numSplit: Int64(count))
+        _Raw.split(splitDim: Tensor<Int32>(Int32(axis)), value: self, numSplit: Int64(count))
     }
 
     /// Splits a tensor into multiple tensors. The tensor is split  into `sizes.shape[0]` pieces.
@@ -119,7 +119,7 @@ public extension Tensor {
         wrt: self,
         vjp: _vjpSplit(sizes:alongAxis:) where Scalar: TensorFlowFloatingPoint)
     func split(sizes: Tensor<Int32>, alongAxis axis: Int = 0) -> [Tensor] {
-        Raw.splitV(
+        _Raw.splitV(
             value: self,
             sizeSplits: sizes,
             splitDim: Tensor<Int32>(Int32(axis)),
@@ -137,7 +137,7 @@ public extension Tensor {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpTiled(multiples:) where Scalar: TensorFlowFloatingPoint)
     func tiled(multiples: Tensor<Int32>) -> Tensor {
-        Raw.tile(self, multiples: multiples)
+        _Raw.tile(self, multiples: multiples)
     }
 
     /// Reshape to the shape of the specified `Tensor`.
@@ -162,7 +162,7 @@ public extension Tensor {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpReshaped(toShape:) where Scalar: TensorFlowFloatingPoint)
     func reshaped(toShape newShape: Tensor<Int32>) -> Tensor {
-        Raw.reshape(self, shape: newShape)
+        _Raw.reshape(self, shape: newShape)
     }
 
     /// Return a copy of the tensor collapsed into a 1-D `Tensor`, in row-major order.
@@ -186,7 +186,7 @@ public extension Tensor {
     @differentiable(wrt: self, vjp: _vjpExpandingShape(at:) where Scalar: TensorFlowFloatingPoint)
     func expandingShape(at axes: [Int]) -> Tensor {
         var result = self
-        for i in axes { result = Raw.expandDims(result, dim: Tensor<Int32>(Int32(i))) }
+        for i in axes { result = _Raw.expandDims(result, dim: Tensor<Int32>(Int32(i))) }
         return result
     }
 
@@ -210,7 +210,7 @@ public extension Tensor {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpSqueezingShape(at:) where Scalar: TensorFlowFloatingPoint)
     func squeezingShape(at axes: [Int]) -> Tensor {
-        Raw.squeeze(self, squeezeDims: axes.map(Int32.init))
+        _Raw.squeeze(self, squeezeDims: axes.map(Int32.init))
     }
 }
 
@@ -282,7 +282,7 @@ public extension Tensor {
         wrt: self,
         vjp: _vjpTransposed(permutation:) where Scalar: TensorFlowFloatingPoint)
     func transposed(permutation: Tensor<Int32>) -> Tensor {
-        Raw.transpose(self, perm: permutation)
+        _Raw.transpose(self, perm: permutation)
     }
 
     /// Returns a transposed tensor, with dimensions permuted in the specified order.
@@ -408,7 +408,7 @@ public extension Tensor {
         atIndices indices: Tensor<Index>,
         alongAxis axis: Int = 0
     ) -> Tensor {
-        Raw.gatherV2(params: self, indices: indices, axis: Tensor<Int32>(Int32(axis)))
+        _Raw.gatherV2(params: self, indices: indices, axis: Tensor<Int32>(Int32(axis)))
     }
 
     /// Returns slices of this tensor at `indices` along the `axis` dimension, while ignoring the 
@@ -612,7 +612,7 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
                 let valuesShape = Tensor<Int32>(concatenating: [indicesCount, shape[1...]])
                 let values = v.reshaped(toShape: valuesShape)
                 let valueIndices = indices.reshaped(toShape: indicesCount)
-                return Raw.unsortedSegmentSum(
+                return _Raw.unsortedSegmentSum(
                     data: values,
                     segmentIds: valueIndices,
                     numSegments: shape[0])
@@ -644,7 +644,7 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
                 outerIndices,
                 innerIndices])
             let transposedValues = values.transposed(permutation: permutations)
-            let gradient = Raw.unsortedSegmentSum(
+            let gradient = _Raw.unsortedSegmentSum(
                 data: transposedValues,
                 segmentIds: valueIndices,
                 numSegments: shape[posAxis])
@@ -691,7 +691,7 @@ public extension Tensor {
     /// - Returns: A tensor with shape `(num_true, rank(condition))`.
     @inlinable
     func nonZeroIndices() -> Tensor<Int64> {
-        return Raw.where_(self)
+        return _Raw.where_(self)
     }
 }
 
@@ -706,7 +706,7 @@ public extension Tensor {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpBroadcasted(toShape:) where Scalar: TensorFlowFloatingPoint)
     func broadcasted(toShape shape: Tensor<Int32>) -> Tensor {
-        return Raw.broadcastTo(self, shape: shape)
+        return _Raw.broadcastTo(self, shape: shape)
     }
 
     @inlinable
@@ -818,11 +818,11 @@ public extension Tensor where Scalar: Numeric {
             scalars: sizes.flatMap { [Int32($0.before), Int32($0.after)] })
         switch mode {
         case .constant(let constantValue):
-            return Raw.padV2(self, paddings: paddings, constantValues: Tensor(constantValue))
+            return _Raw.padV2(self, paddings: paddings, constantValues: Tensor(constantValue))
         case .reflect:
-            return Raw.mirrorPad(self, paddings: paddings, mode: .reflect)
+            return _Raw.mirrorPad(self, paddings: paddings, mode: .reflect)
         case .symmetric:
-            return Raw.mirrorPad(self, paddings: paddings, mode: .symmetric)
+            return _Raw.mirrorPad(self, paddings: paddings, mode: .symmetric)
         }
     }
 }
@@ -840,16 +840,16 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
                 scalars: sizes.flatMap { [Int32($0.before), Int32($0.after)] })
             switch mode {
             case .constant:
-                let padBefore = Raw.slice(
+                let padBefore = _Raw.slice(
                     paddings,
                     begin: Tensor<Int32>([0, 0]),
                     size: Tensor<Int32>(stacking: [rank, Tensor<Int32>(1)]))
                 let begin = padBefore.reshaped(to: [-1])
                 return v.slice(lowerBounds: begin, sizes: shape)
             case .reflect:
-                return Raw.mirrorPadGrad(v, paddings: paddings, mode: .reflect)
+                return _Raw.mirrorPadGrad(v, paddings: paddings, mode: .reflect)
             case .symmetric:
-                return Raw.mirrorPadGrad(v, paddings: paddings, mode: .symmetric)
+                return _Raw.mirrorPadGrad(v, paddings: paddings, mode: .symmetric)
             }
         })
     }
@@ -881,7 +881,7 @@ public extension Tensor {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpSlice where Scalar: TensorFlowFloatingPoint)
     func slice(lowerBounds: Tensor<Int32>, sizes: Tensor<Int32>) -> Tensor {
-        return Raw.slice(self, begin: lowerBounds, size: sizes)
+        return _Raw.slice(self, begin: lowerBounds, size: sizes)
     }
 }
 
@@ -898,7 +898,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
             let afterPaddings = after.expandingShape(at: 1)
             let paddings = Tensor<Int32>(
                 concatenating: [beforePaddings, afterPaddings], alongAxis: 1)
-            return Raw.pad(v, paddings: paddings)
+            return _Raw.pad(v, paddings: paddings)
         })
     }
 }
@@ -1049,7 +1049,7 @@ public extension Tensor {
     @differentiable(wrt: self, vjp: _vjpSubscript where Scalar : TensorFlowFloatingPoint)
     internal subscript(_ indexPath: IndexPath) -> Tensor {
         get {
-            return Raw.stridedSlice(
+            return _Raw.stridedSlice(
                 self, begin: indexPath.begin, end: indexPath.end,
                 strides: indexPath.strides, beginMask: indexPath.beginMask,
                 endMask: indexPath.endMask, ellipsisMask: indexPath.ellipsisMask,
@@ -1057,7 +1057,7 @@ public extension Tensor {
                 shrinkAxisMask: indexPath.squeezeAxisMask)
         }
         set {
-            self = Raw.tensorStridedSliceUpdate(
+            self = _Raw.tensorStridedSliceUpdate(
                 self, begin: indexPath.begin, end: indexPath.end,
                 strides: indexPath.strides, value: newValue,
                 beginMask: indexPath.beginMask, endMask: indexPath.endMask,
@@ -1085,7 +1085,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
         _ indexPath: IndexPath
     ) -> (Tensor, (Tensor) -> Tensor) {
         return (self[indexPath], { [shape = shapeTensor] v in
-            Raw.stridedSliceGrad(
+            _Raw.stridedSliceGrad(
                 shape: shape, begin: indexPath.begin, end: indexPath.end,
                 strides: indexPath.strides, dy: v, beginMask: indexPath.beginMask,
                 endMask: indexPath.endMask, ellipsisMask: indexPath.ellipsisMask,

--- a/Sources/TensorFlow/Operators/Comparison.swift
+++ b/Sources/TensorFlow/Operators/Comparison.swift
@@ -23,81 +23,81 @@ public extension Tensor where Scalar: Numeric & Comparable {
     /// Returns a tensor of Boolean scalars by computing `lhs < rhs` element-wise.
     @inlinable
     static func .< (lhs: Tensor, rhs: Tensor) -> Tensor<Bool> {
-        return Raw.less(lhs, rhs)
+        return _Raw.less(lhs, rhs)
     }
 
     /// Returns a tensor of Boolean scalars by computing `lhs <= rhs` element-wise.
     @inlinable
     static func .<= (lhs: Tensor, rhs: Tensor) -> Tensor<Bool> {
-        return Raw.lessEqual(lhs, rhs)
+        return _Raw.lessEqual(lhs, rhs)
     }
 
     /// Returns a tensor of Boolean scalars by computing `lhs > rhs` element-wise.
     @inlinable
     static func .> (lhs: Tensor, rhs: Tensor) -> Tensor<Bool> {
-        return Raw.greater(lhs, rhs)
+        return _Raw.greater(lhs, rhs)
     }
 
     /// Returns a tensor of Boolean scalars by computing `lhs >= rhs` element-wise.
     @inlinable
     static func .>= (lhs: Tensor, rhs: Tensor) -> Tensor<Bool> {
-        return Raw.greaterEqual(lhs, rhs)
+        return _Raw.greaterEqual(lhs, rhs)
     }
 
     /// Returns a tensor of Boolean scalars by computing `lhs < rhs` element-wise.
     /// - Note: `.<` supports broadcasting.
     @inlinable
     static func .< (lhs: Scalar, rhs: Tensor) -> Tensor<Bool> {
-        return Raw.less(Tensor(lhs), rhs)
+        return _Raw.less(Tensor(lhs), rhs)
     }
 
     /// Returns a tensor of Boolean scalars by computing `lhs <= rhs` element-wise.
     /// - Note: `.<=` supports broadcasting.
     @inlinable
     static func .<= (lhs: Scalar, rhs: Tensor) -> Tensor<Bool> {
-        return Raw.lessEqual(Tensor(lhs), rhs)
+        return _Raw.lessEqual(Tensor(lhs), rhs)
     }
 
     /// Returns a tensor of Boolean scalars by computing `lhs > rhs` element-wise.
     /// - Note: `.>` supports broadcasting.
     @inlinable
     static func .> (lhs: Scalar, rhs: Tensor) -> Tensor<Bool> {
-        return Raw.greater(Tensor(lhs), rhs)
+        return _Raw.greater(Tensor(lhs), rhs)
     }
 
     /// Returns a tensor of Boolean scalars by computing `lhs >= rhs` element-wise.
     /// - Note: `.>=` supports broadcasting.
     @inlinable
     static func .>= (lhs: Scalar, rhs: Tensor) -> Tensor<Bool> {
-        return Raw.greaterEqual(Tensor(lhs), rhs)
+        return _Raw.greaterEqual(Tensor(lhs), rhs)
     }
 
     /// Returns a tensor of Boolean scalars by computing `lhs < rhs` element-wise.
     /// - Note: `.<` supports broadcasting.
     @inlinable
     static func .< (lhs: Tensor, rhs: Scalar) -> Tensor<Bool> {
-        return Raw.less(lhs, Tensor(rhs))
+        return _Raw.less(lhs, Tensor(rhs))
     }
 
     /// Returns a tensor of Boolean scalars by computing `lhs <= rhs` element-wise.
     /// - Note: `.<=` supports broadcasting.
     @inlinable
     static func .<= (lhs: Tensor, rhs: Scalar) -> Tensor<Bool> {
-        return Raw.lessEqual(lhs, Tensor(rhs))
+        return _Raw.lessEqual(lhs, Tensor(rhs))
     }
 
     /// Returns a tensor of Boolean scalars by computing `lhs > rhs` element-wise.
     /// - Note: `.>` supports broadcasting.
     @inlinable
     static func .> (lhs: Tensor, rhs: Scalar) -> Tensor<Bool> {
-        return Raw.greater(lhs, Tensor(rhs))
+        return _Raw.greater(lhs, Tensor(rhs))
     }
 
     /// Returns a tensor of Boolean scalars by computing `lhs >= rhs` element-wise.
     /// - Note: `.>=` supports broadcasting.
     @inlinable
     static func .>= (lhs: Tensor, rhs: Scalar) -> Tensor<Bool> {
-        return Raw.greaterEqual(lhs, Tensor(rhs))
+        return _Raw.greaterEqual(lhs, Tensor(rhs))
     }
 }
 
@@ -106,14 +106,14 @@ public extension Tensor where Scalar: Equatable {
     /// - Note: `.==` supports broadcasting.
     @inlinable
     static func .== (lhs: Tensor, rhs: Tensor) -> Tensor<Bool> {
-        return Raw.equal(lhs, rhs)
+        return _Raw.equal(lhs, rhs)
     }
 
     /// Returns a tensor of Boolean scalars by computing `lhs != rhs` element-wise.
     /// - Note: `.!=` supports broadcasting.
     @inlinable
     static func .!= (lhs: Tensor, rhs: Tensor) -> Tensor<Bool> {
-        return Raw.notEqual(lhs, rhs)
+        return _Raw.notEqual(lhs, rhs)
     }
 
     /// Returns a tensor of Boolean scalars by computing `lhs == rhs` element-wise.
@@ -156,7 +156,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint & Equatable {
         _ other: Tensor,
         tolerance: Scalar = Scalar.ulpOfOne.squareRoot()
     ) -> Tensor<Bool> {
-        return Raw.approximateEqual(self, other, tolerance: Double(tolerance))
+        return _Raw.approximateEqual(self, other, tolerance: Double(tolerance))
     }
 }
 
@@ -165,7 +165,7 @@ public extension StringTensor {
     /// - Note: `elementsEqual` supports broadcasting.
     @inlinable
     func elementsEqual(_ other: StringTensor) -> Tensor<Bool> {
-        return Raw.equal(self, other)
+        return _Raw.equal(self, other)
     }
 }
 

--- a/Sources/TensorFlow/Operators/Dataset.swift
+++ b/Sources/TensorFlow/Operators/Dataset.swift
@@ -53,7 +53,7 @@ public extension Dataset {
     @inlinable
     init(randomSeed: Int64) {
         let (seed1, seed2) = _tensorSeeds(Tensor(randomSeed))
-        self.init(_handle: Raw.experimentalRandomDataset(
+        self.init(_handle: _Raw.experimentalRandomDataset(
             seed: seed1,
             seed2: seed2,
             outputTypes: Element._typeList,
@@ -65,7 +65,7 @@ public extension Dataset {
     /// Creates a dataset from a batch of elements as a tensor.
     @inlinable
     init(elements: Element) {
-        self.init(_handle: Raw.tensorSliceDataset(
+        self.init(_handle: _Raw.tensorSliceDataset(
             components: [elements],
             outputShapes: Element._unknownShapeList))
     }
@@ -77,10 +77,10 @@ extension Dataset: Sequence {
     /// Returns an iterator over the elements of this dataset.
     @inlinable
     public func makeIterator() -> DatasetIterator<Element> {
-        let resource = Raw.anonymousIterator(
+        let resource = _Raw.anonymousIterator(
             outputTypes: Element._typeList,
             outputShapes: Element._unknownShapeList)
-        Raw.makeIterator(dataset: _handle, iterator: resource)
+        _Raw.makeIterator(dataset: _handle, iterator: resource)
         return DatasetIterator(_handle: resource)
     }
 }
@@ -92,7 +92,7 @@ public extension Dataset {
     func map<ResultElement: TensorGroup>(
         _ transform: (Element) -> ResultElement
     ) -> Dataset<ResultElement> {
-        return Dataset<ResultElement>(_handle: Raw.mapDataset(
+        return Dataset<ResultElement>(_handle: _Raw.mapDataset(
             inputDataset: _handle,
             otherArguments: Tensor<Int32>(0),
             f: transform,
@@ -107,7 +107,7 @@ public extension Dataset {
         parallelCallCount: Int,
         _ transform: (Element) -> ResultElement
     ) -> Dataset<ResultElement> {
-        return Dataset<ResultElement>(_handle: Raw.parallelMapDataset(
+        return Dataset<ResultElement>(_handle: _Raw.parallelMapDataset(
             inputDataset: _handle,
             otherArguments: Tensor<Int32>(0),
             numParallelCalls: Tensor<Int32>(Int32(parallelCallCount)),
@@ -121,7 +121,7 @@ public extension Dataset {
 
     @inlinable
     func filter(_ isIncluded: (Element) -> Tensor<Bool>) -> Dataset {
-        return Dataset(_handle: Raw.filterDataset(
+        return Dataset(_handle: _Raw.filterDataset(
             inputDataset: _handle,
             otherArguments: Tensor<Int32>(0),
             predicate: isIncluded,
@@ -133,7 +133,7 @@ public extension Dataset {
 public extension Dataset {
     @inlinable
     func prefetched(count: Int) -> Dataset {
-        return Dataset(_handle: Raw.prefetchDataset(
+        return Dataset(_handle: _Raw.prefetchDataset(
             inputDataset: _handle,
             bufferSize: Tensor(Int64(count)),
             outputTypes: Element._typeList,
@@ -147,7 +147,7 @@ public extension Dataset {
         reshuffleForEachIterator: Bool = true
     ) -> Dataset {
         let (seed1, seed2) = _tensorSeeds(Tensor(randomSeed))
-        return Dataset(_handle: Raw.shuffleDataset(
+        return Dataset(_handle: _Raw.shuffleDataset(
             inputDataset: _handle,
             bufferSize: Tensor(Int64(sampleCount)),
             seed: seed1,
@@ -159,7 +159,7 @@ public extension Dataset {
 
     @inlinable
     func batched(_ batchSize: Int) -> Dataset {
-        return Dataset(_handle: Raw.batchDataset(
+        return Dataset(_handle: _Raw.batchDataset(
             inputDataset: _handle,
             batchSize: Tensor(Int64(batchSize)),
             outputTypes: Element._typeList,
@@ -168,7 +168,7 @@ public extension Dataset {
 
     @inlinable
     func repeated(count: Int? = nil) -> Dataset {
-        return Dataset(_handle: Raw.repeatDataset(
+        return Dataset(_handle: _Raw.repeatDataset(
             inputDataset: _handle,
             count: Tensor(Int64(count ?? -1)),
             outputTypes: Element._typeList,
@@ -191,14 +191,14 @@ extension DatasetIterator: IteratorProtocol {
     /// Advances to the next element and returns it, or `nil` if no next element exists.
     @inlinable
     public mutating func next() -> Element? {
-        let optional = Raw.iteratorGetNextAsOptional(
+        let optional = _Raw.iteratorGetNextAsOptional(
             iterator: _handle,
             outputTypes: Element._typeList,
             outputShapes: Element._unknownShapeList)
-        guard Raw.optionalHasValue(optional: optional).scalarized() else {
+        guard _Raw.optionalHasValue(optional: optional).scalarized() else {
             return nil
         }
-        return Raw.optionalGetValue(
+        return _Raw.optionalGetValue(
             optional: optional,
             outputShapes: Element._unknownShapeList)
     }
@@ -236,7 +236,7 @@ public struct Zip2TensorGroup<T: TensorGroup, U: TensorGroup>: TensorGroup {
 public func zip<T: TensorGroup, U: TensorGroup>(
     _ dataset1: Dataset<T>, _ dataset2: Dataset<U>
 ) -> Dataset<Zip2TensorGroup<T, U>> {
-    let handle = Raw.zipDataset(
+    let handle = _Raw.zipDataset(
         inputDatasets: [dataset1._handle, dataset2._handle],
         outputTypes: Zip2TensorGroup<T, U>._typeList,
         outputShapes: Zip2TensorGroup<T, U>._unknownShapeList)

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -319,7 +319,7 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(vjp: _vjpMultiply(lhs:rhs:) where Scalar: TensorFlowFloatingPoint)
     static func * (lhs: Tensor, rhs: Tensor) -> Tensor {
-        return Raw.mul(lhs, rhs)
+        return _Raw.mul(lhs, rhs)
     }
 
     /// Returns the tensor by multiplying it with every scalar of the tensor.
@@ -355,7 +355,7 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(vjp: _vjpDivide(lhs:rhs:) where Scalar: TensorFlowFloatingPoint)
     static func / (lhs: Tensor, rhs: Tensor) -> Tensor {
-        return Raw.div(lhs, rhs)
+        return _Raw.div(lhs, rhs)
     }
 
     /// Returns the quotient of dividing the scalar by the tensor, broadcasting the scalar.
@@ -390,7 +390,7 @@ public extension Tensor where Scalar: Numeric {
     /// - Note: `%` supports broadcasting.
     @inlinable
     static func % (lhs: Tensor, rhs: Tensor) -> Tensor {
-        return Raw.mod(lhs, rhs)
+        return _Raw.mod(lhs, rhs)
     }
 
     /// Returns the remainder of dividing the tensor by the scalar, broadcasting the scalar.
@@ -445,7 +445,7 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
         return (lhs * rhs, { [lhsShape = lhs.shapeTensor, rhsShape = rhs.shapeTensor] v in
             let lhsGrad = rhs * v
             let rhsGrad = lhs * v
-            let (lhsAxes, rhsAxes) = Raw.broadcastGradientArgs(s0: lhsShape, s1: rhsShape)
+            let (lhsAxes, rhsAxes) = _Raw.broadcastGradientArgs(s0: lhsShape, s1: rhsShape)
             return (lhsGrad.sum(squeezingAxes: lhsAxes).reshaped(toShape: lhsShape),
                     rhsGrad.sum(squeezingAxes: rhsAxes).reshaped(toShape: rhsShape))
         })
@@ -466,7 +466,7 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
         return (lhs / rhs, { [lhsShape = lhs.shapeTensor, rhsShape = rhs.shapeTensor] v in
             let lhsGrad = v / rhs
             let rhsGrad = -lhs / rhs.squared() * v
-            let (lhsAxes, rhsAxes) = Raw.broadcastGradientArgs(s0: lhsShape, s1: rhsShape)
+            let (lhsAxes, rhsAxes) = _Raw.broadcastGradientArgs(s0: lhsShape, s1: rhsShape)
             return (lhsGrad.sum(squeezingAxes: lhsAxes).reshaped(toShape: lhsShape),
                     rhsGrad.sum(squeezingAxes: rhsAxes).reshaped(toShape: rhsShape))
         })
@@ -489,14 +489,14 @@ public extension Tensor where Scalar == Bool {
     /// Returns `!self` element-wise.
     @inlinable
     func elementsLogicalNot() -> Tensor {
-        return Raw.logicalNot(self)
+        return _Raw.logicalNot(self)
     }
 
     /// Returns `self && other` element-wise.
     /// - Note: `&&` supports broadcasting.
     @inlinable
     func elementsLogicalAnd(_ other: Tensor) -> Tensor {
-        return Raw.logicalAnd(self, other)
+        return _Raw.logicalAnd(self, other)
     }
 
     /// Returns `self && other` element-wise, broadcasting `other`.
@@ -508,7 +508,7 @@ public extension Tensor where Scalar == Bool {
     /// Returns `self || other` element-wise.
     @inlinable
     func elementsLogicalOr(_ other: Tensor) -> Tensor {
-        return Raw.logicalOr(self, other)
+        return _Raw.logicalOr(self, other)
     }
 
     /// Returns `self || other` element-wise, broadcasting `other`.
@@ -523,7 +523,7 @@ public extension Tensor where Scalar: TensorFlowNumeric {
     @inlinable
     @differentiable(vjp: _vjpClipped where Scalar: TensorFlowFloatingPoint)
     func clipped(min: Tensor, max: Tensor) -> Tensor {
-        Raw.clipByValue(t: self, clipValueMin: min, clipValueMax: max)
+        _Raw.clipByValue(t: self, clipValueMin: min, clipValueMax: max)
     }
 
     /// Returns `max(min(self, max), min)`.
@@ -561,8 +561,8 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
             let selfGradient = v.replacing(with: zeros, where: minMask.elementsLogicalOr(maxMask))
             let minGradient = zeros.replacing(with: v, where: minMask)
             let maxGradient = zeros.replacing(with: v, where: maxMask)
-            let (selfAxes, minAxes) = Raw.broadcastGradientArgs(s0: selfShape, s1: minShape)
-            let (_, maxAxes) = Raw.broadcastGradientArgs(s0: selfShape, s1: maxShape)
+            let (selfAxes, minAxes) = _Raw.broadcastGradientArgs(s0: selfShape, s1: minShape)
+            let (_, maxAxes) = _Raw.broadcastGradientArgs(s0: selfShape, s1: maxShape)
             return (selfGradient.sum(squeezingAxes: selfAxes).reshaped(toShape: selfShape),
                     minGradient.sum(squeezingAxes: minAxes).reshaped(toShape: minShape),
                     maxGradient.sum(squeezingAxes: maxAxes).reshaped(toShape: maxShape))
@@ -635,7 +635,7 @@ public extension Tensor where Scalar: SignedNumeric {
     @inlinable
     @differentiable(vjp: _vjpNegate(_:) where Scalar: TensorFlowFloatingPoint)
     static prefix func - (rhs: Tensor) -> Tensor {
-        return Raw.neg(rhs)
+        return _Raw.neg(rhs)
     }
 }
 
@@ -650,14 +650,14 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
 @inlinable
 @differentiable(vjp: _vjpAbs(_:) where T: TensorFlowFloatingPoint)
 public func abs<T: SignedNumeric>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.abs(x)
+    _Raw.abs(x)
 }
 
 @inlinable
 internal func _vjpAbs<T: TensorFlowFloatingPoint>(
   _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
-    let sign = Raw.sign(x)
+    let sign = _Raw.sign(x)
     return (abs(x), { v in v * sign })
 }
 
@@ -665,7 +665,7 @@ internal func _vjpAbs<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpLog(_:))
 public func log<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.log(x)
+    _Raw.log(x)
 }
 
 @inlinable
@@ -693,14 +693,14 @@ public func log10<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 @inlinable
 @differentiable(vjp: _vjpLog1p)
 public func log1p<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.log1p(x)
+    _Raw.log1p(x)
 }
 
 @inlinable
 func _vjpLog1p<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
-    (log1p(x), { v in Raw.xdivy(v, 1 + x) })
+    (log1p(x), { v in _Raw.xdivy(v, 1 + x) })
 }
 
 /// Returns `log(1 - exp(x))` using a numerically stable approach.
@@ -722,7 +722,7 @@ public func log1mexp<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 @inlinable
 @differentiable(vjp: _vjpSin(_:))
 public func sin<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.sin(x)
+    _Raw.sin(x)
 }
 
 @inlinable
@@ -736,7 +736,7 @@ internal func _vjpSin<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpCos(_:))
 public func cos<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.cos(x)
+    _Raw.cos(x)
 }
 
 @inlinable
@@ -750,7 +750,7 @@ internal func _vjpCos<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpTan(_:))
 public func tan<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.tan(x)
+    _Raw.tan(x)
 }
 
 @inlinable
@@ -765,7 +765,7 @@ internal func _vjpTan<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpSinh(_:))
 public func sinh<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.sinh(x)
+    _Raw.sinh(x)
 }
 
 @inlinable
@@ -779,7 +779,7 @@ internal func _vjpSinh<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpCosh(_:))
 public func cosh<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.cosh(x)
+    _Raw.cosh(x)
 }
 
 @inlinable
@@ -793,7 +793,7 @@ internal func _vjpCosh<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpTanh(_:))
 public func tanh<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.tanh(x)
+    _Raw.tanh(x)
 }
 
 @inlinable
@@ -808,7 +808,7 @@ internal func _vjpTanh<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpAcos(_:))
 public func acos<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.acos(x)
+    _Raw.acos(x)
 }
 
 @inlinable
@@ -822,7 +822,7 @@ internal func _vjpAcos<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpAsin(_:))
 public func asin<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.asin(x)
+    _Raw.asin(x)
 }
 
 @inlinable
@@ -836,7 +836,7 @@ internal func _vjpAsin<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpAtan(_:))
 public func atan<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.atan(x)
+    _Raw.atan(x)
 }
 
 @inlinable
@@ -850,7 +850,7 @@ internal func _vjpAtan<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpAcosh(_:))
 public func acosh<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.acosh(x)
+    _Raw.acosh(x)
 }
 
 @inlinable
@@ -864,7 +864,7 @@ internal func _vjpAcosh<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpAsinh(_:))
 public func asinh<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.asinh(x)
+    _Raw.asinh(x)
 }
 
 @inlinable
@@ -878,7 +878,7 @@ internal func _vjpAsinh<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpAtanh(_:))
 public func atanh<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.atanh(x)
+    _Raw.atanh(x)
 }
 
 @inlinable
@@ -893,7 +893,7 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpSquared() where Scalar: TensorFlowFloatingPoint)
     func squared() -> Tensor {
-        Raw.square(self)
+        _Raw.square(self)
     }
 }
 
@@ -908,7 +908,7 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
 @inlinable
 @differentiable(vjp: _vjpSqrt(_:))
 public func sqrt<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.sqrt(x)
+    _Raw.sqrt(x)
 }
 
 @inlinable
@@ -923,7 +923,7 @@ internal func _vjpSqrt<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpRsqrt(_:))
 public func rsqrt<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.rsqrt(x)
+    _Raw.rsqrt(x)
 }
 
 @inlinable
@@ -931,14 +931,14 @@ internal func _vjpRsqrt<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
     let value = rsqrt(x)
-    return (value, { v in Raw.rsqrtGrad(value, dy: v) })
+    return (value, { v in _Raw.rsqrtGrad(value, dy: v) })
 }
 
 /// Returns the exponential of the specified tensor element-wise.
 @inlinable
 @differentiable(vjp: _vjpExp(_:))
 public func exp<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.exp(x)
+    _Raw.exp(x)
 }
 
 @inlinable
@@ -967,7 +967,7 @@ public func exp10<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 @inlinable
 @differentiable(vjp: _vjpExpm1)
 public func expm1<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.expm1(x)
+    _Raw.expm1(x)
 }
 
 @inlinable
@@ -982,7 +982,7 @@ internal func _vjpExpm1<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpRound)
 public func round<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.round(x)
+    _Raw.round(x)
 }
 
 @inlinable
@@ -996,7 +996,7 @@ internal func _vjpRound<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpCeil(_:))
 public func ceil<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.ceil(x)
+    _Raw.ceil(x)
 }
 
 @inlinable
@@ -1010,7 +1010,7 @@ internal func _vjpCeil<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpFloor(_:))
 public func floor<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.floor(x)
+    _Raw.floor(x)
 }
 
 @inlinable
@@ -1025,7 +1025,7 @@ internal func _vjpFloor<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpSign(_:) where T: TensorFlowFloatingPoint)
 public func sign<T: Numeric>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.sign(x)
+    _Raw.sign(x)
 }
 
 @inlinable
@@ -1040,7 +1040,7 @@ internal func _vjpSign<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpSigmoid)
 public func sigmoid<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.sigmoid(x)
+    _Raw.sigmoid(x)
 }
 
 @inlinable
@@ -1048,7 +1048,7 @@ internal func _vjpSigmoid<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
     let sigmoidValue = sigmoid(x)
-    return (sigmoidValue, { v in Raw.sigmoidGrad(sigmoidValue, dy: v) })
+    return (sigmoidValue, { v in _Raw.sigmoidGrad(sigmoidValue, dy: v) })
 }
 
 /// Returns the log-sigmoid of the specified tensor element-wise. Specifically,
@@ -1064,14 +1064,14 @@ public func logSigmoid<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> 
 @inlinable
 @differentiable(vjp: _vjpSoftplus)
 public func softplus<T: TensorFlowFloatingPoint>(_ features: Tensor<T>) -> Tensor<T> {
-    Raw.softplus(features: features)
+    _Raw.softplus(features: features)
 }
 
 @inlinable
 internal func _vjpSoftplus<T: TensorFlowFloatingPoint>(
     _ features: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
-    (softplus(features), { v in Raw.softplusGrad(gradients: v, features: features)})
+    (softplus(features), { v in _Raw.softplusGrad(gradients: v, features: features)})
 }
 
 /// Returns the softsign of the specified tensor element-wise.
@@ -1079,14 +1079,14 @@ internal func _vjpSoftplus<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpSoftsign)
 public func softsign<T: TensorFlowFloatingPoint>(_ features: Tensor<T>) -> Tensor<T> {
-    Raw.softsign(features: features)
+    _Raw.softsign(features: features)
 }
 
 @inlinable
 internal func _vjpSoftsign<T: TensorFlowFloatingPoint>(
     _ features: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
-    (softsign(features), { v in Raw.softsignGrad(gradients: v, features: features)})
+    (softsign(features), { v in _Raw.softsignGrad(gradients: v, features: features)})
 }
 
 /// Returns the softmax of the specified tensor along the last axis.
@@ -1094,7 +1094,7 @@ internal func _vjpSoftsign<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpSoftmax(_:))
 public func softmax<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.softmax(logits: x)
+    _Raw.softmax(logits: x)
 }
 
 /// Returns the softmax of the specified tensor along the specified axis.
@@ -1121,7 +1121,7 @@ func _vjpSoftmax<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpLogSoftmax(_:))
 public func logSoftmax<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.logSoftmax(logits: x)
+    _Raw.logSoftmax(logits: x)
 }
 
 @inlinable
@@ -1139,7 +1139,7 @@ func _vjpLogSoftmax<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpElu)
 public func elu<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.elu(features: x)
+    _Raw.elu(features: x)
 }
 
 @inlinable
@@ -1147,7 +1147,7 @@ func _vjpElu<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
     let y = elu(x)
-    return (y, { v in Raw.eluGrad(gradients: v, outputs: y) })
+    return (y, { v in _Raw.eluGrad(gradients: v, outputs: y) })
 }
 
 /// Returns the Gaussian Error Linear Unit (GELU) activations of the specified tensor element-wise.
@@ -1173,28 +1173,28 @@ public func gelu<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 @inlinable
 @differentiable(vjp: _vjpRelu(_:))
 public func relu<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.relu(features: x)
+    _Raw.relu(features: x)
 }
 
 @inlinable
 func _vjpRelu<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
-    (relu(x), { v in Raw.reluGrad(gradients: v, features: x) })
+    (relu(x), { v in _Raw.reluGrad(gradients: v, features: x) })
 }
 
 /// Returns a tensor by applying the ReLU6 activation function, namely `min(max(0, x), 6)`.
 @inlinable
 @differentiable(vjp: _vjpRelu6(_:))
 public func relu6<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.relu6(features: x)
+    _Raw.relu6(features: x)
 }
 
 @inlinable
 func _vjpRelu6<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
-    (relu6(x), { v in Raw.relu6Grad(gradients: v, features: x)})
+    (relu6(x), { v in _Raw.relu6Grad(gradients: v, features: x)})
 }
 
 /// Returns a tensor by applying the leaky ReLU activation function
@@ -1206,7 +1206,7 @@ public func leakyRelu<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>,
     alpha: Double = 0.2
 ) -> Tensor<T> {
-    Raw.leakyRelu(features: x, alpha: alpha)
+    _Raw.leakyRelu(features: x, alpha: alpha)
 }
 
 @inlinable
@@ -1215,7 +1215,7 @@ func _vjpLeakyRelu<T: TensorFlowFloatingPoint>(
     alpha: Double
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
     (leakyRelu(x, alpha: alpha), { v in
-        Raw.leakyReluGrad(gradients: v, features: x, alpha: alpha)
+        _Raw.leakyReluGrad(gradients: v, features: x, alpha: alpha)
     })
 }
 
@@ -1228,7 +1228,7 @@ func _vjpLeakyRelu<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpSelu(_:))
 public func selu<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-    Raw.selu(features: x)
+    _Raw.selu(features: x)
 }
 
 @inlinable
@@ -1237,19 +1237,19 @@ func _vjpSelu<T: TensorFlowFloatingPoint>(
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
     let result = selu(x)
     return (result, { v in
-        Raw.seluGrad(gradients: v, outputs: result)
+        _Raw.seluGrad(gradients: v, outputs: result)
     })
 }
 
 public extension Tensor where Scalar: TensorFlowFloatingPoint {
     /// Returns a boolean tensor indicating which elements of `x` are finite.
-    @inlinable var isFinite: Tensor<Bool> { Raw.isFinite(self) }
+    @inlinable var isFinite: Tensor<Bool> { _Raw.isFinite(self) }
 
     /// Returns a boolean tensor indicating which elements of `x` are infinite.
-    @inlinable var isInfinite: Tensor<Bool> { Raw.isInf(self) }
+    @inlinable var isInfinite: Tensor<Bool> { _Raw.isInf(self) }
 
     /// Returns a boolean tensor indicating which elements of `x` are NaN-valued.
-    @inlinable var isNaN: Tensor<Bool> { Raw.isNan(self) }
+    @inlinable var isNaN: Tensor<Bool> { _Raw.isNan(self) }
 }
 
 //===------------------------------------------------------------------------------------------===//
@@ -1260,7 +1260,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
 @inlinable
 @differentiable(vjp: _vjpPow(_:_:))
 public func pow<T: TensorFlowFloatingPoint>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T> {
-    Raw.pow(lhs, rhs)
+    _Raw.pow(lhs, rhs)
 }
 
 @inlinable
@@ -1273,7 +1273,7 @@ internal func _vjpPow<T: TensorFlowFloatingPoint>(
         let lhsGrad = v * y * pow(x, y - 1)
         let rhsGrad = value * v * log(safeX)
         let (lhsShape, rhsShape) = (x.shapeTensor, y.shapeTensor)
-        let (lhsAxes, rhsAxes) = Raw.broadcastGradientArgs(s0: lhsShape, s1: rhsShape)
+        let (lhsAxes, rhsAxes) = _Raw.broadcastGradientArgs(s0: lhsShape, s1: rhsShape)
         return (lhsGrad.sum(squeezingAxes: lhsAxes).reshaped(toShape: lhsShape),
                 rhsGrad.sum(squeezingAxes: rhsAxes).reshaped(toShape: rhsShape))
     })
@@ -1312,7 +1312,7 @@ public func root<T: TensorFlowFloatingPoint>(_ x: Tensor<T>, _ n: Int) -> Tensor
 @inlinable
 @differentiable(vjp: _vjpSquaredDifference where T: TensorFlowFloatingPoint)
 public func squaredDifference<T: TensorFlowNumeric>(_ x: Tensor<T>, _ y: Tensor<T>) -> Tensor<T> {
-    Raw.squaredDifference(x, y)
+    _Raw.squaredDifference(x, y)
 }
 
 @inlinable
@@ -1324,7 +1324,7 @@ internal func _vjpSquaredDifference<T: TensorFlowFloatingPoint>(
         let lhsGrad = 2 * seed * (x - y)
         let rhsGrad = -lhsGrad
         let (lhsShape, rhsShape) = (x.shapeTensor, y.shapeTensor)
-        let (lhsAxes, rhsAxes) = Raw.broadcastGradientArgs(s0: lhsShape, s1: rhsShape)
+        let (lhsAxes, rhsAxes) = _Raw.broadcastGradientArgs(s0: lhsShape, s1: rhsShape)
         return (lhsGrad.sum(squeezingAxes: lhsAxes).reshaped(toShape: lhsShape),
                 rhsGrad.sum(squeezingAxes: rhsAxes).reshaped(toShape: rhsShape))
     })
@@ -1335,7 +1335,7 @@ internal func _vjpSquaredDifference<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable(vjp: _vjpMax(_:_:) where T: TensorFlowFloatingPoint)
 public func max<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T> where T: Numeric & Comparable {
-    Raw.maximum(lhs, rhs)
+    _Raw.maximum(lhs, rhs)
 }
 
 @inlinable
@@ -1368,7 +1368,7 @@ public func max<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T> where T: Numeric & C
 @inlinable
 @differentiable(vjp: _vjpMin(_:_:) where T: TensorFlowFloatingPoint)
 public func min<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T> where T: Numeric & Comparable {
-    Raw.minimum(lhs, rhs)
+    _Raw.minimum(lhs, rhs)
 }
 
 @inlinable
@@ -1408,7 +1408,7 @@ internal func _vjpMinMaxHelper<T: TensorFlowFloatingPoint>(
     let lhsGrad = seed * mask
     let rhsGrad = seed * (1 - mask)
     let (lhsShape, rhsShape) = (x.shapeTensor, y.shapeTensor)
-    let (lhsAxes, rhsAxes) = Raw.broadcastGradientArgs(s0: lhsShape, s1: rhsShape)
+    let (lhsAxes, rhsAxes) = _Raw.broadcastGradientArgs(s0: lhsShape, s1: rhsShape)
     return (lhsGrad.sum(squeezingAxes: lhsAxes).reshaped(toShape: lhsShape),
             rhsGrad.sum(squeezingAxes: rhsAxes).reshaped(toShape: rhsShape))
 }
@@ -1448,7 +1448,7 @@ public extension Tensor {
     @inlinable
     @differentiable(wrt: (self, other), vjp: _vjpReplacing where Scalar: TensorFlowFloatingPoint)
     func replacing(with other: Tensor, where mask: Tensor<Bool>) -> Tensor {
-        Raw.select(condition: mask, t: other, e: self)
+        _Raw.select(condition: mask, t: other, e: self)
     }
 }
 
@@ -1476,7 +1476,7 @@ public extension Tensor where Scalar == Bool {
     @inlinable
     func all() -> Bool {
         let axes = Tensor<Int32>(rangeFrom: 0, to: Int32(rank), stride: 1)
-        return Raw.all(self, reductionIndices: axes).scalarized()
+        return _Raw.all(self, reductionIndices: axes).scalarized()
     }
 
     /// Returns `true` if any scalars are equal to `true`. Otherwise, returns `false`.
@@ -1485,7 +1485,7 @@ public extension Tensor where Scalar == Bool {
     @inlinable
     func any() -> Bool {
         let axes = Tensor<Int32>(rangeFrom: 0, to: Int32(rank), stride: 1)
-        return Raw.any(self, reductionIndices: axes).scalarized()
+        return _Raw.any(self, reductionIndices: axes).scalarized()
     }
 
     /// Performs a logical AND operation along the specified axes. The reduced dimensions are
@@ -1495,7 +1495,7 @@ public extension Tensor where Scalar == Bool {
     @inlinable
     func all(squeezingAxes axes: Int...) -> Tensor {
         let axes = axes.map(Int32.init)
-        return Raw.all(self, reductionIndices: Tensor<Int32>(axes), keepDims: false)
+        return _Raw.all(self, reductionIndices: Tensor<Int32>(axes), keepDims: false)
     }
 
     /// Performs a logical AND operation along the specified axes. The reduced dimensions are
@@ -1505,7 +1505,7 @@ public extension Tensor where Scalar == Bool {
     @inlinable
     func any(squeezingAxes axes: Int...) -> Tensor {
         let axes = axes.map(Int32.init)
-        return Raw.any(self, reductionIndices: Tensor<Int32>(axes), keepDims: false)
+        return _Raw.any(self, reductionIndices: Tensor<Int32>(axes), keepDims: false)
     }
 
     /// Performs a logical AND operation along the specified axes. The reduced dimensions are
@@ -1515,7 +1515,7 @@ public extension Tensor where Scalar == Bool {
     @inlinable
     func all(alongAxes axes: Int...) -> Tensor {
         let axes = axes.map(Int32.init)
-        return Raw.all(self, reductionIndices: Tensor<Int32>(axes), keepDims: true)
+        return _Raw.all(self, reductionIndices: Tensor<Int32>(axes), keepDims: true)
     }
 
     /// Performs a logical OR operation along the specified axes. The reduced
@@ -1525,7 +1525,7 @@ public extension Tensor where Scalar == Bool {
     @inlinable
     func any(alongAxes axes: Int...) -> Tensor {
         let axes = axes.map(Int32.init)
-        return Raw.any(self, reductionIndices: Tensor<Int32>(axes), keepDims: true)
+        return _Raw.any(self, reductionIndices: Tensor<Int32>(axes), keepDims: true)
     }
 }
 
@@ -1556,7 +1556,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
         wrt: self,
         vjp: _vjpMinOrMax(squeezingAxes:) where Scalar: TensorFlowFloatingPoint)
     func max(squeezingAxes axes: Tensor<Int32>) -> Tensor {
-        return Raw.max(self, reductionIndices: axes, keepDims: false)
+        return _Raw.max(self, reductionIndices: axes, keepDims: false)
     }
 
     /// Returns the maximum values along the specified axes. The reduced dimensions are removed.
@@ -1587,7 +1587,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
         wrt: self,
         vjp: _vjpMinOrMax(squeezingAxes:) where Scalar: TensorFlowFloatingPoint)
     func min(squeezingAxes axes: Tensor<Int32>) -> Tensor {
-        Raw.min(self, reductionIndices: axes, keepDims: false)
+        _Raw.min(self, reductionIndices: axes, keepDims: false)
     }
 
     /// Returns the minimum values along the specified axes. The reduced dimensions are removed.
@@ -1616,7 +1616,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
     func argmax(squeezingAxis axis: Int) -> Tensor<Int32> {
-        Raw.argMax(self, dimension: Tensor<Int32>(Int32(axis)))
+        _Raw.argMax(self, dimension: Tensor<Int32>(Int32(axis)))
     }
 
     /// Returns the indices of the minimum values along the specified axes. The reduced dimensions
@@ -1625,7 +1625,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
     func argmin(squeezingAxis axis: Int) -> Tensor<Int32> {
-        Raw.argMin(self, dimension: Tensor<Int32>(Int32(axis)))
+        _Raw.argMin(self, dimension: Tensor<Int32>(Int32(axis)))
     }
 
     /// Returns the minimum along the specified axes. The reduced dimensions are retained with
@@ -1635,7 +1635,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpMinOrMax(alongAxes:) where Scalar: TensorFlowFloatingPoint)
     func min(alongAxes axes: Tensor<Int32>) -> Tensor {
-        Raw.min(self, reductionIndices: axes, keepDims: true)
+        _Raw.min(self, reductionIndices: axes, keepDims: true)
     }
 
     /// Returns the minimum along the specified axes. The reduced dimensions are retained with
@@ -1667,7 +1667,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpMinOrMax(alongAxes:) where Scalar: TensorFlowFloatingPoint)
     func max(alongAxes axes: Tensor<Int32>) -> Tensor {
-        Raw.max(self, reductionIndices: axes, keepDims: true)
+        _Raw.max(self, reductionIndices: axes, keepDims: true)
     }
 
     /// Returns the minimum along the specified axes. The reduced dimensions are retained with
@@ -1748,7 +1748,7 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpSum(squeezingAxes:) where Scalar: TensorFlowFloatingPoint)
     func sum(squeezingAxes axes: Tensor<Int32>) -> Tensor {
-        Raw.sum(self, reductionIndices: axes, keepDims: false)
+        _Raw.sum(self, reductionIndices: axes, keepDims: false)
     }
 
     /// Returns the sum along the specified axes. The reduced dimensions are removed.
@@ -1783,7 +1783,7 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpSum(alongAxes:) where Scalar: TensorFlowFloatingPoint)
     func sum(alongAxes axes: Tensor<Int32>) -> Tensor {
-        Raw.sum(self, reductionIndices: axes, keepDims: true)
+        _Raw.sum(self, reductionIndices: axes, keepDims: true)
     }
 
     /// Returns the sum along the specified axes. The reduced dimensions are retained with value 1.
@@ -1815,7 +1815,7 @@ public extension Tensor where Scalar: Numeric {
     // TODO: Make this @differentiable.
     @inlinable
     func product(squeezingAxes axes: Tensor<Int32>) -> Tensor {
-        Raw.prod(self, reductionIndices: axes, keepDims: false)
+        _Raw.prod(self, reductionIndices: axes, keepDims: false)
     }
 
     /// Returns the product along the specified axes. The reduced dimensions are removed.
@@ -1849,7 +1849,7 @@ public extension Tensor where Scalar: Numeric {
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
     func product(alongAxes axes: Tensor<Int32>) -> Tensor {
-        Raw.prod(self, reductionIndices: axes, keepDims: true)
+        _Raw.prod(self, reductionIndices: axes, keepDims: true)
     }
 
     /// Returns the product along the specified axes. The reduced dimensions are retained with
@@ -1880,7 +1880,7 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpMean(squeezingAxes:) where Scalar: TensorFlowFloatingPoint)
     func mean(squeezingAxes axes: Tensor<Int32>) -> Tensor {
-        Raw.mean(self, reductionIndices: axes, keepDims: false)
+        _Raw.mean(self, reductionIndices: axes, keepDims: false)
     }
 
     /// Returns the arithmetic mean along the specified axes. The reduced dimensions are removed.
@@ -1916,7 +1916,7 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpMean(alongAxes:) where Scalar: TensorFlowFloatingPoint)
     func mean(alongAxes axes: Tensor<Int32>) -> Tensor {
-        Raw.mean(self, reductionIndices: axes, keepDims: true)
+        _Raw.mean(self, reductionIndices: axes, keepDims: true)
     }
 
     /// Returns the arithmetic mean along the specified axes. The reduced dimensions are retained
@@ -2088,7 +2088,7 @@ public extension Tensor where Scalar: Numeric {
         exclusive: Bool = false,
         reverse: Bool = false
     ) -> Tensor {
-        Raw.cumsum(self, axis: axis, exclusive: exclusive, reverse: reverse)
+        _Raw.cumsum(self, axis: axis, exclusive: exclusive, reverse: reverse)
     }
 
     /// Returns the cumulative product of this tensor along the specified axis. By default, this
@@ -2161,7 +2161,7 @@ public extension Tensor where Scalar: Numeric {
         exclusive: Bool = false,
         reverse: Bool = false
     ) -> Tensor {
-        Raw.cumprod(self, axis: axis, exclusive: exclusive, reverse: reverse)
+        _Raw.cumprod(self, axis: axis, exclusive: exclusive, reverse: reverse)
     }
 }
 
@@ -2184,14 +2184,14 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
     func _vjpMean(alongAxes axes: Tensor<Int32>) -> (Tensor, (Tensor) -> Tensor) {
         let value = mean(alongAxes: axes)
-        let count = Raw.gather(params: shapeTensor, indices: axes).product()
+        let count = _Raw.gather(params: shapeTensor, indices: axes).product()
         return (value, { [shape = shapeTensor] in $0.broadcasted(toShape: shape) / Tensor(count) })
     }
 
     @inlinable
     func _vjpMean(squeezingAxes axes: Tensor<Int32>) -> (Tensor, (Tensor) -> Tensor) {
         let value = mean(squeezingAxes: axes)
-        let count = Raw.gather(params: shapeTensor, indices: axes).product()
+        let count = _Raw.gather(params: shapeTensor, indices: axes).product()
         return (value, { [shape = shapeTensor] v in
             let unsqueezed = v.expandingShape(at: axes.scalars.map { Int($0) })
             return unsqueezed.broadcasted(toShape: shape) / Tensor(count)
@@ -2543,9 +2543,9 @@ public func matmul<Scalar: Numeric>(
 ) -> Tensor<Scalar> {
     if lhs.rank > 2 || rhs.rank > 2 {
         // TODO(TF-629): Conjugate to make compatible with the adjoint.
-        return Raw.batchMatMulV2(lhs, rhs, adjX: transposeLhs, adjY: transposeRhs)
+        return _Raw.batchMatMulV2(lhs, rhs, adjX: transposeLhs, adjY: transposeRhs)
     }
-    return Raw.matMul(lhs, rhs, transposeA: transposeLhs, transposeB: transposeRhs)
+    return _Raw.matMul(lhs, rhs, transposeA: transposeLhs, transposeB: transposeRhs)
 }
 
 @inlinable
@@ -2574,7 +2574,7 @@ internal func _vjpMatmul<Scalar: TensorFlowFloatingPoint>(
         }
         let lhsRank = lhsShape.shape[0] - 2
         let rhsRank = rhsShape.shape[0] - 2
-        let (lhsAxes, rhsAxes) = Raw.broadcastGradientArgs(
+        let (lhsAxes, rhsAxes) = _Raw.broadcastGradientArgs(
             s0: lhsShape[..<lhsRank],
             s1: rhsShape[..<rhsRank])
         return (lhsGrad.sum(squeezingAxes: lhsAxes).reshaped(toShape: lhsShape),
@@ -2619,7 +2619,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     ///     leading `min(shape[rank - 1], shape[rank - 2])` columns of `q`.
     ///  
     func qrDecomposition(fullMatrices: Bool = false) -> (q: Tensor<Scalar>, r: Tensor<Scalar>) {
-        return Raw.qr(self, fullMatrices: fullMatrices)
+        return _Raw.qr(self, fullMatrices: fullMatrices)
     }
 
     /// Returns the diagonal part of the tensor.
@@ -2635,6 +2635,6 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     /// // [1, 2, 3, 4]
     ///
     func diagonalPart() -> Tensor<Scalar> {
-        return Raw.diagPart(self)
+        return _Raw.diagPart(self)
     }
 }

--- a/Sources/TensorFlow/Operators/NN.swift
+++ b/Sources/TensorFlow/Operators/NN.swift
@@ -56,7 +56,7 @@ public enum Padding {
 
 public extension Padding {
     @inlinable
-    var raw: Raw.Padding {
+    var raw: _Raw.Padding {
         switch self {
         case .same: return .same
         case .valid: return .valid
@@ -64,7 +64,7 @@ public extension Padding {
     }
 
     @inlinable
-    internal var raw2: Raw.Padding2 {
+    internal var raw2: _Raw.Padding2 {
         switch self {
         case .same: return .same
         case .valid: return .valid
@@ -90,7 +90,7 @@ public func conv2D<Scalar: TensorFlowFloatingPoint>(
     padding: Padding = .valid,
     dilations: (Int, Int, Int, Int) = (1, 1, 1, 1)
 ) -> Tensor<Scalar> {
-    return Raw.conv2D(
+    return _Raw.conv2D(
         input,
         filter: filter,
         strides: [Int32(strides.0), Int32(strides.1), Int32(strides.2), Int32(strides.3)],
@@ -128,7 +128,7 @@ func conv2DBackpropInput<Scalar: TensorFlowFloatingPoint>(
     padding: Padding = .valid,
     dilations: (Int, Int, Int, Int) = (1, 1, 1, 1)
 ) -> Tensor<Scalar> {
-    return Raw.conv2DBackpropInput(
+    return _Raw.conv2DBackpropInput(
         inputSizes: shape,
         filter: filter,
         outBackprop: x,
@@ -167,7 +167,7 @@ func conv2DBackpropFilter<Scalar: TensorFlowFloatingPoint>(
     padding: Padding = .valid,
     dilations: (Int, Int, Int, Int) = (1, 1, 1, 1)
 ) -> Tensor<Scalar> {
-    return Raw.conv2DBackpropFilter(
+    return _Raw.conv2DBackpropFilter(
         input,
         filterSizes: filterSizes,
         outBackprop: x,
@@ -211,7 +211,7 @@ public func conv3D<Scalar: TensorFlowFloatingPoint>(
     strides: (Int, Int, Int, Int, Int) = (1, 1, 1, 1, 1),
     padding: Padding = .valid
 ) -> Tensor<Scalar> {
-    return Raw.conv3D(
+    return _Raw.conv3D(
         input,
         filter: filter,
         strides: [Int32(strides.0), Int32(strides.1), Int32(strides.2),
@@ -246,7 +246,7 @@ func conv3DBackpropInput<Scalar: TensorFlowFloatingPoint>(
     strides: (Int, Int, Int, Int, Int) = (1, 1, 1, 1, 1),
     padding: Padding = .valid
 ) -> Tensor<Scalar> {
-    return Raw.conv3DBackpropInputV2(
+    return _Raw.conv3DBackpropInputV2(
         inputSizes: shape,
         filter: filter,
         outBackprop: x,
@@ -282,7 +282,7 @@ func conv3DBackpropFilter<Scalar: TensorFlowFloatingPoint>(
     strides: (Int, Int, Int, Int, Int) = (1, 1, 1, 1, 1),
     padding: Padding = .valid
 ) -> Tensor<Scalar> {
-    return Raw.conv3DBackpropFilterV2(
+    return _Raw.conv3DBackpropFilterV2(
         input,
         filterSizes: filterSizes,
         outBackprop: x,
@@ -324,7 +324,7 @@ public func depthwiseConv2D<Scalar: TensorFlowFloatingPoint>(
     strides: (Int, Int, Int, Int),
     padding: Padding
 ) -> Tensor<Scalar> {
-    return Raw.depthwiseConv2dNative(
+    return _Raw.depthwiseConv2dNative(
         input,
         filter: filter,
         strides: [Int32(strides.0), Int32(strides.1), Int32(strides.2),Int32(strides.3)],
@@ -358,7 +358,7 @@ func depthwiseConv2dBackpropInput<Scalar: TensorFlowFloatingPoint>(
     strides: (Int, Int, Int, Int),
     padding: Padding
 ) -> Tensor<Scalar> {
-    return Raw.depthwiseConv2dNativeBackpropInput(
+    return _Raw.depthwiseConv2dNativeBackpropInput(
         inputSizes: shape,
         filter: filter,
         outBackprop: x,
@@ -394,7 +394,7 @@ func depthwiseConv2dBackpropFilter<Scalar: TensorFlowFloatingPoint>(
     strides: (Int, Int, Int, Int),
     padding: Padding
 ) -> Tensor<Scalar> {
-    return Raw.depthwiseConv2dNativeBackpropFilter(
+    return _Raw.depthwiseConv2dNativeBackpropFilter(
         input,
         filterSizes: filterSizes,
         outBackprop: x,
@@ -434,7 +434,7 @@ public func maxPool2D<Scalar: TensorFlowFloatingPoint>(
     strides: (Int, Int, Int, Int),
     padding: Padding
 ) -> Tensor<Scalar> {
-    return Raw.maxPoolV2(
+    return _Raw.maxPoolV2(
         input,
         ksize: Tensor<Int32>([Int32(filterSize.0), Int32(filterSize.1),
                                    Int32(filterSize.2), Int32(filterSize.3)]),
@@ -454,7 +454,7 @@ func _vjpMaxPool2D<Scalar: TensorFlowFloatingPoint>(
     // closed form.
     let value = maxPool2D(x, filterSize: filterSize, strides: strides, padding: padding)
     return (value, { v in
-        Raw.maxPoolGradV2(
+        _Raw.maxPoolGradV2(
             origInput: x,
             origOutput: value,
             grad: v,
@@ -481,7 +481,7 @@ public func maxPool3D<Scalar: TensorFlowFloatingPoint>(
     strides: (Int, Int, Int, Int, Int),
     padding: Padding
 ) -> Tensor<Scalar> {
-    return Raw.maxPool3D(
+    return _Raw.maxPool3D(
         input,
         ksize: [Int32(filterSize.0), Int32(filterSize.1),
                      Int32(filterSize.2), Int32(filterSize.3), Int32(filterSize.4)],
@@ -501,7 +501,7 @@ func _vjpMaxPool3D<Scalar: TensorFlowFloatingPoint>(
     // closed form.
     let value = maxPool3D(x, filterSize: filterSize, strides: strides, padding: padding)
     return (value, { v in
-        return Raw.maxPool3DGrad(
+        return _Raw.maxPool3DGrad(
             origInput: x,
             origOutput: value,
             grad: v,
@@ -529,7 +529,7 @@ public func avgPool2D<Scalar: TensorFlowFloatingPoint>(
     strides: (Int, Int, Int, Int),
     padding: Padding
 ) -> Tensor<Scalar> {
-    return Raw.avgPool(
+    return _Raw.avgPool(
         value: input,
         ksize: [Int32(filterSize.0), Int32(filterSize.1),
                 Int32(filterSize.2), Int32(filterSize.3)],
@@ -548,7 +548,7 @@ func _vjpAvgPool2D<Scalar: TensorFlowFloatingPoint>(
     // closed form.
     let value = avgPool2D(x, filterSize: filterSize, strides: strides, padding: padding)
     return (value, { v in
-        Raw.avgPoolGrad(
+        _Raw.avgPoolGrad(
             origInputShape: x.shapeTensor,
             grad: v,
             ksize: [Int32(filterSize.0), Int32(filterSize.1),
@@ -575,7 +575,7 @@ public func avgPool3D<Scalar: TensorFlowFloatingPoint>(
     strides: (Int, Int, Int, Int, Int),
     padding: Padding
 ) -> Tensor<Scalar> {
-    return Raw.avgPool3D(
+    return _Raw.avgPool3D(
         input,
         ksize: [Int32(filterSize.0), Int32(filterSize.1),
                 Int32(filterSize.2), Int32(filterSize.3), Int32(filterSize.4)],
@@ -595,7 +595,7 @@ func _vjpAvgPool3D<Scalar: TensorFlowFloatingPoint>(
     // closed form.
     let value = avgPool3D(x, filterSize: filterSize, strides: strides, padding: padding)
     return (value, { v in
-        return Raw.avgPool3DGrad(
+        return _Raw.avgPool3DGrad(
             origInputShape: x.shapeTensor,
             grad: v,
             ksize: [Int32(filterSize.0), Int32(filterSize.1), Int32(filterSize.2),

--- a/Tests/TensorFlowTests/InitializerTests.swift
+++ b/Tests/TensorFlowTests/InitializerTests.swift
@@ -103,10 +103,10 @@ final class InitializerTests: XCTestCase {
             // Check orthogonality by computing the inner product.
             t = t.reshaped(to: [t.shape.dimensions.dropLast().reduce(1, *), t.shape[t.rank - 1]])
             if t.shape[0] > t.shape[1] {
-                let eye = Raw.diag(diagonal: Tensor<Float>(ones: [t.shape[1]]))
+                let eye = _Raw.diag(diagonal: Tensor<Float>(ones: [t.shape[1]]))
                 assertEqual(eye, matmul(t.transposed(), t), accuracy: 1e-5)
             } else {
-                let eye = Raw.diag(diagonal: Tensor<Float>(ones: [t.shape[0]]))
+                let eye = _Raw.diag(diagonal: Tensor<Float>(ones: [t.shape[0]]))
                 assertEqual(eye, matmul(t, t.transposed()), accuracy: 1e-5)
             }
         }

--- a/Tests/TensorFlowTests/LazyTensorEvaluationTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorEvaluationTests.swift
@@ -86,23 +86,23 @@ final class LazyTensorEvaluationTests: LazyTensorTestCase {
         let elements2: Tensor<Int32> = [10, 11, 12]
         let outputTypes = [Int32.tensorFlowDataType, Int32.tensorFlowDataType]
         let outputShapes: [TensorShape?] = [nil, nil]
-        let dataset: VariantHandle = Raw.tensorSliceDataset(
+        let dataset: VariantHandle = _Raw.tensorSliceDataset(
             components: [elements1, elements2],
             outputShapes: outputShapes
         )
-        let iterator: ResourceHandle = Raw.iteratorV2(sharedName: "blah",
+        let iterator: ResourceHandle = _Raw.iteratorV2(sharedName: "blah",
             container: "earth", outputTypes: outputTypes, outputShapes: outputShapes
         )
         // `dataset` and `iterator` should not be materialized yet.
         XCTAssertFalse(isMaterialized(dataset.handle))
         XCTAssertFalse(isMaterialized(iterator.handle))
-        Raw.makeIterator(dataset: dataset, iterator: iterator)
+        _Raw.makeIterator(dataset: dataset, iterator: iterator)
 
         // `dataset` and `iterator` should be materialized now as
         // makeIterator executes.
         XCTAssertTrue(isMaterialized(dataset.handle))
         XCTAssertTrue(isMaterialized(iterator.handle))
-        let next: SimpleOutput = Raw.iteratorGetNext(
+        let next: SimpleOutput = _Raw.iteratorGetNext(
             iterator: iterator, outputShapes: outputShapes
         )
         XCTAssertEqual(Tensor(handle: next.a).scalarized(), 0)

--- a/Tests/TensorFlowTests/LazyTensorHandleTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorHandleTests.swift
@@ -138,11 +138,11 @@ final class LazyTensorHandleTests: XCTestCase {
         let elements2: Tensor<Int32> = [10, 11, 12]
         let outputTypes = [Int32.tensorFlowDataType, Int32.tensorFlowDataType]
         let outputShapes: [TensorShape?] = [nil, nil]
-        let dataset: VariantHandle = Raw.tensorSliceDataset(
+        let dataset: VariantHandle = _Raw.tensorSliceDataset(
             components: [elements1, elements2],
             outputShapes: outputShapes
         )
-        let iterator: ResourceHandle = Raw.iteratorV2(sharedName: "blah",
+        let iterator: ResourceHandle = _Raw.iteratorV2(sharedName: "blah",
             container: "earth", outputTypes: outputTypes, outputShapes: outputShapes
         )
         checkConversions(dataset)

--- a/Tests/TensorFlowTests/LazyTensorShapeInferenceTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorShapeInferenceTests.swift
@@ -88,8 +88,8 @@ final class LazyTensorShapeInferenceTests: LazyTensorTestCase {
         let a = Tensor<Int32>(shape: [2], scalars: [1, 1])
         let b = Tensor<Int32>(1)
         let dims = a + b
-        let m = Raw.fill(dims: dims, value: Tensor<Float>(1.0))
-        let result = Raw.matMul(m, m)
+        let m = _Raw.fill(dims: dims, value: Tensor<Float>(1.0))
+        let result = _Raw.matMul(m, m)
         let mLazyTensorOperation = m._lazyTensor!.lazyTensorOperation!
         // Note that we have not triggered materialization yet. So, it should not have happened
         // implicitly during shape inference.

--- a/Tests/TensorFlowTests/LazyTensorTFFunctionBuilderTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTFFunctionBuilderTests.swift
@@ -19,7 +19,7 @@ import CTensorFlow
 final class LazyTensorTFFunctionBuilderTests: LazyTensorTestCase {
     func testSingletonInputs() {
         let a = materializedLazyTensor(Tensor<Float>(10.0))
-        let w = Raw.identity(a)
+        let w = _Raw.identity(a)
         XCTAssertEqual(
             tfFunction(w, "testSingletonInputs")!.description,
             """
@@ -35,7 +35,7 @@ final class LazyTensorTFFunctionBuilderTests: LazyTensorTestCase {
     func testListInputs() {
         let a = materializedLazyTensor(Tensor<Float>(10.0))
         let b = materializedLazyTensor(Tensor<Float>(2.0))
-        let w = Raw.addN(inputs: [a, b])
+        let w = _Raw.addN(inputs: [a, b])
         XCTAssertEqual(
             tfFunction(w, "testListInputs")!.description,
             """

--- a/Tests/TensorFlowTests/LazyTensorTraceTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorTraceTests.swift
@@ -204,7 +204,7 @@ final class LazyTensorTraceTests: LazyTensorTestCase {
         func elseBranch(x: Tensor<Float>) -> Tensor<Float> {
             return x - 9.0
         }
-        let c: Tensor<Float> = Raw.if_(
+        let c: Tensor<Float> = _Raw.if_(
             cond: Tensor<Bool>(false),
             Tensor<Float>(20.0),
             thenBranch: thenBranch,

--- a/Tests/TensorFlowTests/OperatorTests/DatasetTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/DatasetTests.swift
@@ -26,25 +26,25 @@ final class DatasetTests: XCTestCase {
         let elements2: Tensor<Int32> = [10, 11, 12]
         let outputTypes = [Int32.tensorFlowDataType, Int32.tensorFlowDataType]
         let outputShapes: [TensorShape?] = [nil, nil]
-        let dataset: VariantHandle = Raw.tensorSliceDataset(
+        let dataset: VariantHandle = _Raw.tensorSliceDataset(
             components: [elements1, elements2],
             outputShapes: outputShapes
         )
-        let iterator: ResourceHandle = Raw.iteratorV2(sharedName: "blah",
+        let iterator: ResourceHandle = _Raw.iteratorV2(sharedName: "blah",
             container: "earth", outputTypes: outputTypes, outputShapes: outputShapes
         )
-        Raw.makeIterator(dataset: dataset, iterator: iterator)
-        var next: SimpleOutput = Raw.iteratorGetNext(
+        _Raw.makeIterator(dataset: dataset, iterator: iterator)
+        var next: SimpleOutput = _Raw.iteratorGetNext(
             iterator: iterator, outputShapes: outputShapes
         )
         XCTAssertEqual(Tensor(handle: next.a).scalarized(), 0)
         XCTAssertEqual(Tensor(handle: next.b).scalarized(), 10)
-        next = Raw.iteratorGetNext(
+        next = _Raw.iteratorGetNext(
             iterator: iterator, outputShapes: outputShapes
         )
         XCTAssertEqual(Tensor(handle: next.a).scalarized(), 1)
         XCTAssertEqual(Tensor(handle: next.b).scalarized(), 11)
-        next = Raw.iteratorGetNext(
+        next = _Raw.iteratorGetNext(
             iterator: iterator, outputShapes: outputShapes
         )
         XCTAssertEqual(Tensor(handle: next.a).scalarized(), 2)

--- a/Tests/TensorFlowTests/TensorAutoDiffTests.swift
+++ b/Tests/TensorFlowTests/TensorAutoDiffTests.swift
@@ -19,7 +19,7 @@ let cube: @differentiable (Tensor<Float>) -> Tensor<Float> = { ($0 * $0 * $0) }
 
 @differentiable(vjp: vjpFoo)
 func foo(_ x: Tensor<Float>) -> Tensor<Float> {
-    return Raw.identity(x)
+    return _Raw.identity(x)
 }
 func vjpFoo(_ x: Tensor<Float>) -> (Tensor<Float>, (Tensor<Float>) -> Tensor<Float>) {
     return (foo(x), { v in v })


### PR DESCRIPTION
As a follow-up to #543 which renamed `Raw` to `_Raw`, this change updates all
users of `Raw` in the repository to use `_Raw` instead. This fixes all the
deprecation warnings.