### PR TITLE
docs: clarify the CMake dependency version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,11 @@ $ swift test
 
 *Note: CMake support is experimental and under development.*
 
-CMake 3.15.1 or newer is required. In-tree builds are not supported.
+In-tree builds are not supported.  The instructions here expect CMake 3.16
+or newer, although the minimum required version is 3.15.1.  Older releases
+will not allow the use of the `-B` option to specific the build tree and
+require that you are in the location of the build tree (and the `-B` option
+and its argument are elided).
 
 If `swiftc` is not in your `PATH`, you must specify the path to it using
 `-D CMAKE_Swift_COMPILER=`.


### PR DESCRIPTION
The documented instructions rely on CMake 3.16 for the support for
specifying the build tree.  The older releases did not emit the file
output map in the correct location with the option specification.