### PR TITLE
Test `swift build -c release` for auxiliary repositories.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,10 +74,12 @@ RUN git clone https://github.com/deepmind/open_spiel.git
 WORKDIR /swift-models
 
 RUN /swift-tensorflow-toolchain/usr/bin/swift build
+RUN /swift-tensorflow-toolchain/usr/bin/swift build -c release
 
 WORKDIR /fastai_dev/swift/FastaiNotebook_11_imagenette
 
 RUN /swift-tensorflow-toolchain/usr/bin/swift build
+RUN /swift-tensorflow-toolchain/usr/bin/swift build -c release
 
 WORKDIR /open_spiel
 RUN /swift-tensorflow-toolchain/usr/bin/swift test


### PR DESCRIPTION
Test `swift build -c release` (compilation with `-O`) for
tensorflow/swift-models and fastai/fastai_dev.

Motivated by recently discovered `-O`-specific issues ([TF-960](https://bugs.swift.org/browse/TF-960)).