### PR TITLE
Fix deprecation warnings for method-style differential operators.

### DIFF
--- a/Sources/TensorFlow/Core/DifferentialOperators.swift
+++ b/Sources/TensorFlow/Core/DifferentialOperators.swift
@@ -18,7 +18,7 @@
 
 public extension Differentiable {
     @available(*, deprecated, message: """
-        Method-style differential operators are deprecated and will be removed; use top-level
+        Method-style differential operators are deprecated and will be removed; use top-level \
         function 'TensorFlow.gradient(at:in:)' instead
         """)
     @inlinable
@@ -29,7 +29,7 @@ public extension Differentiable {
     }
 
     @available(*, deprecated, message: """
-        Method-style differential operators are deprecated and will be removed; use top-level
+        Method-style differential operators are deprecated and will be removed; use top-level \
         function 'TensorFlow.valueWithGradient(at:in:)' instead
         """)
     @inlinable
@@ -45,7 +45,7 @@ public extension Differentiable {
     }
 
     @available(*, deprecated, message: """
-        Method-style differential operators are deprecated and will be removed; use top-level
+        Method-style differential operators are deprecated and will be removed; use top-level \
         function 'TensorFlow.gradient(at:_:in:)' instead
         """)
     @inlinable
@@ -57,7 +57,7 @@ public extension Differentiable {
     }
 
     @available(*, deprecated, message: """
-        Method-style differential operators are deprecated and will be removed; use top-level
+        Method-style differential operators are deprecated and will be removed; use top-level \
         function 'TensorFlow.valueWithGradient(at:_:in:)' instead
         """)
     @inlinable

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -1173,7 +1173,7 @@ final class LayerTests: XCTestCase {
             let inputs: [Tensor<Float>] = Array(repeating: x, count: 4)
             let rnn = RNN(LSTMCell<Float>(inputSize: 4, hiddenSize: 4))
             withTensorLeakChecking {
-                let (outputs, _) = rnn.valueWithPullback(at: inputs) { rnn, inputs in
+                let (outputs, _) = valueWithPullback(at: rnn, inputs) { rnn, inputs in
                     return rnn(inputs)
                 }
                 assertEqual(

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -48,7 +48,7 @@ final class LayerTests: XCTestCase {
                 expected: y)
             withTensorLeakChecking {
                 for _ in 0..<10 {
-                    let 𝛁model = model.gradient { model -> Tensor<Float> in
+                    let 𝛁model = gradient(at: model) { model -> Tensor<Float> in
                         meanSquaredError(
                             predicted: model(x).squeezingShape(at: 1),
                             expected: y)
@@ -1142,7 +1142,7 @@ final class LayerTests: XCTestCase {
         let rnn = RNN(SimpleRNNCell<Float>(inputSize: 4, hiddenSize: 4,
                                            seed: (0xFeed, 0xBeef)))
         withTensorLeakChecking {
-            let (outputs, _) = rnn.valueWithPullback(at: inputs) { rnn, inputs in
+            let (outputs, _) = valueWithPullback(at: rnn, inputs) { rnn, inputs in
                 return rnn(inputs)
             }
             assertEqual(
@@ -1204,7 +1204,7 @@ final class LayerTests: XCTestCase {
           biasInitializer: zeros())
         )
         withTensorLeakChecking {
-            let (outputs, _) = rnn.valueWithPullback(at: inputs) { rnn, inputs in
+            let (outputs, _) = valueWithPullback(at: rnn, inputs) { rnn, inputs in
                 return rnn(inputs)
             }
             XCTAssertEqual(outputs.map { $0.hidden },

--- a/Tests/TensorFlowTests/OperatorTests/BasicTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/BasicTests.swift
@@ -76,8 +76,8 @@ final class BasicOperatorTests: XCTestCase {
     func testVJPPadded() {
         let x = Tensor<Float>(ones: [3, 2])
         let target = Tensor<Float>([[2, 2], [2, 2], [2, 2]])
-        let grads = x.gradient { a -> Tensor<Float> in
-            let paddedTensor = a.padded(forSizes: [(1, 0), (0, 1)], with: 3.0)
+        let grads = gradient(at: x) { x -> Tensor<Float> in
+            let paddedTensor = x.padded(forSizes: [(1, 0), (0, 1)], with: 3.0)
             return (paddedTensor * paddedTensor).sum()
         }
         XCTAssertEqual(grads, target)
@@ -86,8 +86,8 @@ final class BasicOperatorTests: XCTestCase {
     func testVJPPaddedConstant() {
         let x = Tensor<Float>(ones: [3, 2])
         let target = Tensor<Float>([[2, 2], [2, 2], [2, 2]])
-        let grads = x.gradient { a -> Tensor<Float> in
-            let paddedTensor = a.padded(forSizes: [(1, 0), (0, 1)], mode: .constant(3.0))
+        let grads = gradient(at: x) { x -> Tensor<Float> in
+            let paddedTensor = x.padded(forSizes: [(1, 0), (0, 1)], mode: .constant(3.0))
             return (paddedTensor * paddedTensor).sum()
         }
         XCTAssertEqual(grads, target)
@@ -96,8 +96,8 @@ final class BasicOperatorTests: XCTestCase {
     func testVJPPaddedReflect() {
         let x = Tensor<Float>([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
         let target = Tensor<Float>([[4, 8, 6], [32, 40, 24], [56, 64, 36]])
-        let grads = x.gradient { a -> Tensor<Float> in
-            let paddedTensor = a.padded(forSizes: [(2, 0), (0, 2)], mode: .reflect)
+        let grads = gradient(at: x) { x -> Tensor<Float> in
+            let paddedTensor = x.padded(forSizes: [(2, 0), (0, 2)], mode: .reflect)
             return (paddedTensor * paddedTensor).sum()
         }
         XCTAssertEqual(grads, target)
@@ -106,8 +106,8 @@ final class BasicOperatorTests: XCTestCase {
     func testVJPPaddedSymmetric() {
         let x = Tensor<Float>([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
         let target = Tensor<Float>([[4, 16, 24], [16, 40, 48], [14, 32, 36]])
-        let grads = x.gradient { a -> Tensor<Float> in
-            let paddedTensor = a.padded(forSizes: [(2, 0), (0, 2)], mode: .symmetric)
+        let grads = gradient(at: x) { x -> Tensor<Float> in
+            let paddedTensor = x.padded(forSizes: [(2, 0), (0, 2)], mode: .symmetric)
             return (paddedTensor * paddedTensor).sum()
         }
         XCTAssertEqual(grads, target)

--- a/Tests/TensorFlowTests/SequentialTests.swift
+++ b/Tests/TensorFlowTests/SequentialTests.swift
@@ -48,7 +48,7 @@ final class SequentialTests: XCTestCase {
         Context.local.learningPhase = .training
         withTensorLeakChecking {
             for _ in 0..<1000 {
-                let 𝛁model = model.gradient { model -> Tensor<Float> in
+                let 𝛁model = gradient(at: model) { model -> Tensor<Float> in
                     let ŷ = model(x)
                     return meanSquaredError(predicted: ŷ, expected: y)
                 }

--- a/Tests/TensorFlowTests/TrivialModelTests.swift
+++ b/Tests/TensorFlowTests/TrivialModelTests.swift
@@ -45,7 +45,7 @@ final class TrivialModelTests: XCTestCase {
         Context.local.learningPhase = .training
         withTensorLeakChecking {
             for _ in 0..<3000 {
-                let 𝛁model = classifier.gradient { classifier -> Tensor<Float> in
+                let 𝛁model = gradient(at: classifier) { classifier -> Tensor<Float> in
                     let ŷ = classifier(x)
                     return meanSquaredError(predicted: ŷ, expected: y)
                 }


### PR DESCRIPTION
Before:
```
/swift-models/Gym/CartPole/main.swift:182:13: warning: 'gradient(in:)' is deprecated: Method-style differential operators are deprecated and will be removed; use top-level
function 'TensorFlow.gradient(at:in:)' instead
        net.gradient { net -> Tensor<Float> in
            ^
```

After:
```
/swift-models/Gym/CartPole/main.swift:182:13: warning: 'gradient(in:)' is deprecated: Method-style differential operators are deprecated and will be removed; use top-level function 'TensorFlow.gradient(at:in:)' instead
        net.gradient { net -> Tensor<Float> in
            ^
```