### PR TITLE
Remove references to TensorFlow.

### DIFF
--- a/Sources/TensorFlow/Initializers.swift
+++ b/Sources/TensorFlow/Initializers.swift
@@ -444,7 +444,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
         randomTruncatedNormal shape: TensorShape,
         mean: Tensor<Scalar> = Tensor<Scalar>(0),
         standardDeviation: Tensor<Scalar> = Tensor<Scalar>(1),
-        seed: TensorFlowSeed = TensorFlow.Context.local.randomSeed
+        seed: TensorFlowSeed = Context.local.randomSeed
     ) {
         let sample: Tensor<Scalar> = _Raw.statelessTruncatedNormal(
             shape: Tensor<Int32>((0..<shape.rank).map { Int32(shape[$0]) }),

--- a/Sources/TensorFlow/Layers/Initialization.swift
+++ b/Sources/TensorFlow/Layers/Initialization.swift
@@ -67,7 +67,7 @@ public func glorotUniform<Scalar: TensorFlowFloatingPoint>(
 public func truncatedNormalInitializer<Scalar: TensorFlowFloatingPoint>(
     mean: Tensor<Scalar> = Tensor<Scalar>(0),
     standardDeviation: Tensor<Scalar> = Tensor<Scalar>(1),
-    seed: TensorFlowSeed = TensorFlow.Context.local.randomSeed
+    seed: TensorFlowSeed = Context.local.randomSeed
 ) -> ParameterInitializer<Scalar> {
     {
         Tensor<Scalar>(


### PR DESCRIPTION
I want to be able to build with a different module name to test two tensorflow versions against each other. This breaks that.