### PR TITLE
Remove `@differentiable` attribute from `Layer.inferring(from:)`.

### DIFF
--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -85,12 +85,12 @@ public extension Layer {
     ///
     /// - Parameter input: The input to the layer.
     /// - Returns: The inference output.
-    @differentiable
     func inferring(from input: Input) -> Output {
         withLearningPhase(LearningPhase.inference) { self(input) }
     }
 
-    // TODO(rxwei): Remove this custom VJP once differentiation supports currying.
+    // TODO(TF-433, SR-11882): Remove this custom derivative when
+    // differentiation supports `rethrows` functions and currying.
     @derivative(of: inferring(from:))
     @usableFromInline
     internal func _vjpInferring(from input: Input)


### PR DESCRIPTION
Necessary for [TF-835](https://bugs.swift.org/browse/TF-835): lowering `@derivative` attribute directly to SIL
differentiability witnesses instead of creating implicit `@differentiable`
attributes.

`@differentiable` + `@derivative` attributes for the same original declaration
with the same wrt parameters will be diagnosed:

```
/Users/danielzheng/swift-bart/tensorflow-swift-apis/Sources/TensorFlow/Layer.swift:94:6: error: a derivative already exists for 'inferring(from:)'
    @derivative(of: inferring(from:))
    ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

/Users/danielzheng/swift-bart/tensorflow-swift-apis/Sources/TensorFlow/Layer.swift:88:6: note: other attribute declared here
    @differentiable
     ^
```

This is already done for `@differentiable` + `@differentiable` and
`@derivative` + `@derivative` combinations. Derivative generic signature
mangling is necessary to lift this limitation: .

To relax this limitation, derivative generic signature mangling ([TF-680](https://bugs.swift.org/browse/TF-680)) is
necessary to avoid name collisions for SIL derivative functions with the same
parameter indices but different derivative generic signatures.