### PR TITLE
Rename `@differentiating` to `@derivative(of:)`.

### DIFF
--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -91,7 +91,7 @@ public extension Layer {
     }
 
     // TODO(rxwei): Remove this custom VJP once differentiation supports currying.
-    @differentiating(inferring(from:))
+    @derivative(of: inferring(from:))
     @usableFromInline
     internal func _vjpInferring(from input: Input)
         -> (value: Output, pullback: (Output.TangentVector)


### PR DESCRIPTION
Friend PR: https://github.com/apple/swift/pull/28481

---

We should wait to merge after releasing a macOS toolchain with https://github.com/apple/swift/pull/28481 applied. I'm building such a toolchain now.

Edit: [11-27 macOS toolchain released](https://github.com/tensorflow/swift/blob/master/Installation.md#development-snapshots).