### PR TITLE
Conform all RNN cell `State` structs to the same protocols.

### DIFF
--- a/Sources/TensorFlow/Layers/Recurrent.swift
+++ b/Sources/TensorFlow/Layers/Recurrent.swift
@@ -202,7 +202,7 @@ public struct LSTMCell<Scalar: TensorFlowFloatingPoint>: RNNCell {
         self.fusedBias = Tensor(zeros: [4 * hiddenSize])
     }
 
-    public struct State: Differentiable {
+    public struct State: Equatable, Differentiable, VectorProtocol, KeyPathIterable {
         public var cell: Tensor<Scalar>
         public var hidden: Tensor<Scalar>
 
@@ -306,7 +306,7 @@ public struct GRUCell<Scalar: TensorFlowFloatingPoint>: RNNCell {
 
     // TODO(TF-507): Revert to `typealias State = Tensor<Scalar>` after
     // SR-10697 is fixed.
-    public struct State: Differentiable {
+    public struct State: Equatable, Differentiable, VectorProtocol, KeyPathIterable {
         public var hidden: Tensor<Scalar>
 
         @differentiable


### PR DESCRIPTION
Make the following structs:
- `SimpleRNNCell.State`
- `LSTMCell.State`
- `GRUCell.State`

Conform to the same set of useful protocols:
- `Equatable`
- `Differentiable`
- `VectorProtocol`
- `KeyPathIterable`

These conformances should be defined in the library for convenience.
No tests for synthesized conformances.