### PR TITLE
build: add a `USE_BUNDLED_CTENSORFLOW` option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
+option(USE_BUNDLED_CTENSORFLOW
+  "Use the CTensorFlow module bundled in the active Swift toolchain" OFF)
+
 find_package(TensorFlow REQUIRED)
 
 add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xllvm -sil-inline-generics>")

--- a/Sources/CTensorFlow/CMakeLists.txt
+++ b/Sources/CTensorFlow/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library(CTensorFlow INTERFACE)
-target_include_directories(CTensorFlow INTERFACE
-  ${CMAKE_CURRENT_SOURCE_DIR})
+if(NOT USE_BUNDLED_CTENSORFLOW)
+  target_include_directories(CTensorFlow INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
 target_link_libraries(CTensorFlow INTERFACE
   tensorflow)


### PR DESCRIPTION
This allows us to build with a toolchain which has the `CTensorFlow`
module bundled with it as well as with a toolchain which does not.