### PR TITLE
A scale layer for "mean network"

### DIFF
--- a/Tests/TensorFlowTests/ContextTests.swift
+++ b/Tests/TensorFlowTests/ContextTests.swift
@@ -32,6 +32,18 @@ final class ContextTests: XCTestCase {
         XCTAssertEqual(dropout(x), x)
     }
 
+    func testScale() {
+        let scale = Scale<Float>(by: 0.5)
+        let x = Tensor<Float>(repeating: 1.0, shape: [5])
+        let y = Tensor<Float>(repeating: 0.5, shape: [5])
+        withLearningPhase(LearningPhase.inference) {
+            XCTAssertEqual(scale(x), y)
+        }
+        withLearningPhase(LearningPhase.training) {
+            XCTAssertEqual(scale(x), x)
+        }
+    }
+
     func testMultithreadedDropout() {
         let dropout = Dropout<Float>(probability: 0.5)
         let x = Tensor<Float>(repeating: 1.0, shape: [5, 5])
@@ -51,6 +63,7 @@ final class ContextTests: XCTestCase {
 
     static var allTests = [
         ("testDropout", testDropout),
+        ("testScale", testScale),
         ("testMultithreadedDropout", testMultithreadedDropout)
     ]
 }


### PR DESCRIPTION
We already have a `Dropout` layer, but in the paper [Improving neural networks by preventingco-adaptation of feature detectors](https://arxiv.org/pdf/1207.0580.pdf) they mention `At test time, we use the “mean network” that contains all of the hidden units but with their outgoing  weights  halved  to  compensate  for  the  fact  that  twice  as  many  of  them  are  active.` But I did not find layer that could accomplish it. 

I am not sure about name of this layer and where to put it in source codes, so comments are welcome. 

Or perhaps layer like this is not wanted in swift-apis?