### PR TITLE
Core: uncomment out debugging code

### DIFF
--- a/Sources/TensorFlow/Core/PythonConversion.swift
+++ b/Sources/TensorFlow/Core/PythonConversion.swift
@@ -20,9 +20,11 @@ import Python
 // a Python import error until it is first used.
 private let np = Python.import("numpy")
 
-// private func debugLogNumpyError(_ message: String) {
-//     debugLog("NumPy conversion error: " + message)
-// }
+private func debugLogNumpyError(_ message: String) {
+#if ENABLE_NUMPY_LOGGING
+    debugLog("NumPy conversion error: " + message)
+#endif
+}
 
 extension ShapedArray: ConvertibleFromNumpyArray
     where Scalar: NumpyScalarCompatible {
@@ -35,25 +37,25 @@ extension ShapedArray: ConvertibleFromNumpyArray
     public init?(numpy numpyArray: PythonObject) {
         // Check if input is a `numpy.ndarray` instance.
         guard Python.isinstance(numpyArray, np.ndarray) == true else {
-            // debugLogNumpyError("""
-            //     PythonObject input has type '\(Python.type(numpyArray))' and is not \
-            //     an instance of 'numpy.ndarray'.
-            //     """)
+            debugLogNumpyError("""
+                PythonObject input has type '\(Python.type(numpyArray))' and is not \
+                an instance of 'numpy.ndarray'.
+                """)
             return nil
         }
         // Check if the dtype of the `ndarray` is compatible with the `Scalar`
         // type.
         guard Scalar.numpyScalarTypes.contains(numpyArray.dtype) else {
-            // debugLogNumpyError("""
-            //     'numpy.ndarray' dtype '\(numpyArray.dtype)' is incompatible with \
-            //     Swift type '\(Scalar.self)'.
-            //     """)
+            debugLogNumpyError("""
+                'numpy.ndarray' dtype '\(numpyArray.dtype)' is incompatible with \
+                Swift type '\(Scalar.self)'.
+                """)
             return nil
         }
 
         let pyShape = numpyArray.__array_interface__["shape"]
         guard let shape = [Int](pyShape) else {
-            // debugLogNumpyError("cannot access shape of 'numpy.ndarray' instance.")
+            debugLogNumpyError("cannot access shape of 'numpy.ndarray' instance.")
             return nil
         }
 
@@ -63,7 +65,7 @@ extension ShapedArray: ConvertibleFromNumpyArray
 
         guard let ptrVal =
             UInt(contiguousNumpyArray.__array_interface__["data"].tuple2.0) else {
-            // debugLogNumpyError("cannot access data of 'numpy.ndarray' instance.")
+            debugLogNumpyError("cannot access data of 'numpy.ndarray' instance.")
             return nil
         }
         // Note: `ptr` is not nil even if the `ndarray` is empty (i.e. has a shape
@@ -98,25 +100,25 @@ extension Tensor: ConvertibleFromNumpyArray where Scalar: NumpyScalarCompatible 
     public init?(numpy numpyArray: PythonObject) {
         // Check if input is a `numpy.ndarray` instance.
         guard Python.isinstance(numpyArray, np.ndarray) == true else {
-            // debugLogNumpyError("""
-            //     PythonObject input has type '\(Python.type(numpyArray))' and is not \
-            //     an instance of 'numpy.ndarray'.
-            //     """)
+            debugLogNumpyError("""
+                PythonObject input has type '\(Python.type(numpyArray))' and is not \
+                an instance of 'numpy.ndarray'.
+                """)
             return nil
         }
         // Check if the dtype of the `ndarray` is compatible with the `Scalar`
         // type.
         guard Scalar.numpyScalarTypes.contains(numpyArray.dtype) else {
-            // debugLogNumpyError("""
-            //     'numpy.ndarray' dtype '\(numpyArray.dtype)' is incompatible with \
-            //     Swift type '\(Scalar.self)'.
-            //     """)
+            debugLogNumpyError("""
+                'numpy.ndarray' dtype '\(numpyArray.dtype)' is incompatible with \
+                Swift type '\(Scalar.self)'.
+                """)
             return nil
         }
 
         let pyShape = numpyArray.__array_interface__["shape"]
         guard let dimensions = [Int](pyShape) else {
-            // debugLogNumpyError("cannot access shape of 'numpy.ndarray' instance.")
+            debugLogNumpyError("cannot access shape of 'numpy.ndarray' instance.")
             return nil
         }
         let shape = TensorShape(dimensions)
@@ -126,7 +128,7 @@ extension Tensor: ConvertibleFromNumpyArray where Scalar: NumpyScalarCompatible 
         let contiguousNumpyArray = np.ascontiguousarray(numpyArray)
 
         guard let ptrVal = UInt(contiguousNumpyArray.__array_interface__["data"].tuple2.0) else {
-            // debugLogNumpyError("cannot access data of 'numpy.ndarray' instance.")
+            debugLogNumpyError("cannot access data of 'numpy.ndarray' instance.")
             return nil
         }
         // Note: `ptr` is not nil even if the `ndarray` is empty (i.e. has a shape


### PR DESCRIPTION
This uncomments the debug logging.  Rather than leaving the debug
logging commented out, enable it always.  Make the logging be
conditional, allowing the inliner to remove the call entirely.  This
should have no visible impact.