### PR TITLE
increase compilation benchmark timeout

### DIFF
--- a/Tools/benchmark_compile.py
+++ b/Tools/benchmark_compile.py
@@ -45,7 +45,7 @@ def execute_benchmark(test_case, cmd, timeout):
   return test_case
 
 
-def benchmark(test_case, cmd, timeout=300):
+def benchmark(test_case, cmd, timeout=600):
   with tempfile.TemporaryDirectory() as build_path:
     cmd += ['--build-path', build_path]
     return execute_benchmark(test_case, cmd, timeout)


### PR DESCRIPTION
Compilation has become so slow that it's timing out and we're not getting data on how long it actually takes.

Hopefully we'll be able to improve things soon and reduce the timeout once things are faster.