### PR TITLE
Extract conv1D functionality from Conv1D Layer

### DIFF
--- a/Sources/TensorFlow/Layers/Convolutional.swift
+++ b/Sources/TensorFlow/Layers/Convolutional.swift
@@ -76,13 +76,12 @@ public struct Conv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Note: Padding size equals zero when using `.valid`.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        let conv = conv2D(
-            input.expandingShape(at: 1),
-            filter: filter.expandingShape(at: 0),
-            strides: (1, 1, stride, 1),
+        activation(conv1D(
+            input,
+            filter: filter,
+            stride: stride,
             padding: padding,
-            dilations: (1, 1, dilation, 1))
-        return activation(conv.squeezingShape(at: 1) + bias)
+            dilation: dilation) + bias)
     }
 }
 

--- a/Sources/TensorFlow/Operators/NN.swift
+++ b/Sources/TensorFlow/Operators/NN.swift
@@ -72,6 +72,35 @@ public extension Padding {
     }
 }
 
+/// Returns a 1-D convolution with the specified input, filter, stride, and padding.
+///
+/// - Parameters:
+///   - input: The input.
+///   - filter: The convolution filter.
+///   - stride: The stride of the sliding filter.
+///   - padding: The padding for the operation
+///   - dilation: The dilation factor.
+/// - Precondition: `input` must have rank `3`.
+/// - Precondition: `filter` must have rank 3.
+@differentiable(wrt: (input, filter))
+public func conv1D<Scalar: TensorFlowFloatingPoint>(
+    _ input: Tensor<Scalar>,
+    filter: Tensor<Scalar>,
+    stride: Int = 1,
+    padding: Padding = .valid,
+    dilation: Int = 1
+) -> Tensor<Scalar> {
+    precondition(input.shape.rank == 3, "The input must have rank 3.")
+    precondition(filter.shape.rank == 3, "The filter must have rank 3.")
+    return conv2D(
+        input.expandingShape(at: 1),
+        filter: filter.expandingShape(at: 0),
+        strides: (1, 1, stride, 1),
+        padding: padding,
+        dilations: (1, 1, dilation, 1)
+    ).squeezingShape(at: 1)
+}
+
 /// Returns a 2-D convolution with the specified input, filter, strides, and padding.
 ///
 /// - Parameters:

--- a/Sources/TensorFlow/Operators/NN.swift
+++ b/Sources/TensorFlow/Operators/NN.swift
@@ -78,7 +78,7 @@ public extension Padding {
 ///   - input: The input.
 ///   - filter: The convolution filter.
 ///   - stride: The stride of the sliding filter.
-///   - padding: The padding for the operation
+///   - padding: The padding for the operation.
 ///   - dilation: The dilation factor.
 /// - Precondition: `input` must have rank `3`.
 /// - Precondition: `filter` must have rank 3.


### PR DESCRIPTION
### Description
As described in #528, the layer `Conv1D` is doing two things at a time (1) calculating a one-dimensional convolution and (2) applying the activation function. If we split this functionality into two, we enable clients to only use the conv1D. This will allow them to write code that is easier to read.

### Solution
Extract the `conv1D` functionality into `NN.swfit`

