### PR TITLE
TensorFlow: provide `setenv` on Windows

### DIFF
--- a/Sources/TensorFlow/Core/Runtime.swift
+++ b/Sources/TensorFlow/Core/Runtime.swift
@@ -39,6 +39,17 @@ import Glibc
 
 import CTensorFlow
 
+#if os(Windows)
+// NOTE(abdulras) although the function is racy, we do not really care as the
+// usage here is to not override the value if the user specified one before
+// creating the process.
+@discardableResult
+func setenv(_ variable: String, _ value: String, _ `override`: Int) -> Int {
+  guard `override` > 0 || getenv(variable) == nil else { return 0 }
+  return Int(_putenv_s(variable, value))
+}
+#endif
+
 /// The configuration for the compiler runtime.
 // TODO(hongm): Revisit the longer-term design.
 // @_frozen // SR-9739

--- a/Sources/TensorFlow/Core/Runtime.swift
+++ b/Sources/TensorFlow/Core/Runtime.swift
@@ -40,7 +40,7 @@ import Glibc
 import CTensorFlow
 
 #if os(Windows)
-// NOTE(abdulras) although the function is racy, we do not really care as the
+// NOTE: although the function is racy, we do not really care as the
 // usage here is to not override the value if the user specified one before
 // creating the process.
 @discardableResult


### PR DESCRIPTION
Windows does not have `setenv` but does provide `_putenv_s` for certain
environments.  This can allow us to emulate the `setenv` as this just
does not allow optional replacement.  Since this is used for IPC with
TensorFlow, providing a racy version is not a big deal.