### PR TITLE
Add categorical intializer for Tensor

### DIFF
--- a/Sources/TensorFlow/Initializers.swift
+++ b/Sources/TensorFlow/Initializers.swift
@@ -453,6 +453,31 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
     }
 }
 
+public extension Tensor where Scalar: TensorFlowIndex {
+    /// Creates a tensor by drawing samples from a categorical distribution.
+    ///
+    /// - Parameters:
+    ///     - logits: 2-D Tensor with shape `[batch_size, num_classes]`.  Each slice `[i, :]`
+    ///         represents the unnormalized log probabilities for all classes.
+    ///     - num_samples: 0-D.  Number of independent samples to draw for each row slice.
+    ///
+    /// - Attrs:
+    ///     - seed: If either seed or seed2 is set to be non-zero, the internal random number
+    ///         generator is seeded by the given seed.  Otherwise, a random seed is used.
+    ///     - seed2: A second seed to avoid seed collision.
+    ///
+    /// - Output: 2-D Tensor with shape `[batch_size, num_samples]`.  Each slice `[i, :]`
+    ///     contains the drawn class labels with range `[0, num_classes)`.
+    init<T: TensorFlowNumeric>(
+        logits: Tensor<T>,
+        numSamples: Tensor<Int32>,
+        seed: Int64 = 0,
+        seed2: Int64 = 0
+    ) {
+        self = _Raw.multinomial(logits: logits, numSamples: numSamples, seed: seed, seed2: seed2)
+    }
+}
+
 //===------------------------------------------------------------------------------------------===//
 // Variance Scaling
 //===------------------------------------------------------------------------------------------===//

--- a/Sources/TensorFlow/Initializers.swift
+++ b/Sources/TensorFlow/Initializers.swift
@@ -457,24 +457,22 @@ public extension Tensor where Scalar: TensorFlowIndex {
     /// Creates a tensor by drawing samples from a categorical distribution.
     ///
     /// - Parameters:
-    ///     - logits: 2-D Tensor with shape `[batch_size, num_classes]`.  Each slice `[i, :]`
+    ///     - randomCategorialLogits: 2-D Tensor with shape `[batchSize, classCount]`.  Each slice `[i, :]`
     ///         represents the unnormalized log probabilities for all classes.
-    ///     - num_samples: 0-D.  Number of independent samples to draw for each row slice.
+    ///     - sampleCount: 0-D.  Number of independent samples to draw for each row slice.
+    ///     - seed: The seed value.
     ///
-    /// - Attrs:
-    ///     - seed: If either seed or seed2 is set to be non-zero, the internal random number
-    ///         generator is seeded by the given seed.  Otherwise, a random seed is used.
-    ///     - seed2: A second seed to avoid seed collision.
-    ///
-    /// - Output: 2-D Tensor with shape `[batch_size, num_samples]`.  Each slice `[i, :]`
-    ///     contains the drawn class labels with range `[0, num_classes)`.
+    /// - Returns: 2-D Tensor with shape `[batchSize, sampleCount]`.  Each slice `[i, :]`
+    ///     contains the drawn class labels with range `[0, classCount)`.
     init<T: TensorFlowNumeric>(
-        logits: Tensor<T>,
-        numSamples: Tensor<Int32>,
-        seed: Int64 = 0,
-        seed2: Int64 = 0
+        randomCategorialLogits: Tensor<T>,
+        sampleCount: Int32,
+        seed: TensorFlowSeed = Context.local.randomSeed
     ) {
-        self = _Raw.multinomial(logits: logits, numSamples: numSamples, seed: seed, seed2: seed2)
+        self = _Raw.statelessMultinomial(
+            logits: randomCategorialLogits, 
+            numSamples: Tensor<Int32>(sampleCount), 
+            seed: Tensor<Int32>([seed.graph, seed.op]))
     }
 }
 

--- a/Tests/TensorFlowTests/InitializerTests.swift
+++ b/Tests/TensorFlowTests/InitializerTests.swift
@@ -177,8 +177,8 @@ final class InitializerTests: XCTestCase {
 
         XCTAssertEqual(TensorShape([2, 1]), t.shape)
         // Test all elements are in range of [0, 3)
-        XCTAssertEqual(1, (Tensor<Int32>(t .>= Tensor<Int32>([[0], [0]])).product()).scalar!)
-        XCTAssertEqual(1, (Tensor<Int32>(t .< Tensor<Int32>([[3], [3]])).product()).scalar!)
+        XCTAssertTrue((t .>= Tensor<Int32>([[0], [0]])).all())
+        XCTAssertTrue((t .< Tensor<Int32>([[3], [3]])).all())
     }
 
     func testOrthogonalShapesValues() {

--- a/Tests/TensorFlowTests/InitializerTests.swift
+++ b/Tests/TensorFlowTests/InitializerTests.swift
@@ -173,7 +173,7 @@ final class InitializerTests: XCTestCase {
     func testCategoricalFromLogits() {
         let probabilities = Tensor<Float>([[0.5, 0.3, 0.2], [0.6, 0.3, 0.1]])
         let logits = log(probabilities)
-        let t = Tensor<Int32>(logits: logits, numSamples: Tensor<Int32>(1))
+        let t = Tensor<Int32>(randomCategorialLogits: logits, sampleCount: 1)
 
         XCTAssertEqual(TensorShape([2, 1]), t.shape)
         // Test all elements are in range of [0, 3)

--- a/Tests/TensorFlowTests/InitializerTests.swift
+++ b/Tests/TensorFlowTests/InitializerTests.swift
@@ -170,6 +170,17 @@ final class InitializerTests: XCTestCase {
         testDistribution(t, expectedMean: 0, expectedStandardDeviation: stdDev)
     }
 
+    func testCategoricalFromLogits() {
+        let probabilities = Tensor<Float>([[0.5, 0.3, 0.2], [0.6, 0.3, 0.1]])
+        let logits = log(probabilities)
+        let t = Tensor<Int32>(logits: logits, numSamples: Tensor<Int32>(1))
+
+        XCTAssertEqual(TensorShape([2, 1]), t.shape)
+        // Test all elements are in range of [0, 3)
+        XCTAssertEqual(1, (Tensor<Int32>(t .>= Tensor<Int32>([[0], [0]])).product()).scalar!)
+        XCTAssertEqual(1, (Tensor<Int32>(t .< Tensor<Int32>([[3], [3]])).product()).scalar!)
+    }
+
     func testOrthogonalShapesValues() {
         for shape in [[10, 10], [10, 9, 8], [100, 5, 5], [50, 40], [3, 3, 32, 64]] {
             // Check the shape.
@@ -201,6 +212,7 @@ final class InitializerTests: XCTestCase {
         ("testRandomTruncatedNormal", testRandomTruncatedNormal),
         ("testGlorotUniform", testGlorotUniform),
         ("testGlorotNormal", testGlorotNormal),
+        ("testCategoricalFromLogits", testCategoricalFromLogits),
         ("testOrthogonalShapesValues", testOrthogonalShapesValues)
     ]
 }


### PR DESCRIPTION
This PR introduces capability of drawing samples from a categorical distribution into Tensor's intializer.