### PR TITLE
Add documentation to Sequential

### DIFF
--- a/Sources/TensorFlow/Layers/Sequential.swift
+++ b/Sources/TensorFlow/Layers/Sequential.swift
@@ -12,7 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// A layer that sequentially composes two other layers.
+/// A layer that sequentially composes two or more other layers.
+///
+/// ### Usage Example: ###
+///
+/// - Build a simple 2-layer perceptron model for MNIST:
+///
+/// ````
+/// let inputSize = 28 * 28
+/// let hiddenSize = 300
+/// var classifier = Sequential {
+///      Dense<Float>(inputSize: inputSize, outputSize: hiddenSize, activation: relu)
+///      Dense<Float>(inputSize: hiddenSize, outputSize: 3, activation: identity)
+///  }
+/// ````
+///
+/// - Build an autoencoder for MNIST:
+///
+/// ````
+/// var autoencoder = Sequential {
+///     // The encoder.
+///     Dense<Float>(inputSize: 28 * 28, outputSize: 128, activation: relu)
+///     Dense<Float>(inputSize: 128, outputSize: 64, activation: relu)
+///     Dense<Float>(inputSize: 64, outputSize: 12, activation: relu)
+///     Dense<Float>(inputSize: 12, outputSize: 3, activation: relu)
+///     // The decoder.
+///     Dense<Float>(inputSize: 3, outputSize: 12, activation: relu)
+///     Dense<Float>(inputSize: 12, outputSize: 64, activation: relu)
+///     Dense<Float>(inputSize: 64, outputSize: 128, activation: relu)
+///     Dense<Float>(inputSize: 128, outputSize: imageHeight * imageWidth, activation: tanh)
+/// }
+/// ````
 public struct Sequential<Layer1: Module, Layer2: Layer>: Module
     where Layer1.Output == Layer2.Input,
           Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar {

--- a/Sources/TensorFlow/Layers/Sequential.swift
+++ b/Sources/TensorFlow/Layers/Sequential.swift
@@ -14,7 +14,7 @@
 
 /// A layer that sequentially composes two or more other layers.
 ///
-/// ### Usage Example: ###
+/// ### Examples: ###
 ///
 /// - Build a simple 2-layer perceptron model for MNIST:
 ///

--- a/Sources/TensorFlow/Layers/Sequential.swift.gyb
+++ b/Sources/TensorFlow/Layers/Sequential.swift.gyb
@@ -12,7 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// A layer that sequentially composes two other layers.
+/// A layer that sequentially composes two or more other layers.
+///
+/// ### Usage Example: ###
+///
+/// - Build a simple 2-layer perceptron model for MNIST:
+///
+/// ````
+/// let inputSize = 28 * 28
+/// let hiddenSize = 300
+/// var classifier = Sequential {
+///      Dense<Float>(inputSize: inputSize, outputSize: hiddenSize, activation: relu)
+///      Dense<Float>(inputSize: hiddenSize, outputSize: 3, activation: identity)
+///  }
+/// ````
+///
+/// - Build an autoencoder for MNIST:
+///
+/// ````
+/// var autoencoder = Sequential {
+///     // The encoder.
+///     Dense<Float>(inputSize: 28 * 28, outputSize: 128, activation: relu)
+///     Dense<Float>(inputSize: 128, outputSize: 64, activation: relu)
+///     Dense<Float>(inputSize: 64, outputSize: 12, activation: relu)
+///     Dense<Float>(inputSize: 12, outputSize: 3, activation: relu)
+///     // The decoder.
+///     Dense<Float>(inputSize: 3, outputSize: 12, activation: relu)
+///     Dense<Float>(inputSize: 12, outputSize: 64, activation: relu)
+///     Dense<Float>(inputSize: 64, outputSize: 128, activation: relu)
+///     Dense<Float>(inputSize: 128, outputSize: imageHeight * imageWidth, activation: tanh)
+/// }
+/// ````
 public struct Sequential<Layer1: Module, Layer2: Layer>: Module
     where Layer1.Output == Layer2.Input,
           Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar {

--- a/Sources/TensorFlow/Layers/Sequential.swift.gyb
+++ b/Sources/TensorFlow/Layers/Sequential.swift.gyb
@@ -14,7 +14,7 @@
 
 /// A layer that sequentially composes two or more other layers.
 ///
-/// ### Usage Example: ###
+/// ### Examples: ###
 ///
 /// - Build a simple 2-layer perceptron model for MNIST:
 ///


### PR DESCRIPTION
See https://github.com/tensorflow/swift-apis/pull/648. The autoencoder example is copied from [here](https://github.com/tensorflow/swift-models/blob/master/Autoencoder/main.swift). I trust that is OK with you since the source is also a TensorFlow library.