### PR TITLE
build: install the swift files into the OS specific path

### DIFF
--- a/Sources/Tensor/CMakeLists.txt
+++ b/Sources/Tensor/CMakeLists.txt
@@ -12,4 +12,4 @@ get_swift_host_arch(swift_arch)
 install(FILES
   $<TARGET_PROPERTY:Tensor,Swift_MODULE_DIRECTORY>/Tensor.swiftdoc
   $<TARGET_PROPERTY:Tensor,Swift_MODULE_DIRECTORY>/Tensor.swiftmodule
-  DESTINATION lib/swift/${swift_arch})
+  DESTINATION lib/swift/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})

--- a/Sources/TensorFlow/CMakeLists.txt
+++ b/Sources/TensorFlow/CMakeLists.txt
@@ -71,4 +71,4 @@ get_swift_host_arch(swift_arch)
 install(FILES
   $<TARGET_PROPERTY:TensorFlow,Swift_MODULE_DIRECTORY>/TensorFlow.swiftdoc
   $<TARGET_PROPERTY:TensorFlow,Swift_MODULE_DIRECTORY>/TensorFlow.swiftmodule
-  DESTINATION lib/swift/${swift_arch})
+  DESTINATION lib/swift/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})


### PR DESCRIPTION
The installation path missed the system name, resulting in the swift
files being installed above the desired location, preventing use.

`usr/lib/swift/x86_64` rather than `usr/lib/swift/windows/x86_64`.