### PR TITLE
remove default arg workaround

### DIFF
--- a/Tests/TensorFlowTests/LossTests.swift
+++ b/Tests/TensorFlowTests/LossTests.swift
@@ -223,9 +223,7 @@ final class LossTests: XCTestCase {
         do {
           // Test adapted from:
           // https://github.com/tensorflow/tensorflow/blob/148f07323f97ef54998f28cd95c195064ce2c426/tensorflow/python/keras/losses_test.py#L1554
-          // TODO(TF-1025): Remove `reduction`, use default instead.
-          let loss = huberLoss(
-              predicted: predictions, expected: predictions, delta: 1, reduction: { $0.sum() })
+          let loss = huberLoss(predicted: predictions, expected: predictions, delta: 1)
           assertEqual(loss, Tensor(0), accuracy: 1e-6)
         }
 
@@ -241,9 +239,7 @@ final class LossTests: XCTestCase {
           // print(loss(labels, predictions))
           // # tf.Tensor(0.62500006, shape=(), dtype=float32)
           // ```
-          // TODO(TF-1025): Remove `reduction`, use default instead.
-          let loss = huberLoss(
-              predicted: predictions, expected: labels, delta: Float(1), reduction: { $0.sum() })
+          let loss = huberLoss(predicted: predictions, expected: labels, delta: Float(1))
           assertEqual(loss, Tensor(0.62500006), accuracy: 1e-6)
         }
     }


### PR DESCRIPTION
apple/swift#28582 fixed https://bugs.swift.org/browse/TF-1025, making this workaround no longer necessary.