### PR TITLE
use base deps docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,7 @@
-# TODO: We should have a job that creates a S4TF base image so that
-#we don't have to duplicate the installation everywhere.
-FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04
+FROM gcr.io/swift-tensorflow/base-deps-cuda10.1-cudnn7-ubuntu18.04
 
 # Allows the caller to specify the toolchain to use.
-ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.0-cudnn7-ubuntu18.04.tar.gz
-
-# Install Swift deps.
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        build-essential \
-        ca-certificates \
-        curl \
-        git \
-        python \
-        clang \
-        libbsd-dev \
-        libcurl4-openssl-dev \
-        libicu-dev \
-        libncurses5-dev \
-        libxml2 \
-        libblocksruntime-dev \
-        python3 \
-        python3-pip \
-        python3-setuptools \
-        python3-dev
-
-RUN pip3 install psutil junit-xml
+ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.1-cudnn7-ubuntu18.04.tar.gz
 
 # Download and extract S4TF
 WORKDIR /swift-tensorflow-toolchain
@@ -37,10 +13,6 @@ RUN curl -fSsL $swift_tf_url -o swift.tar.gz \
 # Copy the kernel into the container
 WORKDIR /swift-apis
 COPY . .
-
-# Configure cuda
-RUN echo "/usr/local/cuda-10.0/targets/x86_64-linux/lib/stubs" > /etc/ld.so.conf.d/cuda-10.0-stubs.conf && \
-    ldconfig
 
 # Print out swift version for better debugging for toolchain problems
 RUN /swift-tensorflow-toolchain/usr/bin/swift --version


### PR DESCRIPTION
Uses the docker image built in tensorflow/swift#342, to speed up the build and reduce code duplication.