### PR TITLE
Add a stub which represents the device of a tensor.

### DIFF
--- a/Sources/TensorFlow/Core/Device.swift
+++ b/Sources/TensorFlow/Core/Device.swift
@@ -1,0 +1,16 @@
+/// Represents a device where a tensor logically resides.
+/// Currently, this is just a stub because tensorflow will transfer
+/// tensors between devices on demand.
+public struct Device {
+  public static var getDefault: Device { Device() }
+}
+
+extension Tensor {
+  /// The current device of a tensor.
+  public var device: Device {
+    @_semantics("autodiff.nonvarying")
+    get {
+      return Device()
+    }
+  }
+}

--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -171,8 +171,8 @@ public extension Tensor {
 extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
     func _vjpScalars() -> (value: [Scalar], pullback: (Array<Scalar>.TangentVector) -> Tensor) {
-        (value: scalars, pullback: { [shape = self.shape] v in
-            Tensor(shape: shape, scalars: v.base)
+        (value: scalars, pullback: { [shape = self.shape, device = self.device] v in
+            Tensor(shape: shape, scalars: v.base, on: device)
         })
     }
 }
@@ -185,29 +185,32 @@ public extension Tensor {
     /// Creates a 0-D tensor from a scalar value.
     @inlinable
     @differentiable(vjp: _vjpScalarInit where Scalar: TensorFlowFloatingPoint)
-    init(_ value: Scalar) {
-        self.init(shape: [], scalars: [value])
+    init(_ value: Scalar, on device: Device = Device.getDefault) {
+        self.init(shape: [], scalars: [value], on: device)
     }
 }
 
 internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
-    static func _vjpScalarInit(_ value: __owned Scalar) -> (Tensor, (Tensor) -> Scalar) {
-        return (Tensor(value), { $0.scalarized() })
+    static func _vjpScalarInit(_ value: __owned Scalar, on device: Device = Device.getDefault
+    ) -> (Tensor, (Tensor) -> Scalar) {
+        return (Tensor(value, on: device), { $0.scalarized() })
     }
 }
 
 public extension Tensor {
     /// Creates a 1D tensor from scalars.
     @inlinable
-    @differentiable(vjp: _vjpInit(_:) where Scalar: TensorFlowFloatingPoint)
-    init(_ scalars: [Scalar]) {
-        self.init(shape: [scalars.count], scalars: scalars)
+    @differentiable(vjp: _vjpInit(_:on:) where Scalar: TensorFlowFloatingPoint)
+    init(_ scalars: [Scalar], on device: Device = Device.getDefault) {
+        self.init(shape: [scalars.count], scalars: scalars, on: device)
     }
 
     /// Creates a 1D tensor from scalars.
     @inlinable
-    init<C: RandomAccessCollection>(_ vector: C) where C.Element == Scalar {
+    init<C: RandomAccessCollection>(
+        _ vector: C, on device: Device = Device.getDefault
+    ) where C.Element == Scalar {
         let handle = TensorHandle<Scalar>(
             shape: [vector.count],
             scalarsInitializer: { addr in
@@ -227,15 +230,15 @@ public extension Tensor {
     ///   - scalars: The scalar contents of the tensor.
     /// - Precondition: The product of the dimensions of the shape must equal the number of scalars.
     @inlinable
-    @differentiable(vjp: _vjpInit(shape:scalars:) where Scalar: TensorFlowFloatingPoint)
-    init(shape: TensorShape, scalars: [Scalar]) {
+    @differentiable(vjp: _vjpInit(shape:scalars:on:) where Scalar: TensorFlowFloatingPoint)
+    init(shape: TensorShape, scalars: [Scalar], on device: Device = Device.getDefault) {
         precondition(shape.contiguousSize == scalars.count,
             """
             The shape requires \(shape.contiguousSize) scalars but \(scalars.count) were \
             provided.
             """)
         self = scalars.withUnsafeBufferPointer { bufferPointer in
-            Tensor(shape: shape, scalars: bufferPointer)
+            Tensor(shape: shape, scalars: bufferPointer, on: device)
         }
     }
 
@@ -246,7 +249,11 @@ public extension Tensor {
     ///   - scalars: The scalar contents of the tensor.
     /// - Precondition: The product of the dimensions of the shape must equal the number of scalars.
     @inlinable
-    init(shape: TensorShape, scalars: UnsafeBufferPointer<Scalar>) {
+    init(
+        shape: TensorShape,
+        scalars: UnsafeBufferPointer<Scalar>,
+        on device: Device = Device.getDefault
+    ) {
         precondition(shape.contiguousSize == scalars.count,
             """
             The shape requires \(shape.contiguousSize) scalars but \(scalars.count) were \
@@ -267,7 +274,9 @@ public extension Tensor {
     ///   - scalars: The scalar contents of the tensor.
     /// - Precondition: The product of the dimensions of the shape must equal the number of scalars.
     @inlinable
-    init<C: RandomAccessCollection>(shape: TensorShape, scalars: C) where C.Element == Scalar {
+    init<C: RandomAccessCollection>(
+        shape: TensorShape, scalars: C, on device: Device = Device.getDefault
+    ) where C.Element == Scalar {
         precondition(shape.contiguousSize == scalars.count,
             """
             The shape requires \(shape.contiguousSize) scalars but \(scalars.count) were \
@@ -288,17 +297,21 @@ public extension Tensor {
 
 extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
-    static func _vjpInit(_ scalars: [Scalar]) -> (
+    static func _vjpInit(_ scalars: [Scalar], on device: Device = Device.getDefault) -> (
         value: Tensor, pullback: (Tensor) -> Array<Scalar>.TangentVector
     ) {
-        (value: Tensor(scalars), pullback: { v in Array<Scalar>.TangentVector(v.scalars) })
+        (value: Tensor(scalars, on: device), pullback: { v in
+            Array<Scalar>.TangentVector(v.scalars)
+        })
     }
 
     @inlinable
-    static func _vjpInit(shape: TensorShape, scalars: [Scalar]) -> (
-        value: Tensor, pullback: (Tensor) -> Array<Scalar>.TangentVector
-    ) {
-        (value: Tensor(scalars), pullback: { v in Array<Scalar>.TangentVector(v.scalars) })
+    static func _vjpInit(
+        shape: TensorShape, scalars: [Scalar], on device: Device = Device.getDefault
+    ) -> (value: Tensor, pullback: (Tensor) -> Array<Scalar>.TangentVector) {
+        (value: Tensor(scalars, on: device), pullback: { v in
+            Array<Scalar>.TangentVector(v.scalars)
+        })
     }
 }
 

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -85,13 +85,13 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
           var normalizedAxes = Array(0..<input.rank)
           normalizedAxes.remove(at: positiveAxis)
           let moments = input.moments(alongAxes: normalizedAxes)
-          let decayMomentum = Tensor(1 - momentum)
+          let decayMomentum = Tensor(1 - momentum, on: input.device)
           runningMean.value += (moments.mean - runningMean.value) * decayMomentum
           runningVariance.value += (moments.variance - runningVariance.value) * decayMomentum
-          let inv = rsqrt(moments.variance + Tensor(epsilon)) * scale
+          let inv = rsqrt(moments.variance + Tensor(epsilon, on: input.device)) * scale
           return (input - moments.mean) * inv + offset
         case .inference:
-          let inv = rsqrt(runningVariance.value + Tensor(epsilon)) * scale
+          let inv = rsqrt(runningVariance.value + Tensor(epsilon, on: input.device)) * scale
           return (input - runningMean.value) * inv + offset
         }
     }


### PR DESCRIPTION
Once this device concept is plumbed properly throughout the code we can require that all operands of an op eg: (a + b) live on the same device. This eventually will make it so that transferring tensors always requires an explicit call.