### PR TITLE
build: adjust flags for inlining and partial specializations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,4 +8,7 @@ set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
 find_package(TensorFlow REQUIRED)
 
+add_compile_options($<$<COMPILE_LANGUAGE:Swift>:-Xllvm$<SEMICOLON>-sil-inline-generics>)
+add_compile_options($<$<COMPILE_LANGUAGE:Swift>:-Xllvm$<SEMICOLON>-sil-partial-specialization>)
+
 add_subdirectory(Sources)


### PR DESCRIPTION
This replicates some of the flags from the tensorflow branch of
apple/swift into the repository.  These control optimizations that we
would like to always enable.