### PR TITLE
remove default argument closures

### DIFF
--- a/Sources/TensorFlow/BackwardsCompatibility.swift
+++ b/Sources/TensorFlow/BackwardsCompatibility.swift
@@ -52,7 +52,7 @@ public func hingeLoss<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>,
     expected: Tensor<Scalar>
 ) -> Tensor<Scalar> {
-    hingeLoss(predicted: predicted, expected: expected, reduction: _mean)
+    hingeLoss(predicted: predicted, expected: expected, reduction: { $0.mean() })
 }
 
 /// Returns the squared hinge loss between predictions and expectations.
@@ -65,7 +65,7 @@ public func squaredHingeLoss<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>,
     expected: Tensor<Scalar>
 ) -> Tensor<Scalar> {
-    squaredHingeLoss(predicted: predicted, expected: expected, reduction: _mean)
+    squaredHingeLoss(predicted: predicted, expected: expected, reduction: { $0.mean() })
 }
 
 /// Returns the categorical hinge loss between predictions and expectations.
@@ -78,7 +78,7 @@ public func categoricalHingeLoss<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>,
     expected: Tensor<Scalar>
 ) -> Tensor<Scalar> {
-    categoricalHingeLoss(predicted: predicted, expected: expected, reduction: _mean)
+    categoricalHingeLoss(predicted: predicted, expected: expected, reduction: { $0.mean() })
 }
 
 /// Returns the logarithm of the hyperbolic cosine of the error between predictions and
@@ -92,7 +92,7 @@ public func logCoshLoss<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>,
     expected: Tensor<Scalar>
 ) -> Tensor<Scalar> {
-    logCoshLoss(predicted: predicted, expected: expected, reduction: _mean)
+    logCoshLoss(predicted: predicted, expected: expected, reduction: { $0.mean() })
 }
 
 /// Returns the Poisson loss between predictions and expectations.
@@ -105,7 +105,7 @@ public func poissonLoss<Scalar: TensorFlowFloatingPoint>(
     predicted: Tensor<Scalar>,
     expected: Tensor<Scalar>
 ) -> Tensor<Scalar> {
-    poissonLoss(predicted: predicted, expected: expected, reduction: _mean)
+    poissonLoss(predicted: predicted, expected: expected, reduction: { $0.mean() })
 }
 
 /// Returns the Kullback-Leibler divergence (KL divergence) between between expectations and
@@ -132,7 +132,7 @@ public func softmaxCrossEntropy<Scalar: TensorFlowFloatingPoint>(
     logits: Tensor<Scalar>,
     probabilities: Tensor<Scalar>
 ) -> Tensor<Scalar> {
-    softmaxCrossEntropy(logits: logits, probabilities: probabilities, reduction: _mean)
+    softmaxCrossEntropy(logits: logits, probabilities: probabilities, reduction: { $0.mean() })
 }
 
 /// Returns the sigmoid cross entropy (binary cross entropy) between logits and labels.
@@ -144,5 +144,5 @@ public func sigmoidCrossEntropy<Scalar: TensorFlowFloatingPoint>(
     logits: Tensor<Scalar>,
     labels: Tensor<Scalar>
 ) -> Tensor<Scalar> {
-    sigmoidCrossEntropy(logits: logits, labels:labels, reduction: _mean)
+    sigmoidCrossEntropy(logits: logits, labels:labels, reduction: { $0.mean() })
 }

--- a/Tests/TensorFlowTests/LossTests.swift
+++ b/Tests/TensorFlowTests/LossTests.swift
@@ -223,7 +223,9 @@ final class LossTests: XCTestCase {
         do {
           // Test adapted from:
           // https://github.com/tensorflow/tensorflow/blob/148f07323f97ef54998f28cd95c195064ce2c426/tensorflow/python/keras/losses_test.py#L1554
-          let loss = huberLoss(predicted: predictions, expected: predictions, delta: 1)
+          // TODO(TF-1025): Remove `reduction`, use default instead.
+          let loss = huberLoss(
+              predicted: predictions, expected: predictions, delta: 1, reduction: { $0.sum() })
           assertEqual(loss, Tensor(0), accuracy: 1e-6)
         }
 
@@ -239,7 +241,9 @@ final class LossTests: XCTestCase {
           // print(loss(labels, predictions))
           // # tf.Tensor(0.62500006, shape=(), dtype=float32)
           // ```
-          let loss = huberLoss(predicted: predictions, expected: labels, delta: Float(1))
+          // TODO(TF-1025): Remove `reduction`, use default instead.
+          let loss = huberLoss(
+              predicted: predictions, expected: labels, delta: Float(1), reduction: { $0.sum() })
           assertEqual(loss, Tensor(0.62500006), accuracy: 1e-6)
         }
     }


### PR DESCRIPTION
Differentiable closures as default arguments do not work (https://bugs.swift.org/browse/TF-690), so this PR removes them.

Soon, a diagnostic will forbid differentiable closures as default arguments, as decided in [Swift AD Symbol Linkage](https://docs.google.com/document/d/1Stx2KFw3F_Tf8EXM5bMd1_G6-pkRUbmgU5Ne8ruhUZk/edit#heading=h.vinsehbmywm8).

Eventually, we implement a solution that allows differentiable closures as default arguments (https://bugs.swift.org/browse/TF-1030). When that happens, we can remove `_sum` and `_mean`.