### PR TITLE
Runtime: correct a thread allocation leak

### DIFF
--- a/Sources/TensorFlow/Core/Runtime.swift
+++ b/Sources/TensorFlow/Core/Runtime.swift
@@ -524,9 +524,9 @@ class _ThreadLocalState {
         var key = pthread_key_t()
         pthread_key_create(&key) {
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-            let _: AnyObject = Unmanaged.fromOpaque($0).takeRetainedValue()
+            Unmanaged<AnyObject>.fromOpaque($0).release()
 #else
-            let _: AnyObject = Unmanaged.fromOpaque($0!).takeRetainedValue()
+            Unmanaged<AnyObject>.fromOpaque($0!).release()
 #endif
         }
         return key


### PR DESCRIPTION
`pthread_key_create` takes a destructor which is supposed to *release*
the resources associated with the key.  The code was accidentally
retaining the value instead, which would increment the reference count
before invalidating the key.  Release the value instead.