### PR TITLE
[AutoDiff] Deprecate method-style differential operators.

### DIFF
--- a/Sources/TensorFlow/Core/DifferentialOperators.swift
+++ b/Sources/TensorFlow/Core/DifferentialOperators.swift
@@ -13,10 +13,14 @@
 // limitations under the License.
 
 //===------------------------------------------------------------------------------------------===//
-// Method-style Differential Operators
+// Method-style differential operators
 //===------------------------------------------------------------------------------------------===//
 
 public extension Differentiable {
+    @available(*, deprecated, message: """
+        Method-style differential operators are deprecated and will be removed; use top-level
+        function 'TensorFlow.gradient(at:in:)' instead
+        """)
     @inlinable
     func gradient<R: TensorFlowFloatingPoint>(
         in f: @differentiable (Self) -> Tensor<R>
@@ -24,6 +28,10 @@ public extension Differentiable {
         return self.valueWithGradient(in: f).1
     }
 
+    @available(*, deprecated, message: """
+        Method-style differential operators are deprecated and will be removed; use top-level
+        function 'TensorFlow.valueWithGradient(at:in:)' instead
+        """)
     @inlinable
     func valueWithGradient<R: TensorFlowFloatingPoint>(
         in f: @differentiable (Self) -> Tensor<R>
@@ -36,6 +44,10 @@ public extension Differentiable {
         return (y, pb(Tensor<R>(1)))
     }
 
+    @available(*, deprecated, message: """
+        Method-style differential operators are deprecated and will be removed; use top-level
+        function 'TensorFlow.gradient(at:_:in:)' instead
+        """)
     @inlinable
     func gradient<T: Differentiable, R: TensorFlowFloatingPoint>(
         at x: T,
@@ -44,6 +56,10 @@ public extension Differentiable {
         return self.valueWithGradient(at: x, in: f).1
     }
 
+    @available(*, deprecated, message: """
+        Method-style differential operators are deprecated and will be removed; use top-level
+        function 'TensorFlow.valueWithGradient(at:_:in:)' instead
+        """)
     @inlinable
     func valueWithGradient<T: Differentiable, R: TensorFlowFloatingPoint>(
         at x: T,
@@ -59,7 +75,7 @@ public extension Differentiable {
 }
 
 // ===------------------------------------------------------------------------------------------===//
-// Free-Function-Style Differential Operators
+// Free-function-style differential operators
 // ===------------------------------------------------------------------------------------------===//
 
 // Value with gradient

--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -114,7 +114,7 @@ public extension Layer {
     ///   gradients at the layer and at the input, respectively.
     func appliedForBackpropagation(to input: Input)
         -> (output: Output, backpropagator: Backpropagator) {
-        let (out, pullback) = valueWithPullback(at: input) { layer, input in
+        let (out, pullback) = Swift.valueWithPullback(at: self, input) { layer, input in
             return layer(input)
         }
         return (out, pullback)


### PR DESCRIPTION
Friend PR: https://github.com/apple/swift/pull/28500

---

Currently, there exist both top-level function differential operators and
method-style differential operators. Method-style differential operators apply
top-level function versions to `self`.

Method-style differential operators needlessly increase API surface area and
confuse users. Removing them will make the top-level versions canonical.
[Related mailing list thread.](https://groups.google.com/a/tensorflow.org/d/msg/swift/_lNgd9N5SM4/mBmKiNBxAgAJ)

Resolves TF-1019.