### PR TITLE
[AutoDiff] Use `@derivative` for derivative registration.

### DIFF
--- a/Sources/TensorFlow/Freezable.swift
+++ b/Sources/TensorFlow/Freezable.swift
@@ -30,13 +30,14 @@ public struct _Freezable<Value: Differentiable> {
     }
 
     /// The wrapped differentiable value.
-    @differentiable(vjp: _vjpValue)
+    @differentiable
     public var wrappedValue: Value {
         get { _value }
         set { _value = newValue }
     }
 
     @usableFromInline
+    @derivative(of: wrappedValue)
     func _vjpValue() -> (value: Value, pullback: (Value.TangentVector) -> TangentVector) {
         return (_value, { [isFrozen = self.isFrozen] v in
             isFrozen ? .zero : v

--- a/Sources/TensorFlow/Layers/Recurrent.swift
+++ b/Sources/TensorFlow/Layers/Recurrent.swift
@@ -344,7 +344,7 @@ public struct RNN<Cell: RNNCell>: Layer {
         self.cell = cell()
     }
 
-    @differentiable(wrt: (self, inputs), vjp: _vjpCallAsFunction(_:initialState:))
+    @differentiable(wrt: (self, inputs))
     public func callAsFunction(
         _ inputs: [Cell.TimeStepInput],
         initialState: Cell.State
@@ -369,12 +369,15 @@ public struct RNN<Cell: RNNCell>: Layer {
     }
 
     @usableFromInline
+    @derivative(of: callAsFunction, wrt: (self, inputs))
     internal func _vjpCallAsFunction(
         _ inputs: [Cell.TimeStepInput],
         initialState: Cell.State
-    ) -> ([Cell.TimeStepOutput],
-          (Array<Cell.TimeStepOutput>.TangentVector)
-              -> (TangentVector, Array<Cell.TimeStepInput>.TangentVector)) {
+    ) -> (
+        value: [Cell.TimeStepOutput],
+        pullback: (Array<Cell.TimeStepOutput>.TangentVector)
+            -> (TangentVector, Array<Cell.TimeStepInput>.TangentVector)
+    ) {
         let timeStepCount = inputs.count
         var currentHiddenState = cell.zeroState(for: inputs[0])
         var timeStepOutputs: [Cell.TimeStepOutput] = []

--- a/Sources/TensorFlow/Layers/Upsampling.swift
+++ b/Sources/TensorFlow/Layers/Upsampling.swift
@@ -79,7 +79,7 @@ public struct UpSampling3D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer 
     /// Repeats the elements of a tensor along an axis, like `np.repeat`.
     /// Function adapted from `def repeat_elements`:
     /// https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/backend.py
-    @differentiable(vjp: _vjpRepeatingElements)
+    @differentiable
     private func repeatingElements(
         _ input: Tensor<Scalar>, alongAxis axis: Int, count: Int
     ) -> Tensor<Scalar> {
@@ -91,9 +91,10 @@ public struct UpSampling3D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer 
         return Tensor<Scalar>(concatenating: repeated, alongAxis: axis)
     }
 
+    @derivative(of: repeatingElements)
     private func _vjpRepeatingElements(
         _ input: Tensor<Scalar>, alongAxis axis: Int, count: Int
-    ) -> (Tensor<Scalar>, (Tensor<Scalar>) -> (TangentVector, Tensor<Scalar>)) {
+    ) -> (value: Tensor<Scalar>, pullback: (Tensor<Scalar>) -> (TangentVector, Tensor<Scalar>)) {
         let value = repeatingElements(input, alongAxis: axis, count: count)
         return (value, { v in
             let splits = _Raw.split(

--- a/Sources/TensorFlow/Loss.swift
+++ b/Sources/TensorFlow/Loss.swift
@@ -210,7 +210,7 @@ public func softmaxCrossEntropy<Scalar: TensorFlowFloatingPoint>(
 }
 
 @inlinable
-@differentiable(wrt: logits, vjp: _vjpSoftmaxCrossEntropyHelper(logits:labels:))
+@differentiable(wrt: logits)
 func softmaxCrossEntropyHelper<Scalar: TensorFlowFloatingPoint>(
     logits: Tensor<Scalar>,
     labels: Tensor<Int32>
@@ -219,10 +219,11 @@ func softmaxCrossEntropyHelper<Scalar: TensorFlowFloatingPoint>(
 }
 
 @inlinable
+@derivative(of: softmaxCrossEntropyHelper(logits:labels:))
 func _vjpSoftmaxCrossEntropyHelper<Scalar: TensorFlowFloatingPoint>(
     logits: Tensor<Scalar>,
     labels: Tensor<Int32>
-) -> (Tensor<Scalar>, (Tensor<Scalar>) -> Tensor<Scalar>) {
+) -> (value: Tensor<Scalar>, pullback: (Tensor<Scalar>) -> Tensor<Scalar>) {
     let (loss, grad) = _Raw.sparseSoftmaxCrossEntropyWithLogits(features: logits, labels: labels)
     return (loss, { $0.expandingShape(at: -1) * grad })
 }
@@ -244,7 +245,7 @@ public func softmaxCrossEntropy<Scalar: TensorFlowFloatingPoint>(
 }
 
 @inlinable
-@differentiable(wrt: logits, vjp: _vjpSoftmaxCrossEntropyHelper(logits:probabilities:))
+@differentiable(wrt: logits)
 func softmaxCrossEntropyHelper<Scalar: TensorFlowFloatingPoint>(
     logits: Tensor<Scalar>,
     probabilities: Tensor<Scalar>
@@ -253,10 +254,11 @@ func softmaxCrossEntropyHelper<Scalar: TensorFlowFloatingPoint>(
 }
 
 @inlinable
+@derivative(of: softmaxCrossEntropyHelper(logits:probabilities:), wrt: logits)
 func _vjpSoftmaxCrossEntropyHelper<Scalar: TensorFlowFloatingPoint>(
     logits: Tensor<Scalar>,
     probabilities: Tensor<Scalar>
-) -> (Tensor<Scalar>, (Tensor<Scalar>) -> Tensor<Scalar>) {
+) -> (value: Tensor<Scalar>, pullback: (Tensor<Scalar>) -> Tensor<Scalar>) {
     let (loss, grad) = _Raw.softmaxCrossEntropyWithLogits(features: logits, labels: probabilities)
     return (loss, { $0.expandingShape(at: -1) * grad })
 }

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -259,28 +259,28 @@ extension VectorProtocol where VectorSpaceScalar: SignedNumeric {
 public extension Tensor where Scalar: Numeric {
     /// Adds the scalar to every scalar of the tensor and produces the sum.
     @inlinable
-    @differentiable(vjp: _vjpAdd(lhs:rhs:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(where Scalar: TensorFlowFloatingPoint)
     static func + (lhs: Scalar, rhs: Tensor) -> Tensor {
         return Tensor(lhs) + rhs
     }
 
     /// Adds the scalar to every scalar of the tensor and produces the sum.
     @inlinable
-    @differentiable(vjp: _vjpAdd(lhs:rhs:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(where Scalar: TensorFlowFloatingPoint)
     static func + (lhs: Tensor, rhs: Scalar) -> Tensor {
         return lhs + Tensor(rhs)
     }
 
     /// Subtracts the scalar from every scalar of the tensor and produces the difference.
     @inlinable
-    @differentiable(vjp: _vjpSubtract(lhs:rhs:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(where Scalar: TensorFlowFloatingPoint)
     static func - (lhs: Scalar, rhs: Tensor) -> Tensor {
         return Tensor(lhs) - rhs
     }
 
     /// Subtracts the scalar from every scalar of the tensor and produces the difference
     @inlinable
-    @differentiable(vjp: _vjpSubtract(lhs:rhs:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(where Scalar: TensorFlowFloatingPoint)
     static func - (lhs: Tensor, rhs: Scalar) -> Tensor {
         return lhs - Tensor(rhs)
     }
@@ -317,21 +317,21 @@ public extension Tensor where Scalar: Numeric {
     /// Returns the tensor produced by multiplying the two tensors.
     /// - Note: `*` supports broadcasting.
     @inlinable
-    @differentiable(vjp: _vjpMultiply(lhs:rhs:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(where Scalar: TensorFlowFloatingPoint)
     static func * (lhs: Tensor, rhs: Tensor) -> Tensor {
         return _Raw.mul(lhs, rhs)
     }
 
     /// Returns the tensor by multiplying it with every scalar of the tensor.
     @inlinable
-    @differentiable(vjp: _vjpMultiply(lhs:rhs:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(where Scalar: TensorFlowFloatingPoint)
     static func * (lhs: Scalar, rhs: Tensor) -> Tensor {
         return Tensor(lhs) * rhs
     }
 
     /// Multiplies the scalar with every scalar of the tensor and produces the product.
     @inlinable
-    @differentiable(vjp: _vjpMultiply(lhs:rhs:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(where Scalar: TensorFlowFloatingPoint)
     static func * (lhs: Tensor, rhs: Scalar) -> Tensor {
         return lhs * Tensor(rhs)
     }
@@ -353,21 +353,21 @@ public extension Tensor where Scalar: Numeric {
     /// Returns the quotient of dividing the first tensor by the second.
     /// - Note: `/` supports broadcasting.
     @inlinable
-    @differentiable(vjp: _vjpDivide(lhs:rhs:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(where Scalar: TensorFlowFloatingPoint)
     static func / (lhs: Tensor, rhs: Tensor) -> Tensor {
         return _Raw.div(lhs, rhs)
     }
 
     /// Returns the quotient of dividing the scalar by the tensor, broadcasting the scalar.
     @inlinable
-    @differentiable(vjp: _vjpDivide(lhs:rhs:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(where Scalar: TensorFlowFloatingPoint)
     static func / (lhs: Scalar, rhs: Tensor) -> Tensor {
         return Tensor(lhs) / rhs
     }
 
     /// Returns the quotient of dividing the tensor by the scalar, broadcasting the scalar.
     @inlinable
-    @differentiable(vjp: _vjpDivide(lhs:rhs:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(where Scalar: TensorFlowFloatingPoint)
     static func / (lhs: Tensor, rhs: Scalar) -> Tensor {
         return lhs / Tensor(rhs)
     }
@@ -421,27 +421,42 @@ public extension Tensor where Scalar: Numeric {
 
 internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
-    static func _vjpAdd(lhs: Tensor, rhs: Scalar) -> (Tensor, (Tensor) -> (Tensor, Scalar)) {
+    @derivative(of: +)
+    static func _vjpAdd(lhs: Tensor, rhs: Scalar) -> (
+        value: Tensor, pullback: (Tensor) -> (Tensor, Scalar)
+    ) {
         return (lhs + rhs, { v in (v, v.sum().scalarized()) })
     }
 
     @inlinable
-    static func _vjpAdd(lhs: Scalar, rhs: Tensor) -> (Tensor, (Tensor) -> (Scalar, Tensor)) {
+    @derivative(of: +)
+    static func _vjpAdd(lhs: Scalar, rhs: Tensor) -> (
+        value: Tensor, pullback: (Tensor) -> (Scalar, Tensor)
+    ) {
         return (lhs + rhs, { v in (v.sum().scalarized(), v) })
     }
 
     @inlinable
-    static func _vjpSubtract(lhs: Tensor, rhs: Scalar) -> (Tensor, (Tensor) -> (Tensor, Scalar)) {
+    @derivative(of: -)
+    static func _vjpSubtract(lhs: Tensor, rhs: Scalar) -> (
+        value: Tensor, pullback: (Tensor) -> (Tensor, Scalar)
+    ) {
         return (lhs - rhs, { v in (v, -v.sum().scalarized()) })
     }
 
     @inlinable
-    static func _vjpSubtract(lhs: Scalar, rhs: Tensor) -> (Tensor, (Tensor) -> (Scalar, Tensor)) {
+    @derivative(of: -)
+    static func _vjpSubtract(lhs: Scalar, rhs: Tensor) -> (
+        value: Tensor, pullback: (Tensor) -> (Scalar, Tensor)
+    ) {
         return (lhs - rhs, { v in (v.sum().scalarized(), -v) })
     }
 
     @inlinable
-    static func _vjpMultiply(lhs: Tensor, rhs: Tensor) -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Tensor, rhs: Tensor) -> (
+        value: Tensor, pullback: (Tensor) -> (Tensor, Tensor)
+    ) {
         return (lhs * rhs, { [lhsShape = lhs.shapeTensor, rhsShape = rhs.shapeTensor] v in
             let lhsGrad = rhs * v
             let rhsGrad = lhs * v
@@ -452,17 +467,26 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     }
 
     @inlinable
-    static func _vjpMultiply(lhs: Tensor, rhs: Scalar) -> (Tensor, (Tensor) -> (Tensor, Scalar)) {
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Tensor, rhs: Scalar) -> (
+        value: Tensor, pullback: (Tensor) -> (Tensor, Scalar)
+    ) {
         return (lhs * rhs, { v in (v * rhs, (v * lhs).sum().scalarized()) })
     }
 
     @inlinable
-    static func _vjpMultiply(lhs: Scalar, rhs: Tensor) -> (Tensor, (Tensor) -> (Scalar, Tensor)) {
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Scalar, rhs: Tensor) -> (
+        value: Tensor, pullback: (Tensor) -> (Scalar, Tensor)
+    ) {
         return (lhs * rhs, { v in ((v * rhs).sum().scalarized(), v * lhs) })
     }
 
     @inlinable
-    static func _vjpDivide(lhs: Tensor, rhs: Tensor) -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Tensor, rhs: Tensor) -> (
+        value: Tensor, pullback: (Tensor) -> (Tensor, Tensor)
+    ) {
         return (lhs / rhs, { [lhsShape = lhs.shapeTensor, rhsShape = rhs.shapeTensor] v in
             let lhsGrad = v / rhs
             let rhsGrad = -lhs / rhs.squared() * v
@@ -473,14 +497,20 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     }
 
     @inlinable
-    static func _vjpDivide(lhs: Tensor, rhs: Scalar) -> (Tensor, (Tensor) -> (Tensor, Scalar)) {
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Tensor, rhs: Scalar) -> (
+        value: Tensor, pullback: (Tensor) -> (Tensor, Scalar)
+    ) {
         return (lhs / rhs, { v in
             (v / rhs, (v * -lhs / Tensor(rhs).squared()).sum().scalarized())
         })
     }
 
     @inlinable
-    static func _vjpDivide(lhs: Scalar, rhs: Tensor) -> (Tensor, (Tensor) -> (Scalar, Tensor)) {
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Scalar, rhs: Tensor) -> (
+        value: Tensor, pullback: (Tensor) -> (Scalar, Tensor)
+    ) {
         return (lhs / rhs, { v in ((v / rhs).sum().scalarized(), v * -lhs / rhs.squared()) })
     }
 }
@@ -521,7 +551,7 @@ public extension Tensor where Scalar == Bool {
 public extension Tensor where Scalar: TensorFlowNumeric {
     /// Returns `max(min(self, max), min)`.
     @inlinable
-    @differentiable(vjp: _vjpClipped where Scalar: TensorFlowFloatingPoint)
+    @differentiable(where Scalar: TensorFlowFloatingPoint)
     func clipped(min: Tensor, max: Tensor) -> Tensor {
         _Raw.clipByValue(t: self, clipValueMin: min, clipValueMax: max)
     }
@@ -550,7 +580,10 @@ public extension Tensor where Scalar: TensorFlowNumeric {
 
 internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
-    func _vjpClipped(min: Tensor, max: Tensor) -> (Tensor, (Tensor) -> (Tensor, Tensor, Tensor)) {
+    @derivative(of: clipped)
+    func _vjpClipped(min: Tensor, max: Tensor) -> (
+        value: Tensor, pullback: (Tensor) -> (Tensor, Tensor, Tensor)
+    ) {
         (clipped(min: min, max: max), { v in
             let selfShape = self.shapeTensor
             let minShape = min.shapeTensor
@@ -633,7 +666,7 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
 public extension Tensor where Scalar: SignedNumeric {
     /// Returns the negation of the specified tensor element-wise.
     @inlinable
-    @differentiable(vjp: _vjpNegate(_:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(where Scalar: TensorFlowFloatingPoint)
     static prefix func - (rhs: Tensor) -> Tensor {
         return _Raw.neg(rhs)
     }
@@ -641,37 +674,40 @@ public extension Tensor where Scalar: SignedNumeric {
 
 internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
-    static func _vjpNegate(_ x: Tensor) -> (Tensor, (Tensor) -> Tensor) {
+    @derivative(of: -)
+    static func _vjpNegate(_ x: Tensor) -> (value: Tensor, pullback: (Tensor) -> Tensor) {
         return (-x, { v in -v })
     }
 }
 
 /// Returns the absolute value of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpAbs(_:) where T: TensorFlowFloatingPoint)
+@differentiable(where T: TensorFlowFloatingPoint)
 public func abs<T: SignedNumeric>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.abs(x)
 }
 
 @inlinable
+@derivative(of: abs)
 internal func _vjpAbs<T: TensorFlowFloatingPoint>(
   _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     let sign = _Raw.sign(x)
     return (abs(x), { v in v * sign })
 }
 
 /// Returns the natural logarithm of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpLog(_:))
+@differentiable
 public func log<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.log(x)
 }
 
 @inlinable
+@derivative(of: log)
 internal func _vjpLog<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (log(x), { v in v / x })
 }
 
@@ -691,15 +727,16 @@ public func log10<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 
 /// Returns the logarithm of `1 + x` element-wise.
 @inlinable
-@differentiable(vjp: _vjpLog1p)
+@differentiable
 public func log1p<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.log1p(x)
 }
 
 @inlinable
+@derivative(of: log1p)
 func _vjpLog1p<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (log1p(x), { v in _Raw.xdivy(v, 1 + x) })
 }
 
@@ -720,178 +757,190 @@ public func log1mexp<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 
 /// Returns the sine of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpSin(_:))
+@differentiable
 public func sin<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.sin(x)
 }
 
 @inlinable
+@derivative(of: sin)
 internal func _vjpSin<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (sin(x), { v in v * cos(x) })
 }
 
 /// Returns the cosine of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpCos(_:))
+@differentiable
 public func cos<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.cos(x)
 }
 
 @inlinable
+@derivative(of: cos)
 internal func _vjpCos<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (cos(x), { v in -v * sin(x) })
 }
 
 /// Returns the tangent of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpTan(_:))
+@differentiable
 public func tan<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.tan(x)
 }
 
 @inlinable
+@derivative(of: tan)
 internal func _vjpTan<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     let value = tan(x)
     return (value, { v in v * (1 + value.squared()) })
 }
 
 /// Returns the hyperbolic sine of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpSinh(_:))
+@differentiable
 public func sinh<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.sinh(x)
 }
 
 @inlinable
+@derivative(of: sinh)
 internal func _vjpSinh<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (sinh(x), { v in v * cosh(x) })
 }
 
 /// Returns the hyperbolic cosine of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpCosh(_:))
+@differentiable
 public func cosh<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.cosh(x)
 }
 
 @inlinable
+@derivative(of: cosh)
 internal func _vjpCosh<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (cosh(x), { v in v * sinh(x) })
 }
 
 /// Returns the hyperbolic tangent of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpTanh(_:))
+@differentiable
 public func tanh<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.tanh(x)
 }
 
 @inlinable
+@derivative(of: tanh)
 internal func _vjpTanh<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     let value = tanh(x)
     return (value, { v in v * (1 - value.squared()) })
 }
 
 /// Returns the inverse cosine of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpAcos(_:))
+@differentiable
 public func acos<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.acos(x)
 }
 
 @inlinable
+@derivative(of: acos)
 internal func _vjpAcos<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (acos(x), { v in -v / sqrt(1 - x.squared()) })
 }
 
 /// Returns the inverse sine of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpAsin(_:))
+@differentiable
 public func asin<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.asin(x)
 }
 
 @inlinable
+@derivative(of: asin)
 internal func _vjpAsin<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (asin(x), { v in v / sqrt(1 - x.squared()) })
 }
 
 /// Returns the inverse tangent of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpAtan(_:))
+@differentiable
 public func atan<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.atan(x)
 }
 
 @inlinable
+@derivative(of: atan)
 internal func _vjpAtan<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (atan(x), { v in v / (1 + x.squared()) })
 }
 
 /// Returns the inverse hyperbolic cosine of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpAcosh(_:))
+@differentiable
 public func acosh<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.acosh(x)
 }
 
 @inlinable
+@derivative(of: acosh)
 internal func _vjpAcosh<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (acosh(x), { v in v / asinh(x) })
 }
 
 /// Returns the inverse hyperbolic sine of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpAsinh(_:))
+@differentiable
 public func asinh<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.asinh(x)
 }
 
 @inlinable
+@derivative(of: asinh)
 internal func _vjpAsinh<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (asinh(x), { v in v / acosh(x) })
 }
 
 /// Returns the inverse hyperbolic tangent of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpAtanh(_:))
+@differentiable
 public func atanh<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.atanh(x)
 }
 
 @inlinable
+@derivative(of: atanh)
 internal func _vjpAtanh<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (atanh(x), { v in v / (1 - x.squared()) })
 }
 
 /// Returns the square of the tensor.
 public extension Tensor where Scalar: Numeric {
     @inlinable
-    @differentiable(wrt: self, vjp: _vjpSquared() where Scalar: TensorFlowFloatingPoint)
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func squared() -> Tensor {
         _Raw.square(self)
     }
@@ -899,52 +948,56 @@ public extension Tensor where Scalar: Numeric {
 
 internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
-    func _vjpSquared() -> (Tensor, (Tensor) -> Tensor) {
+    @derivative(of: squared)
+    func _vjpSquared() -> (value: Tensor, pullback: (Tensor) -> Tensor) {
         (squared(), { 2 * self * $0 })
     }
 }
 
 /// Returns the square root of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpSqrt(_:))
+@differentiable
 public func sqrt<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.sqrt(x)
 }
 
 @inlinable
+@derivative(of: sqrt)
 internal func _vjpSqrt<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     let value = sqrt(x)
     return (value, { v in v / (2 * value) })
 }
 
 /// Returns the inverse square root of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpRsqrt(_:))
+@differentiable
 public func rsqrt<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.rsqrt(x)
 }
 
 @inlinable
+@derivative(of: rsqrt)
 internal func _vjpRsqrt<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     let value = rsqrt(x)
     return (value, { v in _Raw.rsqrtGrad(value, dy: v) })
 }
 
 /// Returns the exponential of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpExp(_:))
+@differentiable
 public func exp<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.exp(x)
 }
 
 @inlinable
+@derivative(of: exp)
 internal func _vjpExp<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     let value = exp(x)
     return (value, { v in value * v })
 }
@@ -965,88 +1018,94 @@ public func exp10<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 
 /// Returns the exponential of `x - 1` element-wise.
 @inlinable
-@differentiable(vjp: _vjpExpm1)
+@differentiable
 public func expm1<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.expm1(x)
 }
 
 @inlinable
+@derivative(of: expm1)
 internal func _vjpExpm1<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     let y = expm1(x)
     return (y, { v in v * y })
 }
 
 /// Returns the values of the specified tensor rounded to the nearest integer, element-wise.
 @inlinable
-@differentiable(vjp: _vjpRound)
+@differentiable
 public func round<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.round(x)
 }
 
 @inlinable
+@derivative(of: round)
 internal func _vjpRound<T: TensorFlowFloatingPoint>(
   _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (round(x), { v in Tensor<T>(zerosLike: v) })
 }
 
 /// Returns the ceiling of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpCeil(_:))
+@differentiable
 public func ceil<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.ceil(x)
 }
 
 @inlinable
+@derivative(of: ceil)
 internal func _vjpCeil<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (ceil(x), { _ in Tensor(0).broadcasted(like: x) })
 }
 
 /// Returns the floor of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpFloor(_:))
+@differentiable
 public func floor<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.floor(x)
 }
 
 @inlinable
+@derivative(of: floor)
 internal func _vjpFloor<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (floor(x), { _ in Tensor(0).broadcasted(like: x) })
 }
 
 /// Returns an indication of the sign of the specified tensor element-wise.
 /// Specifically, computes `y = sign(x) = -1` if `x < 0`; 0 if `x == 0`; 1 if `x > 0`.
 @inlinable
-@differentiable(vjp: _vjpSign(_:) where T: TensorFlowFloatingPoint)
+@differentiable(where T: TensorFlowFloatingPoint)
 public func sign<T: Numeric>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.sign(x)
 }
 
 @inlinable
+@derivative(of: sign)
 internal func _vjpSign<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (sign(x), { v in Tensor<T>(zerosLike: x) })
 }
 
 /// Returns the sigmoid of the specified tensor element-wise.
 /// Specifically, computes `1 / (1 + exp(-x))`.
 @inlinable
-@differentiable(vjp: _vjpSigmoid)
+@differentiable
 public func sigmoid<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.sigmoid(x)
 }
 
 @inlinable
+@derivative(of: sigmoid)
 internal func _vjpSigmoid<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     let sigmoidValue = sigmoid(x)
     return (sigmoidValue, { v in _Raw.sigmoidGrad(sigmoidValue, dy: v) })
 }
@@ -1062,37 +1121,39 @@ public func logSigmoid<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> 
 /// Returns the softplus of the specified tensor element-wise.
 /// Specifically, computes `log(exp(features) + 1)`.
 @inlinable
-@differentiable(vjp: _vjpSoftplus)
+@differentiable
 public func softplus<T: TensorFlowFloatingPoint>(_ features: Tensor<T>) -> Tensor<T> {
     _Raw.softplus(features: features)
 }
 
 @inlinable
+@derivative(of: softplus)
 internal func _vjpSoftplus<T: TensorFlowFloatingPoint>(
     _ features: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (softplus(features), { v in _Raw.softplusGrad(gradients: v, features: features)})
 }
 
 /// Returns the softsign of the specified tensor element-wise.
 /// Specifically, computes `features/ (abs(features) + 1)`.
 @inlinable
-@differentiable(vjp: _vjpSoftsign)
+@differentiable
 public func softsign<T: TensorFlowFloatingPoint>(_ features: Tensor<T>) -> Tensor<T> {
     _Raw.softsign(features: features)
 }
 
 @inlinable
+@derivative(of: softsign)
 internal func _vjpSoftsign<T: TensorFlowFloatingPoint>(
     _ features: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (softsign(features), { v in _Raw.softsignGrad(gradients: v, features: features)})
 }
 
 /// Returns the softmax of the specified tensor along the last axis.
 /// Specifically, computes `exp(x) / exp(x).sum(alongAxes: -1)`.
 @inlinable
-@differentiable(vjp: _vjpSoftmax(_:))
+@differentiable
 public func softmax<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.softmax(logits: x)
 }
@@ -1107,9 +1168,10 @@ public func softmax<T: TensorFlowFloatingPoint>(_ x: Tensor<T>, alongAxis axis: 
 }
 
 @inlinable
+@derivative(of: softmax)
 func _vjpSoftmax<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     let value = softmax(x)
     return (value, { v in
         let sumChannels = (v * value).sum(alongAxes: -1)
@@ -1119,15 +1181,16 @@ func _vjpSoftmax<T: TensorFlowFloatingPoint>(
 
 /// Returns the log-softmax of the specified tensor element-wise.
 @inlinable
-@differentiable(vjp: _vjpLogSoftmax(_:))
+@differentiable
 public func logSoftmax<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.logSoftmax(logits: x)
 }
 
 @inlinable
+@derivative(of: logSoftmax)
 func _vjpLogSoftmax<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     let value = logSoftmax(x)
     return (value, { v in v - v.sum(alongAxes: -1) * exp(value) })
 }
@@ -1137,15 +1200,16 @@ func _vjpLogSoftmax<T: TensorFlowFloatingPoint>(
 /// See [Fast and Accurate Deep Network Learning by Exponential Linear Units (ELUs)
 /// ](http://arxiv.org/abs/1511.07289)
 @inlinable
-@differentiable(vjp: _vjpElu)
+@differentiable
 public func elu<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.elu(features: x)
 }
 
 @inlinable
+@derivative(of: elu)
 func _vjpElu<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     let y = elu(x)
     return (y, { v in _Raw.eluGrad(gradients: v, outputs: y) })
 }
@@ -1171,29 +1235,31 @@ public func gelu<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 /// Returns a tensor by applying the ReLU activation function to the specified tensor element-wise.
 /// Specifically, computes `max(0, x)`.
 @inlinable
-@differentiable(vjp: _vjpRelu(_:))
+@differentiable
 public func relu<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.relu(features: x)
 }
 
 @inlinable
+@derivative(of: relu)
 func _vjpRelu<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (relu(x), { v in _Raw.reluGrad(gradients: v, features: x) })
 }
 
 /// Returns a tensor by applying the ReLU6 activation function, namely `min(max(0, x), 6)`.
 @inlinable
-@differentiable(vjp: _vjpRelu6(_:))
+@differentiable
 public func relu6<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.relu6(features: x)
 }
 
 @inlinable
+@derivative(of: relu6)
 func _vjpRelu6<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (relu6(x), { v in _Raw.relu6Grad(gradients: v, features: x)})
 }
 
@@ -1201,7 +1267,7 @@ func _vjpRelu6<T: TensorFlowFloatingPoint>(
 /// to the specified tensor element-wise.
 /// Specifically, computes `max(x, x * alpha)`.
 @inlinable
-@differentiable(wrt: x, vjp: _vjpLeakyRelu)
+@differentiable(wrt: x)
 public func leakyRelu<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>,
     alpha: Double = 0.2
@@ -1210,10 +1276,11 @@ public func leakyRelu<T: TensorFlowFloatingPoint>(
 }
 
 @inlinable
+@derivative(of: leakyRelu, wrt: x)
 func _vjpLeakyRelu<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>,
     alpha: Double
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     (leakyRelu(x, alpha: alpha), { v in
         _Raw.leakyReluGrad(gradients: v, features: x, alpha: alpha)
     })
@@ -1226,15 +1293,16 @@ func _vjpLeakyRelu<T: TensorFlowFloatingPoint>(
 ///   Please refer to [Self-Normalizing Neural Networks](https://arxiv.org/abs/1706.02515) for more
 ///   information.
 @inlinable
-@differentiable(vjp: _vjpSelu(_:))
+@differentiable
 public func selu<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
     _Raw.selu(features: x)
 }
 
 @inlinable
+@derivative(of: selu)
 func _vjpSelu<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> Tensor<T>) {
     let result = selu(x)
     return (result, { v in
         _Raw.seluGrad(gradients: v, outputs: result)
@@ -1258,15 +1326,16 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
 
 /// Returns the power of the first tensor to the second tensor.
 @inlinable
-@differentiable(vjp: _vjpPow(_:_:))
+@differentiable
 public func pow<T: TensorFlowFloatingPoint>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T> {
     _Raw.pow(lhs, rhs)
 }
 
 @inlinable
+@derivative(of: pow)
 internal func _vjpPow<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>, _ y: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> (Tensor<T>, Tensor<T>)) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> (Tensor<T>, Tensor<T>)) {
     let value = pow(x, y)
     return (value, { v in
         let safeX = x.replacing(with: Tensor<T>(onesLike: x), where: x .<= 0)
@@ -1310,16 +1379,17 @@ public func root<T: TensorFlowFloatingPoint>(_ x: Tensor<T>, _ n: Int) -> Tensor
 /// Returns the squared difference between `x` and `y`.
 /// - Returns: `(x - y) ^ 2`.
 @inlinable
-@differentiable(vjp: _vjpSquaredDifference where T: TensorFlowFloatingPoint)
+@differentiable(where T: TensorFlowFloatingPoint)
 public func squaredDifference<T: TensorFlowNumeric>(_ x: Tensor<T>, _ y: Tensor<T>) -> Tensor<T> {
     _Raw.squaredDifference(x, y)
 }
 
 @inlinable
+@derivative(of: squaredDifference)
 internal func _vjpSquaredDifference<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>,
     _ y: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> (Tensor<T>, Tensor<T>)) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> (Tensor<T>, Tensor<T>)) {
     (squaredDifference(x, y), { seed in
         let lhsGrad = 2 * seed * (x - y)
         let rhsGrad = -lhsGrad
@@ -1333,16 +1403,17 @@ internal func _vjpSquaredDifference<T: TensorFlowFloatingPoint>(
 /// Returns the element-wise maximum of two tensors.
 /// - Note: `max` supports broadcasting.
 @inlinable
-@differentiable(vjp: _vjpMax(_:_:) where T: TensorFlowFloatingPoint)
+@differentiable(where T: TensorFlowFloatingPoint)
 public func max<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T> where T: Numeric & Comparable {
     _Raw.maximum(lhs, rhs)
 }
 
 @inlinable
+@derivative(of: max)
 internal func _vjpMax<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>,
     _ y: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> (Tensor<T>, Tensor<T>)) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> (Tensor<T>, Tensor<T>)) {
     let value = max(x, y)
     return (value, { v in
         _vjpMinMaxHelper(x, y, originalValue: value, seed: v, comparisonOperation: .>=)
@@ -1366,16 +1437,17 @@ public func max<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T> where T: Numeric & C
 /// Returns the element-wise minimum of two tensors.
 /// - Note: `min` supports broadcasting.
 @inlinable
-@differentiable(vjp: _vjpMin(_:_:) where T: TensorFlowFloatingPoint)
+@differentiable(where T: TensorFlowFloatingPoint)
 public func min<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T> where T: Numeric & Comparable {
     _Raw.minimum(lhs, rhs)
 }
 
 @inlinable
+@derivative(of: min)
 internal func _vjpMin<T: TensorFlowFloatingPoint>(
     _ x: Tensor<T>,
     _ y: Tensor<T>
-) -> (Tensor<T>, (Tensor<T>) -> (Tensor<T>, Tensor<T>)) {
+) -> (value: Tensor<T>, pullback: (Tensor<T>) -> (Tensor<T>, Tensor<T>)) {
     let value = min(x, y)
     return (value, { v in
         _vjpMinMaxHelper(x, y, originalValue: value, seed: v, comparisonOperation: .<=)
@@ -1405,7 +1477,7 @@ internal func _vjpMinMaxHelper<T: TensorFlowFloatingPoint>(
     originalValue: Tensor<T>,
     seed: Tensor<T>,
     comparisonOperation: (Tensor<T>, Tensor<T>) -> Tensor<Bool>
-) -> (Tensor<T>, Tensor<T>) {
+) -> (value: Tensor<T>, pullback: Tensor<T>) {
     let mask = Tensor<T>(comparisonOperation(x, y))
     let lhsGrad = seed * mask
     let rhsGrad = seed * (1 - mask)
@@ -1448,7 +1520,7 @@ public extension Tensor {
     ///   must be either have the same shape as `self` or be a 1-D `Tensor` such
     ///   that `mask.scalarCount == self.shape[0]`.
     @inlinable
-    @differentiable(wrt: (self, other), vjp: _vjpReplacing where Scalar: TensorFlowFloatingPoint)
+    @differentiable(wrt: (self, other) where Scalar: TensorFlowFloatingPoint)
     func replacing(with other: Tensor, where mask: Tensor<Bool>) -> Tensor {
         _Raw.select(condition: mask, t: other, e: self)
     }
@@ -1456,10 +1528,11 @@ public extension Tensor {
 
 internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
+    @derivative(of: replacing)
     func _vjpReplacing(
         with other: Tensor,
         where mask: Tensor<Bool>
-    ) -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
+    ) -> (value: Tensor, pullback: (Tensor) -> (Tensor, Tensor)) {
         return (replacing(with: other, where: mask), { v in
             let zeros = Tensor(zeros: v.shape)
             return (v.replacing(with: zeros, where: mask), zeros.replacing(with: v, where: mask))
@@ -1554,9 +1627,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
     /// - Parameter axes: The dimensions to reduce.
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
-    @differentiable(
-        wrt: self,
-        vjp: _vjpMax(squeezingAxes:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func max(squeezingAxes axes: Tensor<Int32>) -> Tensor {
         return _Raw.max(self, reductionIndices: axes, keepDims: false)
     }
@@ -1585,9 +1656,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
     /// - Parameter axes: The dimensions to reduce.
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
-    @differentiable(
-        wrt: self,
-        vjp: _vjpMin(squeezingAxes:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func min(squeezingAxes axes: Tensor<Int32>) -> Tensor {
         _Raw.min(self, reductionIndices: axes, keepDims: false)
     }
@@ -1635,7 +1704,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
     /// - Parameter axes: The dimensions to reduce.
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
-    @differentiable(wrt: self, vjp: _vjpMin(alongAxes:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func min(alongAxes axes: Tensor<Int32>) -> Tensor {
         _Raw.min(self, reductionIndices: axes, keepDims: true)
     }
@@ -1667,7 +1736,7 @@ public extension Tensor where Scalar: Numeric & Comparable {
     /// - Parameter axes: The dimensions to reduce.
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
-    @differentiable(wrt: self, vjp: _vjpMax(alongAxes:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func max(alongAxes axes: Tensor<Int32>) -> Tensor {
         _Raw.max(self, reductionIndices: axes, keepDims: true)
     }
@@ -1729,7 +1798,10 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     }
 
     @inlinable
-    func _vjpMax(squeezingAxes axes: Tensor<Int32>) -> (Tensor, (Tensor) -> Tensor) {
+    @derivative(of: max(squeezingAxes:))
+    func _vjpMax(squeezingAxes axes: Tensor<Int32>) -> (
+        value: Tensor, pullback: (Tensor) -> Tensor
+    ) {
         let result = max(squeezingAxes: axes)
         return (result, { v in
             self._vjpMinMaxHelper(squeezingAxes: axes, originalValue: result, seed: v)
@@ -1737,7 +1809,10 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     }
 
     @inlinable
-    func _vjpMin(squeezingAxes axes: Tensor<Int32>) -> (Tensor, (Tensor) -> Tensor) {
+    @derivative(of: min(squeezingAxes:))
+    func _vjpMin(squeezingAxes axes: Tensor<Int32>) -> (
+        value: Tensor, pullback: (Tensor) -> Tensor
+    ) {
         let result = min(squeezingAxes: axes)
         return (result, { v in
             self._vjpMinMaxHelper(squeezingAxes: axes, originalValue: result, seed: v)
@@ -1761,7 +1836,8 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     }
 
     @inlinable
-    func _vjpMax(alongAxes axes: Tensor<Int32>) -> (Tensor, (Tensor) -> Tensor) {
+    @derivative(of: max(alongAxes:))
+    func _vjpMax(alongAxes axes: Tensor<Int32>) -> (value: Tensor, pullback: (Tensor) -> Tensor) {
         let result = max(alongAxes: axes)
         return (result, { v in
             self._vjpMinMaxHelper(alongAxes: axes, originalValue: result, seed: v)
@@ -1769,7 +1845,8 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     }
 
     @inlinable
-    func _vjpMin(alongAxes axes: Tensor<Int32>) -> (Tensor, (Tensor) -> Tensor) {
+    @derivative(of: min(alongAxes:))
+    func _vjpMin(alongAxes axes: Tensor<Int32>) -> (value: Tensor, pullback: (Tensor) -> Tensor) {
         let result = min(alongAxes: axes)
         return (result, { v in
             self._vjpMinMaxHelper(alongAxes: axes, originalValue: result, seed: v)
@@ -1786,7 +1863,7 @@ public extension Tensor where Scalar: Numeric {
     /// - Parameter axes: The dimensions to reduce.
     /// - Precondition: Each value in `axes` must be in the range `-rank...rank`.
     @inlinable
-    @differentiable(wrt: self, vjp: _vjpSum(squeezingAxes:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func sum(squeezingAxes axes: Tensor<Int32>) -> Tensor {
         _Raw.sum(self, reductionIndices: axes, keepDims: false)
     }
@@ -1821,7 +1898,7 @@ public extension Tensor where Scalar: Numeric {
     /// - Parameter axes: The dimensions to reduce.
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
-    @differentiable(wrt: self, vjp: _vjpSum(alongAxes:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func sum(alongAxes axes: Tensor<Int32>) -> Tensor {
         _Raw.sum(self, reductionIndices: axes, keepDims: true)
     }
@@ -1853,7 +1930,7 @@ public extension Tensor where Scalar: Numeric {
     /// - Parameter axes: The dimensions to reduce.
     /// - Precondition: Each value in `axes` must be in the range `-rank...rank`.
     @inlinable
-    @differentiable(wrt: self, vjp: _vjpProduct(squeezingAxes:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func product(squeezingAxes axes: Tensor<Int32>) -> Tensor {
         _Raw.prod(self, reductionIndices: axes, keepDims: false)
     }
@@ -1921,7 +1998,7 @@ public extension Tensor where Scalar: Numeric {
     /// - Parameter axes: The dimensions to reduce.
     /// - Precondition: Each value in `axes` must be in the range `-rank...rank`.
     @inlinable
-    @differentiable(wrt: self, vjp: _vjpMean(squeezingAxes:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func mean(squeezingAxes axes: Tensor<Int32>) -> Tensor {
         _Raw.mean(self, reductionIndices: axes, keepDims: false)
     }
@@ -1930,7 +2007,7 @@ public extension Tensor where Scalar: Numeric {
     /// - Parameter axes: The dimensions to reduce.
     /// - Precondition: Each value in `axes` must be in the range `-rank...rank`.
     @inlinable
-    @differentiable(wrt: self, vjp: _vjpMean(squeezingAxes:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func mean(squeezingAxes axes: [Int]) -> Tensor {
         // TODO(TF-433): Remove workaround for differentiating `map`.
         let axes = {axes.map(Int32.init)}()
@@ -1957,7 +2034,7 @@ public extension Tensor where Scalar: Numeric {
     /// - Parameter axes: The dimensions to reduce.
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
-    @differentiable(wrt: self, vjp: _vjpMean(alongAxes:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func mean(alongAxes axes: Tensor<Int32>) -> Tensor {
         _Raw.mean(self, reductionIndices: axes, keepDims: true)
     }
@@ -1967,7 +2044,7 @@ public extension Tensor where Scalar: Numeric {
     /// - Parameter axes: The dimensions to reduce.
     /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
     @inlinable
-    @differentiable(wrt: self, vjp: _vjpMean(alongAxes:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func mean(alongAxes axes: [Int]) -> Tensor {
         // TODO(TF-433): Remove workaround for differentiating `map`.
         let axes = {axes.map(Int32.init)}()
@@ -2125,7 +2202,7 @@ public extension Tensor where Scalar: Numeric {
     /// - Precondition: `axis.rank` must be `0`.
     /// - Precondition: `axis` must be in the range `-rank..<rank`.
     @inlinable
-    @differentiable(wrt: self, vjp: _vjpCumulativeSum where Scalar: TensorFlowFloatingPoint)
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func cumulativeSum(
         alongAxis axis: Tensor<Int32>,
         exclusive: Bool = false,
@@ -2198,7 +2275,7 @@ public extension Tensor where Scalar: Numeric {
     /// - Returns: Result of the cumulative product operation.
     /// - Precondition: `axis` must be in the range `-rank..<rank`.
     @inlinable
-    @differentiable(wrt: self, vjp: _vjpCumulativeProduct where Scalar: TensorFlowFloatingPoint)
+    @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func cumulativeProduct(
         alongAxis axis: Tensor<Int32>,
         exclusive: Bool = false,
@@ -2210,13 +2287,17 @@ public extension Tensor where Scalar: Numeric {
 
 internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     @inlinable
-    func _vjpSum(alongAxes axes: Tensor<Int32>) -> (Tensor, (Tensor) -> Tensor) {
+    @derivative(of: sum(alongAxes:))
+    func _vjpSum(alongAxes axes: Tensor<Int32>) -> (value: Tensor, pullback: (Tensor) -> Tensor) {
         let value = sum(alongAxes: axes)
         return (value, { [shape = shapeTensor] in $0.broadcasted(toShape: shape) })
     }
 
     @inlinable
-    func _vjpSum(squeezingAxes axes: Tensor<Int32>) -> (Tensor, (Tensor) -> Tensor) {
+    @derivative(of: sum(squeezingAxes:))
+    func _vjpSum(squeezingAxes axes: Tensor<Int32>) -> (
+        value: Tensor, pullback: (Tensor) -> Tensor
+    ) {
         let value = sum(squeezingAxes: axes)
         return (value, { [shape = shapeTensor] v in
             let unsqueezed = v.expandingShape(at: axes.scalars.map { Int($0) })
@@ -2225,14 +2306,18 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     }
 
     @inlinable
-    func _vjpMean(alongAxes axes: Tensor<Int32>) -> (Tensor, (Tensor) -> Tensor) {
+    @derivative(of: mean(alongAxes:))
+    func _vjpMean(alongAxes axes: Tensor<Int32>) -> (value: Tensor, pullback: (Tensor) -> Tensor) {
         let value = mean(alongAxes: axes)
         let count = _Raw.gather(params: shapeTensor, indices: axes).product()
         return (value, { [shape = shapeTensor] in $0.broadcasted(toShape: shape) / Tensor(count) })
     }
 
     @inlinable
-    func _vjpMean(squeezingAxes axes: Tensor<Int32>) -> (Tensor, (Tensor) -> Tensor) {
+    @derivative(of: mean(squeezingAxes:))
+    func _vjpMean(squeezingAxes axes: Tensor<Int32>) -> (
+        value: Tensor, pullback: (Tensor) -> Tensor
+    ) {
         let value = mean(squeezingAxes: axes)
         let count = _Raw.gather(params: shapeTensor, indices: axes).product()
         return (value, { [shape = shapeTensor] v in
@@ -2244,7 +2329,8 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     // Specialization to avoid _Raw.gather on shapes when axes is known to be
     // [Int].
     @inlinable
-    func _vjpMean(alongAxes axes: [Int]) -> (Tensor, (Tensor) -> Tensor) {
+    @derivative(of: mean(alongAxes:))
+    func _vjpMean(alongAxes axes: [Int]) -> (value: Tensor, pullback: (Tensor) -> Tensor) {
         let value = mean(alongAxes: axes)
         // Cache shape because it is a computed property.
         let cachedShape = shape
@@ -2255,7 +2341,8 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     // Specialization to avoid _Raw.gather on shapes when axes is known to be
     // [Int].
     @inlinable
-    func _vjpMean(squeezingAxes axes: [Int]) -> (Tensor, (Tensor) -> Tensor) {
+    @derivative(of: mean(squeezingAxes:))
+    func _vjpMean(squeezingAxes axes: [Int]) -> (value: Tensor, pullback: (Tensor) -> Tensor) {
         let value = mean(squeezingAxes: axes)
         // Cache shape because it is a computed property.
         let cachedShape = shape
@@ -2267,22 +2354,24 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     }
 
     @inlinable
+    @derivative(of: cumulativeSum)
     func _vjpCumulativeSum(
         alongAxis axis: Tensor<Int32>,
         exclusive: Bool = false,
         reverse: Bool = false
-    ) -> (Tensor, (Tensor) -> Tensor) {
+    ) -> (value: Tensor, pullback: (Tensor) -> Tensor) {
         (cumulativeSum(alongAxis: axis, exclusive: exclusive, reverse: reverse), { v in
             v.cumulativeSum(alongAxis: axis, exclusive: exclusive, reverse: !reverse)
         })
     }
 
     @inlinable
+    @derivative(of: cumulativeProduct)
     func _vjpCumulativeProduct(
         alongAxis axis: Tensor<Int32>,
         exclusive: Bool = false,
         reverse: Bool = false
-    ) -> (Tensor, (Tensor) -> Tensor) {
+    ) -> (value: Tensor, pullback: (Tensor) -> Tensor) {
         let result = cumulativeProduct(alongAxis: axis, exclusive: exclusive, reverse: reverse)
         return (result, { v in
             (result * v).cumulativeSum(
@@ -2296,7 +2385,10 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     // Adapted from `_ProdGrad` in Python TensorFlow:
     // https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/math_grad.py
     @inlinable
-    func _vjpProduct(squeezingAxes axes: Tensor<Int32>) -> (Tensor, (Tensor) -> Tensor) {
+    @derivative(of: product(squeezingAxes:))
+    func _vjpProduct(squeezingAxes axes: Tensor<Int32>) -> (
+        value: Tensor, pullback: (Tensor) -> Tensor
+    ) {
         // The gradient can be expressed by dividing the product by each entry of the
         // input tensor, but this approach can't deal with zeros in the input.
         // Here, we avoid this problem by composing the output as a product of two
@@ -2649,7 +2741,7 @@ public extension Tensor where Scalar: TensorFlowFloatingPoint {
 
 /// Performs matrix multiplication with another tensor and produces the result.
 @inlinable
-@differentiable(vjp: _vjpMatmul(_:transposed:_:transposed:) where Scalar: TensorFlowFloatingPoint)
+@differentiable(where Scalar: TensorFlowFloatingPoint)
 public func matmul<Scalar: Numeric>(
     _ lhs: Tensor<Scalar>,
     transposed transposeLhs: Bool = false,
@@ -2664,12 +2756,13 @@ public func matmul<Scalar: Numeric>(
 }
 
 @inlinable
+@derivative(of: matmul)
 internal func _vjpMatmul<Scalar: TensorFlowFloatingPoint>(
     _ lhs: Tensor<Scalar>,
     transposed transposeLhs: Bool = false,
     _ rhs: Tensor<Scalar>,
     transposed transposeRhs: Bool = false
-) -> (Tensor<Scalar>, (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
+) -> (value: Tensor<Scalar>, pullback: (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
     let value = matmul(lhs, transposed: transposeLhs, rhs, transposed: transposeRhs)
     return (value, { [lhsShape = lhs.shape, rhsShape = rhs.shape] v in
         let (lhsGrad, rhsGrad): (Tensor<Scalar>, Tensor<Scalar>)
@@ -2702,26 +2795,10 @@ internal func _vjpMatmul<Scalar: TensorFlowFloatingPoint>(
 infix operator •: MultiplicationPrecedence
 
 public extension Tensor where Scalar: Numeric {
-    // TODO: We have to define a custom VJP on • because AD can't yet differentiate generic methods.
-    // After AD can differentiate generic methods, remove the custom VJP.
-
     /// Performs matrix multiplication between two tensors and produces the result.
     @inlinable
-    @differentiable(vjp: _vjpMatmulOperator(lhs:rhs:) where Scalar: TensorFlowFloatingPoint)
+    @differentiable(where Scalar: TensorFlowFloatingPoint)
     static func • (lhs: Tensor, rhs: Tensor) -> Tensor {
         matmul(lhs, rhs)
-    }
-}
-
-// TODO: We have to define a custom VJP on • because AD can't yet
-// differentiate generic methods. After AD can differentiate generic methods,
-// remove the custom VJP.
-internal extension Tensor where Scalar: TensorFlowFloatingPoint {
-    @inlinable
-    static func _vjpMatmulOperator(
-        lhs: Tensor,
-        rhs: Tensor
-    ) -> (Tensor, (Tensor) -> (Tensor, Tensor)) {
-        _vjpMatmul(lhs, rhs)
     }
 }

--- a/Sources/TensorFlow/Operators/NN.swift
+++ b/Sources/TensorFlow/Operators/NN.swift
@@ -111,7 +111,7 @@ public func conv1D<Scalar: TensorFlowFloatingPoint>(
 ///   - dilations: The dilation factor for each dimension of the input.
 /// - Precondition: `input` must have rank `4`.
 /// - Precondition: `filter` must have rank 4.
-@differentiable(wrt: (input, filter), vjp: _vjpConv2D)
+@differentiable(wrt: (input, filter))
 public func conv2D<Scalar: TensorFlowFloatingPoint>(
     _ input: Tensor<Scalar>,
     filter: Tensor<Scalar>,
@@ -132,13 +132,14 @@ public func conv2D<Scalar: TensorFlowFloatingPoint>(
 }
 
 @usableFromInline
+@derivative(of: conv2D)
 func _vjpConv2D<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
     filter: Tensor<Scalar>,
     strides: (Int, Int, Int, Int),
     padding: Padding,
     dilations: (Int, Int, Int, Int)
-) -> (Tensor<Scalar>, (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
+) -> (value: Tensor<Scalar>, pullback: (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
     let value = conv2D(x, filter: filter, strides: strides, padding: padding, dilations: dilations)
     return (value, { v in
         (conv2DBackpropInput(v, shape: x.shapeTensor, filter: filter,
@@ -149,7 +150,7 @@ func _vjpConv2D<Scalar: TensorFlowFloatingPoint>(
 }
 
 /// TensorFlow builtin conv2d gradient helper for the input.
-@differentiable(wrt: (x, filter), vjp: _vjpConv2DBackpropInput)
+@differentiable(wrt: (x, filter))
 @usableFromInline
 func conv2DBackpropInput<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
@@ -170,6 +171,7 @@ func conv2DBackpropInput<Scalar: TensorFlowFloatingPoint>(
 }
 
 @usableFromInline
+@derivative(of: conv2DBackpropInput)
 func _vjpConv2DBackpropInput<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
     _ shape: Tensor<Int32>,
@@ -177,7 +179,7 @@ func _vjpConv2DBackpropInput<Scalar: TensorFlowFloatingPoint>(
     _ strides: (Int, Int, Int, Int),
     _ padding: Padding,
     _ dilations: (Int, Int, Int, Int)
-) -> (Tensor<Scalar>, (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
+) -> (value: Tensor<Scalar>, pullback: (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
     let value = conv2DBackpropInput(x, shape: shape, filter: filter,
                                     strides: strides, padding: padding, dilations: dilations)
     return (value, { v in
@@ -188,7 +190,7 @@ func _vjpConv2DBackpropInput<Scalar: TensorFlowFloatingPoint>(
 }
 
 /// TensorFlow builtin conv2d gradient helper for the filter.
-@differentiable(wrt: (x, input), vjp: _vjpConv2DBackpropFilter)
+@differentiable(wrt: (x, input))
 @usableFromInline
 func conv2DBackpropFilter<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
@@ -209,6 +211,7 @@ func conv2DBackpropFilter<Scalar: TensorFlowFloatingPoint>(
 }
 
 @usableFromInline
+@derivative(of: conv2DBackpropFilter)
 func _vjpConv2DBackpropFilter<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
     _ input: Tensor<Scalar>,
@@ -216,7 +219,7 @@ func _vjpConv2DBackpropFilter<Scalar: TensorFlowFloatingPoint>(
     _ strides: (Int, Int, Int, Int),
     _ padding: Padding,
     _ dilations: (Int, Int, Int, Int)
-) -> (Tensor<Scalar>, (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
+) -> (value: Tensor<Scalar>, pullback: (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
     let value = conv2DBackpropFilter(x, input: input, filterSizes: filterSizes,
                                      strides: strides, padding: padding, dilations: dilations)
     return (value, { v in
@@ -236,7 +239,7 @@ func _vjpConv2DBackpropFilter<Scalar: TensorFlowFloatingPoint>(
 ///   - dilations: The dilation factor for each dimension of the input.
 /// - Precondition: `input` must have rank `5`.
 /// - Precondition: `filter` must have rank 5.
-@differentiable(wrt: (input, filter), vjp: _vjpConv3D)
+@differentiable(wrt: (input, filter))
 public func conv3D<Scalar: TensorFlowFloatingPoint>(
     _ input: Tensor<Scalar>,
     filter: Tensor<Scalar>,
@@ -258,13 +261,14 @@ public func conv3D<Scalar: TensorFlowFloatingPoint>(
 }
 
 @usableFromInline
+@derivative(of: conv3D)
 func _vjpConv3D<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
     filter: Tensor<Scalar>,
     strides: (Int, Int, Int, Int, Int),
     padding: Padding,
     dilations: (Int, Int, Int, Int, Int)
-) -> (Tensor<Scalar>, (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
+) -> (value: Tensor<Scalar>, pullback: (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
     let value = conv3D(x, filter: filter, strides: strides,
                        padding: padding, dilations: dilations)
     return (value, { v in
@@ -276,7 +280,7 @@ func _vjpConv3D<Scalar: TensorFlowFloatingPoint>(
 }
 
 /// TensorFlow builtin conv3d gradient helper for the input.
-@differentiable(wrt: (x, filter), vjp: _vjpConv3DBackpropInput)
+@differentiable(wrt: (x, filter))
 @usableFromInline
 func conv3DBackpropInput<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
@@ -299,6 +303,7 @@ func conv3DBackpropInput<Scalar: TensorFlowFloatingPoint>(
 }
 
 @usableFromInline
+@derivative(of: conv3DBackpropInput)
 func _vjpConv3DBackpropInput<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
     _ shape: Tensor<Int32>,
@@ -306,7 +311,7 @@ func _vjpConv3DBackpropInput<Scalar: TensorFlowFloatingPoint>(
     _ strides: (Int, Int, Int, Int, Int),
     _ padding: Padding,
     _ dilations: (Int, Int, Int, Int, Int)
-) -> (Tensor<Scalar>, (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
+) -> (value: Tensor<Scalar>, pullback: (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
     let value = conv3DBackpropInput(x, shape: shape, filter: filter, strides: strides,
                                     padding: padding, dilations: dilations)
     return (value, { v in
@@ -317,7 +322,7 @@ func _vjpConv3DBackpropInput<Scalar: TensorFlowFloatingPoint>(
 }
 
 /// TensorFlow builtin conv3d gradient helper for the filter.
-@differentiable(wrt: (x, input), vjp: _vjpConv3DBackpropFilter)
+@differentiable(wrt: (x, input))
 @usableFromInline
 func conv3DBackpropFilter<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
@@ -340,6 +345,7 @@ func conv3DBackpropFilter<Scalar: TensorFlowFloatingPoint>(
 }
 
 @usableFromInline
+@derivative(of: conv3DBackpropFilter)
 func _vjpConv3DBackpropFilter<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
     _ input: Tensor<Scalar>,
@@ -347,7 +353,7 @@ func _vjpConv3DBackpropFilter<Scalar: TensorFlowFloatingPoint>(
     _ strides: (Int, Int, Int, Int, Int),
     _ padding: Padding,
     _ dilations: (Int, Int, Int, Int, Int)
-) -> (Tensor<Scalar>, (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
+) -> (value: Tensor<Scalar>, pullback: (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
     let value = conv3DBackpropFilter(x, input: input, filterSizes: filterSizes,
                                      strides: strides, padding: padding, dilations: dilations)
     return (value, { v in
@@ -366,7 +372,7 @@ func _vjpConv3DBackpropFilter<Scalar: TensorFlowFloatingPoint>(
 ///   - padding: The padding for the operation.
 /// - Precondition: `input` must have rank 4.
 /// - Precondition: `filter` must have rank 4.
-@differentiable(wrt: (input, filter), vjp: _vjpDepthwiseConv2D)
+@differentiable(wrt: (input, filter))
 public func depthwiseConv2D<Scalar: TensorFlowFloatingPoint>(
     _ input: Tensor<Scalar>,
     filter: Tensor<Scalar>,
@@ -383,12 +389,13 @@ public func depthwiseConv2D<Scalar: TensorFlowFloatingPoint>(
 }
 
 @usableFromInline
+@derivative(of: depthwiseConv2D)
 func _vjpDepthwiseConv2D<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
     filter: Tensor<Scalar>,
     strides: (Int, Int, Int, Int),
     padding: Padding
-) -> (Tensor<Scalar>, (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
+) -> (value: Tensor<Scalar>, pullback: (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
     let value = depthwiseConv2D(x, filter: filter, strides: strides,
                                 padding: padding)
     return (value, { v in
@@ -400,7 +407,7 @@ func _vjpDepthwiseConv2D<Scalar: TensorFlowFloatingPoint>(
 }
 
 /// TensorFlow builtin depthwiseConv2D gradient helper for the input.
-@differentiable(wrt: (x, filter), vjp: _vjpDepthwiseConv2dBackpropInput)
+@differentiable(wrt: (x, filter))
 @usableFromInline
 func depthwiseConv2dBackpropInput<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
@@ -418,13 +425,14 @@ func depthwiseConv2dBackpropInput<Scalar: TensorFlowFloatingPoint>(
 }
 
 @usableFromInline
+@derivative(of: depthwiseConv2dBackpropInput)
 func _vjpDepthwiseConv2dBackpropInput<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
     _ shape: Tensor<Int32>,
     _ filter: Tensor<Scalar>,
     _ strides: (Int, Int, Int, Int),
     _ padding: Padding
-) -> (Tensor<Scalar>, (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
+) -> (value: Tensor<Scalar>, pullback: (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
     let value = depthwiseConv2dBackpropInput(x, shape: shape, filter: filter, strides: strides,
                                              padding: padding)
     return (value, { v in
@@ -436,7 +444,7 @@ func _vjpDepthwiseConv2dBackpropInput<Scalar: TensorFlowFloatingPoint>(
 }
 
 /// TensorFlow builtin depthwiseConv2D gradient helper for the filter.
-@differentiable(wrt: (x, input), vjp: _vjpDepthwiseConv2dBackpropFilter)
+@differentiable(wrt: (x, input))
 @usableFromInline
 func depthwiseConv2dBackpropFilter<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
@@ -454,13 +462,14 @@ func depthwiseConv2dBackpropFilter<Scalar: TensorFlowFloatingPoint>(
 }
 
 @usableFromInline
+@derivative(of: depthwiseConv2dBackpropFilter)
 func _vjpDepthwiseConv2dBackpropFilter<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
     _ input: Tensor<Scalar>,
     _ filterSizes: Tensor<Int32>,
     _ strides: (Int, Int, Int, Int),
     _ padding: Padding
-) -> (Tensor<Scalar>, (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
+) -> (value: Tensor<Scalar>, pullback: (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {
     let value = depthwiseConv2dBackpropFilter(x, input: input, filterSizes: filterSizes,
                                               strides: strides, padding: padding)
     return (value, { v in
@@ -478,7 +487,7 @@ func _vjpDepthwiseConv2dBackpropFilter<Scalar: TensorFlowFloatingPoint>(
 ///   - filterSize: The dimensions of the pooling kernel.
 ///   - strides: The strides of the sliding filter for each dimension of the input.
 ///   - padding: The padding for the operation.
-@differentiable(wrt: input, vjp: _vjpMaxPool2D)
+@differentiable(wrt: input)
 public func maxPool2D<Scalar: TensorFlowFloatingPoint>(
     _ input: Tensor<Scalar>,
     filterSize: (Int, Int, Int, Int),
@@ -495,12 +504,13 @@ public func maxPool2D<Scalar: TensorFlowFloatingPoint>(
 }
 
 @usableFromInline
+@derivative(of: maxPool2D)
 func _vjpMaxPool2D<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
     filterSize: (Int, Int, Int, Int),
     strides: (Int, Int, Int, Int),
     padding: Padding
-) -> (Tensor<Scalar>, (Tensor<Scalar>) -> Tensor<Scalar>) {
+) -> (value: Tensor<Scalar>, pullback: (Tensor<Scalar>) -> Tensor<Scalar>) {
     // TODO: Currently this is not higher order differentiable. Redefine in
     // closed form.
     let value = maxPool2D(x, filterSize: filterSize, strides: strides, padding: padding)
@@ -525,7 +535,7 @@ func _vjpMaxPool2D<Scalar: TensorFlowFloatingPoint>(
 ///   - filterSize: The dimensions of the pooling kernel.
 ///   - strides: The strides of the sliding filter for each dimension of the input.
 ///   - padding: The padding for the operation.
-@differentiable(wrt: input, vjp: _vjpMaxPool3D)
+@differentiable(wrt: input)
 public func maxPool3D<Scalar: TensorFlowFloatingPoint>(
     _ input: Tensor<Scalar>,
     filterSize: (Int, Int, Int, Int, Int),
@@ -542,12 +552,13 @@ public func maxPool3D<Scalar: TensorFlowFloatingPoint>(
 }
 
 @usableFromInline
+@derivative(of: maxPool3D)
 func _vjpMaxPool3D<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
     filterSize: (Int, Int, Int, Int, Int),
     strides: (Int, Int, Int, Int, Int),
     padding: Padding
-) -> (Tensor<Scalar>, (Tensor<Scalar>) -> Tensor<Scalar>) {
+) -> (value: Tensor<Scalar>, pullback: (Tensor<Scalar>) -> Tensor<Scalar>) {
     // TODO: Currently this is not higher order differentiable. Redefine in
     // closed form.
     let value = maxPool3D(x, filterSize: filterSize, strides: strides, padding: padding)
@@ -573,7 +584,7 @@ func _vjpMaxPool3D<Scalar: TensorFlowFloatingPoint>(
 ///   - filterSize: The dimensions of the pooling kernel.
 ///   - strides: The strides of the sliding filter for each dimension of the input.
 ///   - padding: The padding for the operation.
-@differentiable(wrt: input, vjp: _vjpAvgPool2D)
+@differentiable(wrt: input)
 public func avgPool2D<Scalar: TensorFlowFloatingPoint>(
     _ input: Tensor<Scalar>,
     filterSize: (Int, Int, Int, Int),
@@ -589,12 +600,13 @@ public func avgPool2D<Scalar: TensorFlowFloatingPoint>(
 }
 
 @usableFromInline
+@derivative(of: avgPool2D)
 func _vjpAvgPool2D<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
     filterSize: (Int, Int, Int, Int),
     strides: (Int, Int, Int, Int),
     padding: Padding
-) -> (Tensor<Scalar>, (Tensor<Scalar>) -> Tensor<Scalar>) {
+) -> (value: Tensor<Scalar>, pullback: (Tensor<Scalar>) -> Tensor<Scalar>) {
     // TODO: Currently this is not higher order differentiable. Redefine in
     // closed form.
     let value = avgPool2D(x, filterSize: filterSize, strides: strides, padding: padding)
@@ -619,7 +631,7 @@ func _vjpAvgPool2D<Scalar: TensorFlowFloatingPoint>(
 ///   - filterSize: The dimensions of the pooling kernel.
 ///   - strides: The strides of the sliding filter for each dimension of the input.
 ///   - padding: The padding for the operation.
-@differentiable(wrt: input, vjp: _vjpAvgPool3D)
+@differentiable(wrt: input)
 public func avgPool3D<Scalar: TensorFlowFloatingPoint>(
     _ input: Tensor<Scalar>,
     filterSize: (Int, Int, Int, Int, Int),
@@ -636,12 +648,13 @@ public func avgPool3D<Scalar: TensorFlowFloatingPoint>(
 }
 
 @usableFromInline
+@derivative(of: avgPool3D)
 func _vjpAvgPool3D<Scalar: TensorFlowFloatingPoint>(
     _ x: Tensor<Scalar>,
     filterSize: (Int, Int, Int, Int, Int),
     strides: (Int, Int, Int, Int, Int),
     padding: Padding
-) -> (Tensor<Scalar>, (Tensor<Scalar>) -> Tensor<Scalar>) {
+) -> (value: Tensor<Scalar>, pullback: (Tensor<Scalar>) -> Tensor<Scalar>) {
     // TODO: Currently this is not higher order differentiable. Redefine in
     // closed form.
     let value = avgPool3D(x, filterSize: filterSize, strides: strides, padding: padding)

--- a/Tests/TensorFlowTests/TensorAutoDiffTests.swift
+++ b/Tests/TensorFlowTests/TensorAutoDiffTests.swift
@@ -17,14 +17,6 @@ import XCTest
 
 let cube: @differentiable (Tensor<Float>) -> Tensor<Float> = { ($0 * $0 * $0) }
 
-@differentiable(vjp: vjpFoo)
-func foo(_ x: Tensor<Float>) -> Tensor<Float> {
-    return _Raw.identity(x)
-}
-func vjpFoo(_ x: Tensor<Float>) -> (Tensor<Float>, (Tensor<Float>) -> Tensor<Float>) {
-    return (foo(x), { v in v })
-}
-
 final class TensorAutoDiffTests: XCTestCase {
     func testSimpleGrad() {
         func square(_ x: Tensor<Float>) -> Tensor<Float> {
@@ -575,16 +567,6 @@ final class TensorAutoDiffTests: XCTestCase {
         XCTAssertEqual(pb(Tensor(ones: [3, 3])), Tensor(repeating: 5.9604645e-08, shape: [3, 3]))
     }
 
-    // SR-9345
-    func testOwnedCheckpoints() {
-        func body(_ x: Tensor<Float>) -> Tensor<Float> {
-            return foo(foo(x))
-        }
-
-        let pb = pullback(at: Tensor(Float(10)), in: body)
-        XCTAssertEqual(Tensor(1), pb(Tensor(1)))
-    }
-
     // SR-9804
     func testADRefcounting() {
         func f(_ x: Tensor<Float>) -> Tensor<Float> {
@@ -818,7 +800,6 @@ final class TensorAutoDiffTests: XCTestCase {
         ("testRelu", testRelu),
         ("testSoftmax", testSoftmax),
         ("testLogSoftmax", testLogSoftmax),
-        ("testOwnedCheckpoints", testOwnedCheckpoints),
         ("testADRefcounting", testADRefcounting),
         ("testDifferentiateGlobal", testDifferentiateGlobal),
         ("testSideEffects", testSideEffects),


### PR DESCRIPTION
Rewrite all derivative registration using `@differentiable(jvp:vjp:)` with
`@derivative`. This has no functional impact.

Keep original `@differentiable` attributes so that derivative functions are
publicly exposed.

When [retroactive derivative registration]() is complete:
- `@differentiable(jvp:vjp:)` will be deprecated.
- `@derivative` attribute will be the canonical way to register derivatives.

Resolves TF-1076.

---

No remaining uses of `@differentiable(vjp:)` for derivative registration:
```console
$ grep -nr "vjp:" *
# No remaining uses.
```

---

Example:

```swift
// Before: `@differentiable(vjp:)`.
extension Tensor where Scalar: Numeric {
    @differentiable(vjp: _vjpAdd where Scalar: TensorFlowFloatingPoint)
    public static func + (lhs: Tensor, rhs: Tensor) -> Tensor { ... }
}

extension Tensor where Scalar: TensorFlowFloatingPoint {
    @inlinable
    static func _vjpAdd(lhs: Tensor, rhs: Tensor) -> (
        value: Tensor, pullback: (Tensor) -> (Tensor, Tensor)
    ) { ... }
}
```

```swift
// After: `@derivative`.
extension Tensor where Scalar: Numeric {
    @differentiable(where Scalar: TensorFlowFloatingPoint)
    public static func + (lhs: Tensor, rhs: Tensor) -> Tensor { ... }
}

extension Tensor where Scalar: TensorFlowFloatingPoint {
    @inlinable
    @derivative(of: +)
    static func _vjpAdd(lhs: Tensor, rhs: Tensor) -> (
        value: Tensor, pullback: (Tensor) -> (Tensor, Tensor)
    ) { ... }
}
```