### PR TITLE
build: fix the CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
 find_package(TensorFlow REQUIRED)
 
-add_compile_options($<$<COMPILE_LANGUAGE:Swift>:-Xllvm$<SEMICOLON>-sil-inline-generics>)
-add_compile_options($<$<COMPILE_LANGUAGE:Swift>:-Xllvm$<SEMICOLON>-sil-partial-specialization>)
+add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xllvm -sil-inline-generics>")
+add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xllvm -sil-partial-specialization>")
 
 add_subdirectory(Sources)


### PR DESCRIPTION
The `-Xllvm` option will be deduplicated by CMake.  We need to
explicitly perform shell escaping on the parameter to ensure that the
duplicate value is passed along.