### PR TITLE
Fix: Crash when computing gradient of `tensor.mean` with negative axis

### DIFF
--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -2352,6 +2352,7 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
     @derivative(of: mean(alongAxes:))
     func _vjpMean(alongAxes axes: Tensor<Int32>) -> (value: Tensor, pullback: (Tensor) -> Tensor) {
         let value = mean(alongAxes: axes)
+        let axes = (axes + Int32(self.rank)) % Int32(self.rank)
         let count = _Raw.gather(params: shapeTensor, indices: axes).product()
         return (value, { [shape = shapeTensor] in $0.broadcasted(toShape: shape) / Tensor(count) })
     }
@@ -2362,6 +2363,7 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
         value: Tensor, pullback: (Tensor) -> Tensor
     ) {
         let value = mean(squeezingAxes: axes)
+        let axes = (axes + Int32(self.rank)) % Int32(self.rank)
         let count = _Raw.gather(params: shapeTensor, indices: axes).product()
         return (value, { [shape = shapeTensor] v in
             let unsqueezed = v.expandingShape(at: axes.scalars.map { Int($0) })
@@ -2377,7 +2379,7 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
         let value = mean(alongAxes: axes)
         // Cache shape because it is a computed property.
         let cachedShape = shape
-        let count = axes.map { cachedShape[$0] }.reduce(1, *)
+        let count = axes.map { cachedShape[($0 + self.rank) % self.rank] }.reduce(1, *)
         return (value, { [shape = shapeTensor] in $0.broadcasted(toShape: shape) / Tensor(Scalar(count)) })
     }
 
@@ -2389,7 +2391,7 @@ internal extension Tensor where Scalar: TensorFlowFloatingPoint {
         let value = mean(squeezingAxes: axes)
         // Cache shape because it is a computed property.
         let cachedShape = shape
-        let count = axes.map { cachedShape[$0] }.reduce(1, *)
+        let count = axes.map { cachedShape[($0 + self.rank) % self.rank] }.reduce(1, *)
         return (value, { [shape = shapeTensor] v in
             let unsqueezed = v.expandingShape(at: axes)
             return unsqueezed.broadcasted(toShape: shape) / Tensor(Scalar(count))

--- a/Tests/TensorFlowTests/TensorAutoDiffTests.swift
+++ b/Tests/TensorFlowTests/TensorAutoDiffTests.swift
@@ -249,15 +249,25 @@ final class TensorAutoDiffTests: XCTestCase {
     func testMean() {
         let meanGradScalar = gradient { (a: Tensor<Float>) in a.mean().sum() }
         let meanGradSqueezingAxes = gradient { (a: Tensor<Float>) in
-            a.mean(squeezingAxes: 0, 1).sum()
+            a.mean(squeezingAxes: 0, -1).sum()
         }
-        let meanGradAlongAxes = gradient { (a: Tensor<Float>) in a.mean(alongAxes: 0, 1).sum() }
+        let meanGradSqueezingAxes2 = gradient { (a: Tensor<Float>) in
+            a.mean(squeezingAxes: Tensor<Int32>([0, -1])).sum()
+        }
+        let meanGradAlongAxes = gradient { (a: Tensor<Float>) in
+            a.mean(alongAxes: 0, -1).sum()
+        }
+        let meanGradAlongAxes2 = gradient { (a: Tensor<Float>) in
+            a.mean(alongAxes: Tensor<Int32>([0, -1])).sum()
+        }
 
         let input = Tensor<Float>(ones: [2, 2])
         let expected = Tensor<Float>(repeating: 0.25, shape: [2, 2])
         XCTAssertEqual(meanGradScalar(input), expected)
         XCTAssertEqual(meanGradSqueezingAxes(input), expected)
+        XCTAssertEqual(meanGradSqueezingAxes2(input), expected)
         XCTAssertEqual(meanGradAlongAxes(input), expected)
+        XCTAssertEqual(meanGradAlongAxes2(input), expected)
     }
 
     func testVariance() {


### PR DESCRIPTION
Gradient computation of `tensor.mean` causes crash when negative axes are passed.

There are 4 variants of `_vjpMean` and none of them were supporting negative axes. We have to pass non-negative parameters to underlying `_Raw.gather` / `Array.subscript`. 
I added axes normalizations before them.

I also made the test case some more exhaustive.

I imitated axis normalization code from here:

https://github.com/tensorflow/swift-apis/blob/4288fb3a6a4451b902b37186723e8d6ae4490796/Sources/TensorFlow/Operators/Math.swift#L2444

I think we can have it as a method.