### PR TITLE
Change variance implementations

### DIFF
--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -2070,7 +2070,7 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func variance(squeezingAxes axes: Tensor<Int32>) -> Tensor {
-        let squaredDiff = (self - mean(alongAxes: axes)).squared()
+        let squaredDiff = squaredDifference(self, mean(alongAxes: axes))
         return squaredDiff.mean(squeezingAxes: axes)
     }
 
@@ -2100,7 +2100,7 @@ public extension Tensor where Scalar: Numeric {
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func variance() -> Tensor {
         let mean = self.mean()
-        let squaredDiff = (self - mean).squared()
+        let squaredDiff = squaredDifference(self, mean)
         return squaredDiff.mean()
     }
 
@@ -2111,7 +2111,7 @@ public extension Tensor where Scalar: Numeric {
     @inlinable
     @differentiable(wrt: self where Scalar: TensorFlowFloatingPoint)
     func variance(alongAxes axes: Tensor<Int32>) -> Tensor {
-        let squaredDiff = (self - mean(alongAxes: axes)).squared()
+        let squaredDiff = squaredDifference(self, mean(alongAxes: axes))
         return squaredDiff.mean(alongAxes: axes)
     }
 


### PR DESCRIPTION
There's small difference between [`variance`](https://github.com/tensorflow/swift-apis/blob/7330b8d7106489c906f85b92c8f5471f6959b10e/Sources/TensorFlow/Operators/Math.swift#L2072-L2075) and [variance of `moments`](https://github.com/tensorflow/swift-apis/blob/7330b8d7106489c906f85b92c8f5471f6959b10e/Sources/TensorFlow/Operators/Math.swift#L2660).
`squaredDifference` version is more efficient.