### PR TITLE
Add more preconditions for Basic.swift module

### DIFF
--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -188,7 +188,23 @@ public extension Tensor {
     @inlinable
     @differentiable(wrt: self, vjp: _vjpReshaped(toShape:) where Scalar: TensorFlowFloatingPoint)
     func reshaped(toShape newShape: Tensor<Int32>) -> Tensor {
-        _Raw.reshape(self, shape: newShape)
+        let totalNegative = newShape.scalars.filter({$0 == -1}).count
+        let positiveShapeSizes = newShape.scalars.filter({$0 > 0})
+        let newShapeScalarCount = positiveShapeSizes.reduce(1, {$0 * $1})
+
+        precondition(totalNegative <= 1, "Only one input size may be -1.")
+
+        if totalNegative == 1 {
+            precondition(
+                scalarCount % Int(newShapeScalarCount) == 0,
+                "The number of scalars must be a multiple of the new shape.")
+        } else {
+            precondition(
+                scalarCount == newShapeScalarCount,
+                "The number of scalars must match the new shape.")
+        }
+
+        return _Raw.reshape(self, shape: newShape)
     }
 
     /// Return a copy of the tensor collapsed into a 1-D `Tensor`, in row-major order.

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -102,6 +102,9 @@ public extension Tensor {
     @differentiable(vjp: _vjpSplit(count:alongAxis:) where Scalar: TensorFlowFloatingPoint)
     func split(count: Int, alongAxis axis: Int = 0) -> [Tensor] {
         preconditionAxis(axis)
+        precondition(
+            shape[axis] % count == 0,
+            "Number of ways to split should evenly divide the split dimension.")
         return _Raw.split(splitDim: Tensor<Int32>(Int32(axis)), value: self, numSplit: Int64(count))
     }
 
@@ -134,6 +137,9 @@ public extension Tensor {
         vjp: _vjpSplit(sizes:alongAxis:) where Scalar: TensorFlowFloatingPoint)
     func split(sizes: Tensor<Int32>, alongAxis axis: Int = 0) -> [Tensor] {
         preconditionAxis(axis)
+        precondition(
+            shape[axis] == Int(sizes.sum().scalarized()),
+            "The values in sizes must add up to the size of dimension axis.")
         return _Raw.splitV(
             value: self,
             sizeSplits: sizes,

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -103,7 +103,7 @@ public extension Tensor {
     func split(count: Int, alongAxis axis: Int = 0) -> [Tensor] {
         preconditionAxis(axis)
         precondition(
-            shape[axis] % count == 0,
+            shapeTensor[axis].scalarized() % Int32(count) == 0,
             "Number of ways to split should evenly divide the split dimension.")
         return _Raw.split(splitDim: Tensor<Int32>(Int32(axis)), value: self, numSplit: Int64(count))
     }
@@ -138,7 +138,7 @@ public extension Tensor {
     func split(sizes: Tensor<Int32>, alongAxis axis: Int = 0) -> [Tensor] {
         preconditionAxis(axis)
         precondition(
-            shape[axis] == Int(sizes.sum().scalarized()),
+            shapeTensor[axis] == sizes.sum(),
             "The values in sizes must add up to the size of dimension axis.")
         return _Raw.splitV(
             value: self,

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -154,11 +154,16 @@ public extension Tensor {
     /// values of this tensor are replicated `multiples[i]` times along the `i`'th dimension. For
     /// example, tiling `[a b c d]` by `[2]` produces `[a b c d a b c d]`.
     ///
+    /// - Precondition: The expected `rank` of multiples must be `1`.
     /// - Precondition: The shape of `multiples` must be `[tensor.rank]`.
     @inlinable
     @differentiable(wrt: self, vjp: _vjpTiled(multiples:) where Scalar: TensorFlowFloatingPoint)
     func tiled(multiples: Tensor<Int32>) -> Tensor {
-        _Raw.tile(self, multiples: multiples)
+        precondition(multiples.rank == 1, "The expected rank of multiples must be 1.")
+        precondition(
+            rank == multiples.shapeTensor.scalarized(),
+            "The shape of multiples must be [tensor.rank].")
+        return _Raw.tile(self, multiples: multiples)
     }
 
     /// Reshape to the shape of the specified `Tensor`.


### PR DESCRIPTION
- [x] Precondition for `unstacked`
- [x] Preconditions for `split` for count and axis
- [x] Precondition for `tiled`
- [x] Preconditions for all `reshaped`
- [x] Preconditions for `gathering`

As requested in #517