### PR TITLE
build: rename the `TensorFlow` library to `swiftTensorFlow`

### DIFF
--- a/Sources/TensorFlow/CMakeLists.txt
+++ b/Sources/TensorFlow/CMakeLists.txt
@@ -57,7 +57,8 @@ add_library(TensorFlow SHARED
   Optimizers/MomentumBased.swift
   Optimizers/Optimizer.swift
   Optimizers/SGD.swift)
-
+set_target_properties(TensorFlow PROPERTIES
+  OUTPUT_NAME swiftTensorFlow)
 target_link_libraries(TensorFlow PRIVATE
   CTensorFlow
   Tensor)

--- a/Sources/TensorFlow/CMakeLists.txt
+++ b/Sources/TensorFlow/CMakeLists.txt
@@ -57,7 +57,7 @@ add_library(TensorFlow SHARED
   Optimizers/MomentumBased.swift
   Optimizers/Optimizer.swift
   Optimizers/SGD.swift)
-  
+
 target_link_libraries(TensorFlow PRIVATE
   CTensorFlow
   Tensor)


### PR DESCRIPTION
Apparently, the s-p-m build already named the library this way, but we did not replicate this into the CMake build.  This is useful though to differentiate between `tensorflow` and the Swift `Tensorflow` module.