### PR TITLE
[DNM] build: force strong symbol resolution

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,10 @@ let package = Package(
             dependencies: []),
         .target(
             name: "TensorFlow",
-            dependencies: ["Tensor"]),
+            dependencies: ["Tensor"],
+            linkerSettings: [
+              .unsafeFlags(["-z", "defs"], .when(platforms: [.linux])),
+            ]),
         .target(
             name: "Experimental",
             dependencies: [],

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
             name: "TensorFlow",
             dependencies: ["Tensor"],
             linkerSettings: [
-              .unsafeFlags(["-z", "defs"], .when(platforms: [.linux])),
+              .unsafeFlags(["-Xlinker", "-z", "-Xlinker", "defs"], .when(platforms: [.linux])),
             ]),
         .target(
             name: "Experimental",

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 //
 // Copyright 2019 The TensorFlow Authors. All Rights Reserved.


### PR DESCRIPTION
In the case that TensorFlow does not have GPU support, this should break
the build for Linux.