### PR TITLE
TensorFlow: remove cancellation point handling

### DIFF
--- a/Sources/TensorFlow/Core/Runtime.swift
+++ b/Sources/TensorFlow/Core/Runtime.swift
@@ -406,10 +406,6 @@ internal extension _ExecutionContext {
         defer {
             let unlockStatus = mutex.release()
             internalConsistencyCheck(unlockStatus == 0)
-#if !os(Windows)
-            // Create a cancellation point.
-            pthread_testcancel()
-#endif
         }
         return try body()
     }

--- a/Sources/TensorFlow/Core/Threading.swift
+++ b/Sources/TensorFlow/Core/Threading.swift
@@ -113,9 +113,6 @@ class Thread {
         }, context, 0, nil)
 #else
         let status = pthread_create(&self.thread, nil, {
-            // Set the cancelability of the detached thread.
-            pthread_setcanceltype(Int32(PTHREAD_CANCEL_DEFERRED), nil)
-
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
             let procedure: Thread.Procedure =
                 Unmanaged.fromOpaque($0).takeRetainedValue()


### PR DESCRIPTION
The cancellation point handling is of questionable value.  Furthermore,
the concept is not portable to all platforms (e.g. Windows).  Until we
have a clear reason and proper abstraction for cancellation points,
remove them to make the paths more uniform.