### PR TITLE
Add transposedConv2D (#596)

### DIFF
--- a/Sources/TensorFlow/Layers/Convolutional.swift
+++ b/Sources/TensorFlow/Layers/Convolutional.swift
@@ -420,7 +420,7 @@ public struct TransposedConv1D<Scalar: TensorFlowFloatingPoint>: Layer {
             stride + (filter.shape[0] * paddingIndex)
         let c = filter.shape[2]
         let newShape = Tensor<Int32>([Int32(batchSize), 1, Int32(w), Int32(c)])
-        return activation(conv2DBackpropInput(
+        return activation(transposedConv2D(
             input.expandingShape(at: 1),
             shape: newShape,
             filter: filter.expandingShape(at: 0),
@@ -519,7 +519,7 @@ public struct TransposedConv2D<Scalar: TensorFlowFloatingPoint>: Layer {
           strides.1 + (filter.shape[1] * paddingIndex)
         let c = filter.shape[2]
         let newShape = Tensor<Int32>([Int32(batchSize), Int32(h), Int32(w), Int32(c)])
-        return activation(conv2DBackpropInput(
+        return activation(transposedConv2D(
             input,
             shape: newShape,
             filter: filter,

--- a/Sources/TensorFlow/Operators/NN.swift
+++ b/Sources/TensorFlow/Operators/NN.swift
@@ -169,8 +169,10 @@ public func transposedConv2D<Scalar: TensorFlowFloatingPoint>(
     padding: Padding = .valid,
     dilations: (Int, Int, Int, Int) = (1, 1, 1, 1)
 ) -> Tensor<Scalar> {
-    conv2DBackpropInput(input, shape: shape, filter: filter,
-                        strides: strides, padding: padding, dilations: dilations)
+    precondition(input.shape.rank == 4, "The input must have rank 4.")
+    precondition(filter.shape.rank == 4, "The filter must have rank 4.")
+    return conv2DBackpropInput(input, shape: shape, filter: filter,
+                               strides: strides, padding: padding, dilations: dilations)
 }
 
 /// TensorFlow builtin conv2d gradient helper for the input.
@@ -184,8 +186,6 @@ func conv2DBackpropInput<Scalar: TensorFlowFloatingPoint>(
     padding: Padding = .valid,
     dilations: (Int, Int, Int, Int) = (1, 1, 1, 1)
 ) -> Tensor<Scalar> {
-    precondition(x.shape.rank == 4, "The input must have rank 4.")
-    precondition(filter.shape.rank == 4, "The filter must have rank 4.")
     return _Raw.conv2DBackpropInput(
         inputSizes: shape,
         filter: filter,

--- a/Sources/TensorFlow/Operators/NN.swift
+++ b/Sources/TensorFlow/Operators/NN.swift
@@ -153,6 +153,7 @@ func _vjpConv2D<Scalar: TensorFlowFloatingPoint>(
 ///
 /// - Parameters:
 ///   - input: The input.
+///   - shape: The output shape of the deconvolution operation.
 ///   - filter: The convolution filter.
 ///   - strides: The strides of the sliding filter for each dimension of the input.
 ///   - padding: The padding for the operation

--- a/Sources/TensorFlow/Operators/NN.swift
+++ b/Sources/TensorFlow/Operators/NN.swift
@@ -174,22 +174,22 @@ public func transposedConv2D<Scalar: TensorFlowFloatingPoint>(
 }
 
 /// TensorFlow builtin conv2d gradient helper for the input.
-@differentiable(wrt: (input, filter))
+@differentiable(wrt: (x, filter))
 @usableFromInline
 func conv2DBackpropInput<Scalar: TensorFlowFloatingPoint>(
-    _ input: Tensor<Scalar>,
+    _ x: Tensor<Scalar>,
     shape: Tensor<Int32>,
     filter: Tensor<Scalar>,
     strides: (Int, Int, Int, Int) = (1, 1, 1, 1),
     padding: Padding = .valid,
     dilations: (Int, Int, Int, Int) = (1, 1, 1, 1)
 ) -> Tensor<Scalar> {
-    precondition(input.shape.rank == 4, "The input must have rank 4.")
+    precondition(x.shape.rank == 4, "The input must have rank 4.")
     precondition(filter.shape.rank == 4, "The filter must have rank 4.")
     return _Raw.conv2DBackpropInput(
         inputSizes: shape,
         filter: filter,
-        outBackprop: input,
+        outBackprop: x,
         strides: [Int32(strides.0), Int32(strides.1), Int32(strides.2), Int32(strides.3)],
         padding: padding.raw2,
         explicitPaddings: [],

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -353,6 +353,7 @@ final class LayerTests: XCTestCase {
         let expected = Tensor<Float>(shape: [1, 4, 2, 1],
                                      scalars: [8, 12, 12, 28, 24, 64, 48, 112])
         XCTAssertEqual(output, expected)
+        
         let layerNoBias = TransposedConv2D(filter: filter, bias: nil, activation: identity,
                                            strides: (1, 1), padding: .same)
         let outputNoBias = layerNoBias.inferring(from: input)

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -324,7 +324,51 @@ final class LayerTests: XCTestCase {
         let expected = Tensor<Float>(shape: [1, 4, 2, 1],
                                      scalars: [8, 12, 12, 28, 24, 64, 48, 112])
         XCTAssertEqual(output, expected)
-    }  
+    }
+    
+    func testTransposedConv2DGradient() {
+        let filter =  Tensor(shape: [3, 3, 2, 4], scalars: (0..<72).map(Float.init))
+        let bias = Tensor<Float>(zeros: [2])
+        let layer = TransposedConv2D<Float>(filter: filter,
+                                            bias: bias,
+                                            activation: identity,
+                                            strides: (2, 2),
+                                            padding: .same)
+        let input = Tensor(shape: [2, 2, 2, 4], scalars: (0..<32).map(Float.init))
+        let grads = gradient( at: input, layer) { $1($0).sum() }
+        // The expected value of the gradient was computed using the following Python code:
+        // ```
+        // import tensorflow as tf
+        // x = tf.reshape(tf.range(32, dtype=tf.float32), [2, 2, 2, 4])
+        // filter = tf.reshape(tf.range(72, dtype=tf.float32), [3, 3, 2, 4])
+        // bias = tf.zeros([2])
+        // with tf.GradientTape() as tape:
+        //     tape.watch([x, filter, bias])
+        //     y = tf.math.reduce_sum(tf.nn.conv2d_transpose(input=x,
+        //                                                   filters=filter,
+        //                                                   output_shape=[2, 4, 4, 2],
+        //                                                   strides=[1, 2, 2, 1],
+        //                                                   data_format="NHWC",
+        //                                                   padding="SAME") + bias)
+        // print(tape.gradient(y, [x, filter, bias]))
+        // ```
+        XCTAssertEqual(grads.0,
+                       [[[[612, 630, 648, 666], [360, 372, 384, 396]],
+                         [[264, 276, 288, 300], [144, 152, 160, 168]]],
+                        [[[612, 630, 648, 666], [360, 372, 384, 396]],
+                         [[264, 276, 288, 300], [144, 152, 160, 168]]]])
+        XCTAssertEqual(grads.1.filter,
+                       [[[[112, 120, 128, 136], [112, 120, 128, 136]],
+                         [[112, 120, 128, 136], [112, 120, 128, 136]],
+                         [[ 48,  52,  56,  60], [ 48,  52,  56,  60]]],
+                        [[[112, 120, 128, 136], [112, 120, 128, 136]],
+                         [[112, 120, 128, 136], [112, 120, 128, 136]],
+                         [[ 48,  52,  56,  60], [ 48,  52,  56,  60]]],
+                        [[[ 40,  44,  48,  52], [ 40,  44,  48,  52]],
+                         [[ 40,  44,  48,  52], [ 40,  44,  48,  52]],
+                         [[ 16,  18,  20,  22], [ 16,  18,  20,  22]]]])
+        XCTAssertEqual(grads.1.bias, [32, 32])
+    }
 
     
     func testTransposedConv3D() {
@@ -1537,6 +1581,7 @@ final class LayerTests: XCTestCase {
         ("testConv3DGradient", testConv3DGradient),
         ("testTransposedConv1D", testTransposedConv1D),
         ("testTransposedConv2D", testTransposedConv2D),
+        ("testTransposedConv2DGradient", testTransposedConv2DGradient),
         ("testTransposedConv3D", testTransposedConv3D),
         ("testDepthwiseConv2D", testDepthwiseConv2D),
         ("testDepthwiseConv2DGradient", testDepthwiseConv2DGradient),


### PR DESCRIPTION
`TansposedConv2D` layer is using internal API `conv2DBackpropInput`.
It makes creating custom transposed convolutional layers outside the library hard.

This PR exposes that API with new name `transposedConv2D`.