### PR TITLE
Avoid scalars and immutable Parameter<> fields.

### DIFF
--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -33,9 +33,9 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
     /// The variance epsilon value.
     @noDerivative public let epsilon: Scalar
     /// The running mean.
-    @noDerivative public let runningMean: Parameter<Scalar>
+    @noDerivative public var runningMean: Parameter<Scalar>
     /// The running variance.
-    @noDerivative public let runningVariance: Parameter<Scalar>
+    @noDerivative public var runningVariance: Parameter<Scalar>
 
     /// Creates a batch normalization layer.
     ///
@@ -85,12 +85,13 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
           var normalizedAxes = Array(0..<input.rank)
           normalizedAxes.remove(at: positiveAxis)
           let moments = input.moments(alongAxes: normalizedAxes)
-          runningMean.value += (moments.mean - runningMean.value) * (1 - momentum)
-          runningVariance.value += (moments.variance - runningVariance.value) * (1 - momentum)
-          let inv = rsqrt(moments.variance + epsilon) * scale
+          let decayMomentum = Tensor(1 - momentum)
+          runningMean.value += (moments.mean - runningMean.value) * decayMomentum
+          runningVariance.value += (moments.variance - runningVariance.value) * decayMomentum
+          let inv = rsqrt(moments.variance + Tensor(epsilon)) * scale
           return (input - moments.mean) * inv + offset
         case .inference:
-          let inv = rsqrt(runningVariance.value + epsilon) * scale
+          let inv = rsqrt(runningVariance.value + Tensor(epsilon)) * scale
           return (input - runningMean.value) * inv + offset
         }
     }


### PR DESCRIPTION
Scalars participating in vjps become "scalarized()" which become host transfers.
let Parameter values cannot be written to via key-path-iterable.