### PR TITLE
Make bias optional in Dense and all Conv layers

### DIFF
--- a/Sources/TensorFlow/Layers/Convolutional.swift
+++ b/Sources/TensorFlow/Layers/Convolutional.swift
@@ -49,7 +49,7 @@ public struct Conv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   - dilation: The dilation factor for the temporal dimension.
     public init(
         filter: Tensor<Scalar>,
-        bias: Tensor<Scalar>?,
+        bias: Tensor<Scalar>? = nil,
         activation: @escaping Activation = identity,
         stride: Int = 1,
         padding: Padding = .valid,
@@ -163,7 +163,7 @@ public struct Conv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///     (dilation height, dilation width).
     public init(
         filter: Tensor<Scalar>,
-        bias: Tensor<Scalar>?,
+        bias: Tensor<Scalar>? = nil,
         activation: @escaping Activation = identity,
         strides: (Int, Int) = (1, 1),
         padding: Padding = .valid,
@@ -286,7 +286,7 @@ public struct Conv3D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   - dilations: The dilation factor for spatial/spatio-temporal dimensions.
     public init(
         filter: Tensor<Scalar>,
-        bias: Tensor<Scalar>?,
+        bias: Tensor<Scalar>? = nil,
         activation: @escaping Activation = identity,
         strides: (Int, Int, Int) = (1, 1, 1),
         padding: Padding = .valid,
@@ -412,7 +412,7 @@ public struct TransposedConv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   - padding: The padding algorithm for convolution.
     public init(
         filter: Tensor<Scalar>,
-        bias: Tensor<Scalar>?,
+        bias: Tensor<Scalar>? = nil,
         activation: @escaping Activation = identity,
         stride: Int = 1,
         padding: Padding = .valid
@@ -514,7 +514,7 @@ public struct TransposedConv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   - padding: The padding algorithm for convolution.
     public init(
         filter: Tensor<Scalar>,
-        bias: Tensor<Scalar>?,
+        bias: Tensor<Scalar>? = nil,
         activation: @escaping Activation = identity,
         strides: (Int, Int) = (1, 1),
         padding: Padding = .valid
@@ -619,7 +619,7 @@ public struct TransposedConv3D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   - padding: The padding algorithm for convolution.
     public init(
         filter: Tensor<Scalar>,
-        bias: Tensor<Scalar>?,
+        bias: Tensor<Scalar>? = nil,
         activation: @escaping Activation = identity,
         strides: (Int, Int, Int) = (1, 1, 1),
         padding: Padding = .valid
@@ -722,7 +722,7 @@ public struct DepthwiseConv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   - padding: The padding algorithm for convolution.
     public init(
         filter: Tensor<Scalar>,
-        bias: Tensor<Scalar>?,
+        bias: Tensor<Scalar>? = nil,
         activation: @escaping Activation = identity,
         strides: (Int, Int) = (1, 1),
         padding: Padding = .valid
@@ -918,7 +918,7 @@ public struct SeparableConv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     public init(
         depthwiseFilter: Tensor<Scalar>,
         pointwiseFilter: Tensor<Scalar>,
-        bias: Tensor<Scalar>?,
+        bias: Tensor<Scalar>? = nil,
         activation: @escaping Activation = identity,
         stride: Int = 1,
         padding: Padding = .valid
@@ -1029,7 +1029,7 @@ public struct SeparableConv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     public init(
         depthwiseFilter: Tensor<Scalar>,
         pointwiseFilter: Tensor<Scalar>,
-        bias: Tensor<Scalar>?,
+        bias: Tensor<Scalar>? = nil,
         activation: @escaping Activation = identity,
         strides: (Int, Int) = (1, 1),
         padding: Padding = .valid

--- a/Sources/TensorFlow/Layers/Convolutional.swift
+++ b/Sources/TensorFlow/Layers/Convolutional.swift
@@ -30,7 +30,7 @@ public struct Conv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let padding: Padding
     /// The dilation factor for the temporal dimension.
     @noDerivative public let dilation: Int
-    /// Workaround optionals not being handled by AD
+    /// Note: `useBias` is a workaround for TF-1153: optional differentiation support.
     @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.
@@ -142,7 +142,7 @@ public struct Conv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let padding: Padding
     /// The dilation factor for spatial dimensions.
     @noDerivative public let dilations: (Int, Int)
-    /// Workaround optionals not being handled by AD
+    /// Note: `useBias` is a workaround for TF-1153: optional differentiation support.
     @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.
@@ -265,7 +265,7 @@ public struct Conv3D<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let padding: Padding
     /// The dilation factor for spatial/spatio temporal dimensions.
     @noDerivative public let dilations: (Int, Int, Int)
-    /// Workaround optionals not being handled by AD
+    /// Note: `useBias` is a workaround for TF-1153: optional differentiation support.
     @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.
@@ -395,7 +395,7 @@ public struct TransposedConv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let padding: Padding
     /// The paddingIndex property allows us to handle computation based on padding.
     @noDerivative public let paddingIndex: Int
-    /// Workaround optionals not being handled by AD
+    /// Note: `useBias` is a workaround for TF-1153: optional differentiation support.
     @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.
@@ -496,7 +496,7 @@ public struct TransposedConv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let padding: Padding
     /// The paddingIndex property allows us to handle computation based on padding.
     @noDerivative public let paddingIndex: Int
-    /// Workaround optionals not being handled by AD
+    /// Note: `useBias` is a workaround for TF-1153: optional differentiation support.
     @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.
@@ -602,7 +602,7 @@ public struct TransposedConv3D<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let padding: Padding
     /// The paddingIndex property allows us to handle computation based on padding.
     @noDerivative public let paddingIndex: Int
-    /// Workaround optionals not being handled by AD
+    /// Note: `useBias` is a workaround for TF-1153: optional differentiation support.
     @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.
@@ -705,7 +705,7 @@ public struct DepthwiseConv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let strides: (Int, Int)
     /// The padding algorithm for convolution.
     @noDerivative public let padding: Padding
-    /// Workaround optionals not being handled by AD
+    /// Note: `useBias` is a workaround for TF-1153: optional differentiation support.
     @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.
@@ -897,7 +897,7 @@ public struct SeparableConv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let stride: Int
     /// The padding algorithm for convolution.
     @noDerivative public let padding: Padding
-    /// Workaround optionals not being handled by AD
+    /// Note: `useBias` is a workaround for TF-1153: optional differentiation support.
     @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.
@@ -1008,7 +1008,7 @@ public struct SeparableConv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let strides: (Int, Int)
     /// The padding algorithm for convolution.
     @noDerivative public let padding: Padding
-    /// Workaround optionals not being handled by AD
+    /// Note: `useBias` is a workaround for TF-1153: optional differentiation support.
     @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.

--- a/Sources/TensorFlow/Layers/Convolutional.swift
+++ b/Sources/TensorFlow/Layers/Convolutional.swift
@@ -30,6 +30,8 @@ public struct Conv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let padding: Padding
     /// The dilation factor for the temporal dimension.
     @noDerivative public let dilation: Int
+    /// Workaround optionals not being handled by AD
+    @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.
     public typealias Activation = @differentiable (Tensor<Scalar>) -> Tensor<Scalar>
@@ -47,18 +49,19 @@ public struct Conv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   - dilation: The dilation factor for the temporal dimension.
     public init(
         filter: Tensor<Scalar>,
-        bias: Tensor<Scalar>,
+        bias: Tensor<Scalar>?,
         activation: @escaping Activation = identity,
         stride: Int = 1,
         padding: Padding = .valid,
         dilation: Int = 1
     ) {
         self.filter = filter
-        self.bias = bias
+        self.bias = bias ?? .zero
         self.activation = activation
         self.stride = stride
         self.padding = padding
         self.dilation = dilation
+        useBias = (bias != nil)
     }
 
     /// Returns the output obtained from applying the layer to the given input.
@@ -76,12 +79,13 @@ public struct Conv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Note: Padding size equals zero when using `.valid`.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        activation(conv1D(
+        let conv = conv1D(
             input,
             filter: filter,
             stride: stride,
             padding: padding,
-            dilation: dilation) + bias)
+            dilation: dilation)
+        return activation(useBias ? (conv + bias) : conv)
     }
 }
 
@@ -104,6 +108,7 @@ public extension Conv1D where Scalar.RawSignificand: FixedWidthInteger {
         padding: Padding = .valid,
         dilation: Int = 1,
         activation: @escaping Activation = identity,
+        useBias: Bool = true,
         filterInitializer: ParameterInitializer<Scalar> = glorotUniform(),
         biasInitializer: ParameterInitializer<Scalar> = zeros()
     ) {
@@ -111,7 +116,7 @@ public extension Conv1D where Scalar.RawSignificand: FixedWidthInteger {
             filterShape.0, filterShape.1, filterShape.2])
         self.init(
             filter: filterInitializer(filterTensorShape),
-            bias: biasInitializer([filterShape.2]),
+            bias: useBias ? biasInitializer([filterShape.2]) : nil,
             activation: activation,
             stride: stride,
             padding: padding,
@@ -137,6 +142,8 @@ public struct Conv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let padding: Padding
     /// The dilation factor for spatial dimensions.
     @noDerivative public let dilations: (Int, Int)
+    /// Workaround optionals not being handled by AD
+    @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.
     public typealias Activation = @differentiable (Tensor<Scalar>) -> Tensor<Scalar>
@@ -156,18 +163,19 @@ public struct Conv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///     (dilation height, dilation width).
     public init(
         filter: Tensor<Scalar>,
-        bias: Tensor<Scalar>,
+        bias: Tensor<Scalar>?,
         activation: @escaping Activation = identity,
         strides: (Int, Int) = (1, 1),
         padding: Padding = .valid,
         dilations: (Int, Int) = (1, 1)
     ) {
         self.filter = filter
-        self.bias = bias
+        self.bias = bias ?? .zero
         self.activation = activation
         self.strides = strides
         self.padding = padding
         self.dilations = dilations
+        useBias = (bias != nil)
     }
 
     /// Returns the output obtained from applying the layer to the given input.
@@ -192,12 +200,13 @@ public struct Conv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Note: Padding size equals zero when using `.valid`.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return activation(conv2D(
+        let conv = conv2D(
             input,
             filter: filter,
             strides: (1, strides.0, strides.1, 1),
             padding: padding,
-            dilations: (1, dilations.0, dilations.1, 1)) + bias)
+            dilations: (1, dilations.0, dilations.1, 1))
+        return activation(useBias ? (conv + bias) : conv)
     }
 }
 
@@ -222,6 +231,7 @@ public extension Conv2D {
         padding: Padding = .valid,
         dilations: (Int, Int) = (1, 1),
         activation: @escaping Activation = identity,
+        useBias: Bool = true,
         filterInitializer: ParameterInitializer<Scalar> = glorotUniform(),
         biasInitializer: ParameterInitializer<Scalar> = zeros()
     ) {
@@ -229,7 +239,7 @@ public extension Conv2D {
             filterShape.0, filterShape.1, filterShape.2, filterShape.3])
         self.init(
             filter: filterInitializer(filterTensorShape),
-            bias: biasInitializer([filterShape.3]),
+            bias: useBias ? biasInitializer([filterShape.3]) : nil,
             activation: activation,
             strides: strides,
             padding: padding,
@@ -255,6 +265,8 @@ public struct Conv3D<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let padding: Padding
     /// The dilation factor for spatial/spatio temporal dimensions.
     @noDerivative public let dilations: (Int, Int, Int)
+    /// Workaround optionals not being handled by AD
+    @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.
     public typealias Activation = @differentiable (Tensor<Scalar>) -> Tensor<Scalar>
@@ -274,7 +286,7 @@ public struct Conv3D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   - dilations: The dilation factor for spatial/spatio-temporal dimensions.
     public init(
         filter: Tensor<Scalar>,
-        bias: Tensor<Scalar>,
+        bias: Tensor<Scalar>?,
         activation: @escaping Activation = identity,
         strides: (Int, Int, Int) = (1, 1, 1),
         padding: Padding = .valid,
@@ -283,11 +295,12 @@ public struct Conv3D<Scalar: TensorFlowFloatingPoint>: Layer {
         precondition(dilations.2 == 1,
                      "Dilations in the depth dimension must be 1.")
         self.filter = filter
-        self.bias = bias
+        self.bias = bias ?? .zero
         self.activation = activation
         self.strides = strides
         self.padding = padding
         self.dilations = dilations
+        useBias = (bias != nil)
     }
 
     /// Returns the output obtained from applying the layer to the given input.
@@ -316,13 +329,13 @@ public struct Conv3D<Scalar: TensorFlowFloatingPoint>: Layer {
     /// - Note: Padding size equals zero when using `.valid`.
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return activation(conv3D(
+        let conv = conv3D(
             input,
             filter: filter,
             strides: (1, strides.0, strides.1, strides.2, 1),
             padding: padding,
-            dilations: (1, dilations.0, dilations.1, dilations.2, 1)
-        ) + bias)
+            dilations: (1, dilations.0, dilations.1, dilations.2, 1))
+        return activation(useBias ? (conv + bias) : conv)
     }
 }
 
@@ -348,6 +361,7 @@ public extension Conv3D {
         padding: Padding = .valid,
         dilations: (Int, Int, Int) = (1, 1, 1),
         activation: @escaping Activation = identity,
+        useBias: Bool = true,
         filterInitializer: ParameterInitializer<Scalar> = glorotUniform(),
         biasInitializer: ParameterInitializer<Scalar> = zeros()
     ) {
@@ -355,7 +369,7 @@ public extension Conv3D {
             filterShape.0, filterShape.1, filterShape.2, filterShape.3, filterShape.4])
         self.init(
             filter: filterInitializer(filterTensorShape),
-            bias: biasInitializer([filterShape.4]),
+            bias: useBias ? biasInitializer([filterShape.4]) : nil,
             activation: activation,
             strides: strides,
             padding: padding,
@@ -381,6 +395,8 @@ public struct TransposedConv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let padding: Padding
     /// The paddingIndex property allows us to handle computation based on padding.
     @noDerivative public let paddingIndex: Int
+    /// Workaround optionals not being handled by AD
+    @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.
     public typealias Activation = @differentiable (Tensor<Scalar>) -> Tensor<Scalar>
@@ -396,17 +412,18 @@ public struct TransposedConv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   - padding: The padding algorithm for convolution.
     public init(
         filter: Tensor<Scalar>,
-        bias: Tensor<Scalar>,
+        bias: Tensor<Scalar>?,
         activation: @escaping Activation = identity,
         stride: Int = 1,
         padding: Padding = .valid
     ) {
         self.filter = filter
-        self.bias = bias
+        self.bias = bias ?? .zero
         self.activation = activation
         self.stride = stride
         self.padding = padding
         self.paddingIndex = padding == .same ? 0 : 1
+        useBias = (bias != nil)
     }
 
     /// Returns the output obtained from applying the layer to the given input.
@@ -420,12 +437,13 @@ public struct TransposedConv1D<Scalar: TensorFlowFloatingPoint>: Layer {
             stride + (filter.shape[0] * paddingIndex)
         let c = filter.shape[2]
         let newShape = Tensor<Int32>([Int32(batchSize), 1, Int32(w), Int32(c)])
-        return activation(conv2DBackpropInput(
+        let conv = conv2DBackpropInput(
             input.expandingShape(at: 1),
             shape: newShape,
             filter: filter.expandingShape(at: 0),
             strides: (1, 1, stride, 1),
-            padding: padding) + bias)
+            padding: padding)
+        return activation(useBias ? (conv + bias) : conv)
     }
 }
 
@@ -445,6 +463,7 @@ public extension TransposedConv1D {
         stride: Int = 1,
         padding: Padding = .valid,
         activation: @escaping Activation = identity,
+        useBias: Bool = true,
         filterInitializer: ParameterInitializer<Scalar> = glorotUniform(),
         biasInitializer: ParameterInitializer<Scalar> = zeros()
     ) {
@@ -452,7 +471,7 @@ public extension TransposedConv1D {
             filterShape.0, filterShape.1, filterShape.2])
         self.init(
             filter: filterInitializer(filterTensorShape),
-            bias: biasInitializer([filterShape.2]),
+            bias: useBias ? biasInitializer([filterShape.2]) : nil,
             activation: activation,
             stride: stride,
             padding: padding)
@@ -477,6 +496,8 @@ public struct TransposedConv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let padding: Padding
     /// The paddingIndex property allows us to handle computation based on padding.
     @noDerivative public let paddingIndex: Int
+    /// Workaround optionals not being handled by AD
+    @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.
     public typealias Activation = @differentiable (Tensor<Scalar>) -> Tensor<Scalar>
@@ -493,17 +514,18 @@ public struct TransposedConv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   - padding: The padding algorithm for convolution.
     public init(
         filter: Tensor<Scalar>,
-        bias: Tensor<Scalar>,
+        bias: Tensor<Scalar>?,
         activation: @escaping Activation = identity,
         strides: (Int, Int) = (1, 1),
         padding: Padding = .valid
     ) {
         self.filter = filter
-        self.bias = bias
+        self.bias = bias ?? .zero
         self.activation = activation
         self.strides = strides
         self.padding = padding
         self.paddingIndex = padding == .same ? 0 : 1
+        useBias = (bias != nil)
     }
 
     /// Returns the output obtained from applying the layer to the given input.
@@ -519,12 +541,13 @@ public struct TransposedConv2D<Scalar: TensorFlowFloatingPoint>: Layer {
           strides.1 + (filter.shape[1] * paddingIndex)
         let c = filter.shape[2]
         let newShape = Tensor<Int32>([Int32(batchSize), Int32(h), Int32(w), Int32(c)])
-        return activation(conv2DBackpropInput(
+        let conv = conv2DBackpropInput(
             input,
             shape: newShape,
             filter: filter,
             strides: (1, strides.0, strides.1, 1),
-            padding: padding) + bias)
+            padding: padding)
+        return activation(useBias ? (conv + bias) : conv)
     }
 }
 
@@ -545,6 +568,7 @@ public extension TransposedConv2D {
         strides: (Int, Int) = (1, 1),
         padding: Padding = .valid,
         activation: @escaping Activation = identity,
+        useBias: Bool = true,
         filterInitializer: ParameterInitializer<Scalar> = glorotUniform(),
         biasInitializer: ParameterInitializer<Scalar> = zeros()
     ) {
@@ -552,7 +576,7 @@ public extension TransposedConv2D {
             filterShape.0, filterShape.1, filterShape.2, filterShape.3])
         self.init(
             filter: filterInitializer(filterTensorShape),
-            bias: biasInitializer([filterShape.2]),
+            bias: useBias ? biasInitializer([filterShape.2]) : nil,
             activation: activation,
             strides: strides,
             padding: padding)
@@ -578,6 +602,8 @@ public struct TransposedConv3D<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let padding: Padding
     /// The paddingIndex property allows us to handle computation based on padding.
     @noDerivative public let paddingIndex: Int
+    /// Workaround optionals not being handled by AD
+    @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.
     public typealias Activation = @differentiable (Tensor<Scalar>) -> Tensor<Scalar>
@@ -593,17 +619,18 @@ public struct TransposedConv3D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   - padding: The padding algorithm for convolution.
     public init(
         filter: Tensor<Scalar>,
-        bias: Tensor<Scalar>,
+        bias: Tensor<Scalar>?,
         activation: @escaping Activation = identity,
         strides: (Int, Int, Int) = (1, 1, 1),
         padding: Padding = .valid
     ) {
         self.filter = filter
-        self.bias = bias
+        self.bias = bias ?? .zero
         self.activation = activation
         self.strides = strides
         self.padding = padding
         self.paddingIndex = padding == .same ? 0 : 1
+        useBias = (bias != nil)
     }
 
     /// Returns the output obtained from applying the layer to the given input.
@@ -621,12 +648,13 @@ public struct TransposedConv3D<Scalar: TensorFlowFloatingPoint>: Layer {
             strides.2 + (filter.shape[2] * paddingIndex)
         let c = filter.shape[3]
         let newShape = Tensor<Int32>([Int32(batchSize), Int32(w), Int32(h), Int32(d), Int32(c)])
-        return activation(conv3DBackpropInput(
+        let conv = conv3DBackpropInput(
             input,
             shape: newShape,
             filter: filter,
             strides: (1, strides.0, strides.1, strides.2, 1),
-            padding: padding) + bias)
+            padding: padding)
+        return activation(useBias ? (conv + bias) : conv)
     }
 }
 
@@ -646,6 +674,7 @@ public extension TransposedConv3D {
         strides: (Int, Int, Int) = (1, 1, 1),
         padding: Padding = .valid,
         activation: @escaping Activation = identity,
+        useBias: Bool = true,
         filterInitializer: ParameterInitializer<Scalar> = glorotUniform(),
         biasInitializer: ParameterInitializer<Scalar> = zeros()
     ) {
@@ -653,7 +682,7 @@ public extension TransposedConv3D {
             filterShape.0, filterShape.1, filterShape.2, filterShape.3, filterShape.4])
         self.init(
             filter: filterInitializer(filterTensorShape),
-            bias: biasInitializer([filterShape.4]),
+            bias: useBias ? biasInitializer([filterShape.4]) : nil,
             activation: activation,
             strides: strides,
             padding: padding)
@@ -676,6 +705,8 @@ public struct DepthwiseConv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let strides: (Int, Int)
     /// The padding algorithm for convolution.
     @noDerivative public let padding: Padding
+    /// Workaround optionals not being handled by AD
+    @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.
     public typealias Activation = @differentiable (Tensor<Scalar>) -> Tensor<Scalar>
@@ -691,16 +722,17 @@ public struct DepthwiseConv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   - padding: The padding algorithm for convolution.
     public init(
         filter: Tensor<Scalar>,
-        bias: Tensor<Scalar>,
+        bias: Tensor<Scalar>?,
         activation: @escaping Activation = identity,
         strides: (Int, Int) = (1, 1),
         padding: Padding = .valid
     ) {
         self.filter = filter
-        self.bias = bias
+        self.bias = bias ?? .zero
         self.activation = activation
         self.strides = strides
         self.padding = padding
+        useBias = (bias != nil)
     }
 
     /// Returns the output obtained from applying the layer to the given input.
@@ -711,11 +743,12 @@ public struct DepthwiseConv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     ///   [batch count, output height, output width, input channel count * channel multiplier]
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return activation(depthwiseConv2D(
+        let conv = depthwiseConv2D(
             input,
             filter: filter,
             strides: (1, strides.0, strides.1, 1),
-            padding: padding) + bias)
+            padding: padding)
+        return activation(useBias ? (conv + bias) : conv)
     }
 }
 
@@ -736,6 +769,7 @@ public extension DepthwiseConv2D {
         strides: (Int, Int) = (1, 1),
         padding: Padding = .valid,
         activation: @escaping Activation = identity,
+        useBias: Bool = true,
         filterInitializer: ParameterInitializer<Scalar> = glorotUniform(),
         biasInitializer: ParameterInitializer<Scalar> = zeros()
     ) {
@@ -743,7 +777,7 @@ public extension DepthwiseConv2D {
             filterShape.0, filterShape.1, filterShape.2, filterShape.3])
         self.init(
             filter: filterInitializer(filterTensorShape),
-            bias: biasInitializer([filterShape.2 * filterShape.3]),
+            bias: useBias ? biasInitializer([filterShape.2 * filterShape.3]) : nil,
             activation: activation,
             strides: strides,
             padding: padding)
@@ -863,6 +897,8 @@ public struct SeparableConv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let stride: Int
     /// The padding algorithm for convolution.
     @noDerivative public let padding: Padding
+    /// Workaround optionals not being handled by AD
+    @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.
     public typealias Activation = @differentiable (Tensor<Scalar>) -> Tensor<Scalar>
@@ -882,17 +918,18 @@ public struct SeparableConv1D<Scalar: TensorFlowFloatingPoint>: Layer {
     public init(
         depthwiseFilter: Tensor<Scalar>,
         pointwiseFilter: Tensor<Scalar>,
-        bias: Tensor<Scalar>,
+        bias: Tensor<Scalar>?,
         activation: @escaping Activation = identity,
         stride: Int = 1,
         padding: Padding = .valid
     ) {
         self.depthwiseFilter = depthwiseFilter
         self.pointwiseFilter = pointwiseFilter
-        self.bias = bias
+        self.bias = bias ?? .zero
         self.activation = activation
         self.stride = stride
         self.padding = padding
+        useBias = (bias != nil)
     }
 
     /// Returns the output obtained from applying the layer to the given input.
@@ -912,7 +949,7 @@ public struct SeparableConv1D<Scalar: TensorFlowFloatingPoint>: Layer {
             strides: (1, 1, 1, 1),
             padding: padding,
             dilations: (1, 1, 1, 1))
-        return activation(x.squeezingShape(at: 1) + bias)
+        return activation(useBias ? (x.squeezingShape(at: 1) + bias) : x.squeezingShape(at: 1))
     }
 }
 
@@ -934,6 +971,7 @@ public extension SeparableConv1D {
         stride: Int = 1,
         padding: Padding = .valid,
         activation: @escaping Activation = identity,
+        useBias: Bool = true,
         depthwiseFilterInitializer: ParameterInitializer<Scalar> = glorotUniform(),
         pointwiseFilterInitializer: ParameterInitializer<Scalar> = glorotUniform(),
         biasInitializer: ParameterInitializer<Scalar> = zeros()
@@ -945,7 +983,7 @@ public extension SeparableConv1D {
         self.init(
             depthwiseFilter: depthwiseFilterInitializer(depthwiseFilterTensorShape),
             pointwiseFilter: pointwiseFilterInitializer(pointwiseFilterTensorShape),
-            bias: biasInitializer([pointwiseFilterShape.2]),
+            bias: useBias ? biasInitializer([pointwiseFilterShape.2]) : nil,
             activation: activation,
             stride: stride,
             padding: padding)
@@ -970,6 +1008,8 @@ public struct SeparableConv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let strides: (Int, Int)
     /// The padding algorithm for convolution.
     @noDerivative public let padding: Padding
+    /// Workaround optionals not being handled by AD
+    @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.
     public typealias Activation = @differentiable (Tensor<Scalar>) -> Tensor<Scalar>
@@ -989,17 +1029,18 @@ public struct SeparableConv2D<Scalar: TensorFlowFloatingPoint>: Layer {
     public init(
         depthwiseFilter: Tensor<Scalar>,
         pointwiseFilter: Tensor<Scalar>,
-        bias: Tensor<Scalar>,
+        bias: Tensor<Scalar>?,
         activation: @escaping Activation = identity,
         strides: (Int, Int) = (1, 1),
         padding: Padding = .valid
     ) {
         self.depthwiseFilter = depthwiseFilter
         self.pointwiseFilter = pointwiseFilter
-        self.bias = bias
+        self.bias = bias ?? .zero
         self.activation = activation
         self.strides = strides
         self.padding = padding
+        useBias = (bias != nil)
     }
 
     /// Returns the output obtained from applying the layer to the given input.
@@ -1013,12 +1054,13 @@ public struct SeparableConv2D<Scalar: TensorFlowFloatingPoint>: Layer {
             filter: depthwiseFilter,
             strides: (1, strides.0, strides.1, 1),
             padding: padding)
-        return activation(conv2D(
+        let conv = conv2D(
             depthwise,
             filter: pointwiseFilter,
             strides: (1, 1, 1, 1),
             padding: padding,
-            dilations: (1, 1, 1, 1)) + bias)
+            dilations: (1, 1, 1, 1))
+        return activation(useBias ? (conv + bias) : conv)
     }
 }
 
@@ -1040,6 +1082,7 @@ public extension SeparableConv2D {
         strides: (Int, Int) = (1, 1),
         padding: Padding = .valid,
         activation: @escaping Activation = identity,
+        useBias: Bool = true,
         depthwiseFilterInitializer: ParameterInitializer<Scalar> = glorotUniform(),
         pointwiseFilterInitializer: ParameterInitializer<Scalar> = glorotUniform(),
         biasInitializer: ParameterInitializer<Scalar> = zeros()
@@ -1053,7 +1096,7 @@ public extension SeparableConv2D {
         self.init(
             depthwiseFilter: depthwiseFilterInitializer(depthwiseFilterTensorShape),
             pointwiseFilter: pointwiseFilterInitializer(pointwiseFilterTensorShape),
-            bias: biasInitializer([pointwiseFilterShape.3]),
+            bias: useBias ? biasInitializer([pointwiseFilterShape.3]) : nil,
             activation: activation,
             strides: strides,
             padding: padding)

--- a/Sources/TensorFlow/Layers/Dense.swift
+++ b/Sources/TensorFlow/Layers/Dense.swift
@@ -40,7 +40,7 @@ public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
 
     public init(
         weight: Tensor<Scalar>,
-        bias: Tensor<Scalar>?,
+        bias: Tensor<Scalar>? = nil,
         activation: @escaping Activation
     ) {
         precondition(weight.rank <= 3, "The rank of the 'weight' tensor must be less than 4.")

--- a/Sources/TensorFlow/Layers/Dense.swift
+++ b/Sources/TensorFlow/Layers/Dense.swift
@@ -32,21 +32,24 @@ public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
     @noDerivative public let activation: Activation
     /// Indicates whether this is a batched dense layer.
     @noDerivative internal let batched: Bool
+    /// Workaround optionals not being handled by AD
+    @noDerivative private let useBias: Bool
 
     /// The element-wise activation function type.
     public typealias Activation = @differentiable (Tensor<Scalar>) -> Tensor<Scalar>
 
     public init(
         weight: Tensor<Scalar>,
-        bias: Tensor<Scalar>,
+        bias: Tensor<Scalar>?,
         activation: @escaping Activation
     ) {
         precondition(weight.rank <= 3, "The rank of the 'weight' tensor must be less than 4.")
-        precondition(bias.rank <= 2, "The rank of the 'bias' tensor must be less than 3.")
+        precondition(bias == nil || bias!.rank <= 2, "The rank of the 'bias' tensor must be less than 3.")
         self.weight = weight
-        self.bias = bias
+        self.bias = bias ?? .zero
         self.activation = activation
         self.batched = weight.rank == 3
+        useBias = (bias != nil)
     }
 
     /// Returns the output obtained from applying the layer to the given input.
@@ -59,7 +62,7 @@ public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
             let hidden = matmul(input.expandingShape(at: 1), weight)
             return activation(hidden.squeezingShape(at: 1) + bias)
         }
-        return activation(matmul(input, weight) + bias)
+        return activation(useBias ? (matmul(input, weight) + bias) : matmul(input, weight))
     }
 }
 
@@ -78,12 +81,13 @@ public extension Dense {
         inputSize: Int,
         outputSize: Int,
         activation: @escaping Activation = identity,
+        useBias: Bool = true,
         weightInitializer: ParameterInitializer<Scalar> = glorotUniform(),
         biasInitializer: ParameterInitializer<Scalar> = zeros()
     ) {
         self.init(
             weight: weightInitializer([inputSize, outputSize]),
-            bias: biasInitializer([outputSize]),
+            bias: useBias ? biasInitializer([outputSize]) : nil,
             activation: activation)
     }
 }

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -74,6 +74,14 @@ final class LayerTests: XCTestCase {
           shape: [2, 3, 2],
           scalars: [1.5, 4, 3, 7, 4.5, 10, 16.5, 34, 18, 37, 19.5, 40])
         XCTAssertEqual(output, expected)
+        
+        let layerNoBias = Conv1D<Float>(filter: filter, bias: nil, activation: identity, stride: 1,
+                                        padding: .valid)
+        let outputNoBias = layerNoBias.inferring(from: input)
+        let expectedNoBias = Tensor<Float>(
+          shape: [2, 3, 2],
+          scalars: [1.5, 3, 3, 6, 4.5, 9, 16.5, 33, 18, 36, 19.5, 39])
+        XCTAssertEqual(outputNoBias, expectedNoBias)
     }
 
     func testConv1DDilation() {
@@ -108,6 +116,13 @@ final class LayerTests: XCTestCase {
         let expected = Tensor<Float>(shape: [2, 1, 1, 2],
                                      scalars: [15, 16, 63, 64])
         XCTAssertEqual(output, expected)
+        
+        let layerNoBias = Conv2D<Float>(filter: filter, bias: nil, activation: identity,
+                                        strides: (2, 2), padding: .valid)
+        let outputNoBias = layerNoBias.inferring(from: input)
+        let expectedNoBias = Tensor<Float>(shape: [2, 1, 1, 2],
+                                           scalars: [15, 15, 63, 63])
+        XCTAssertEqual(outputNoBias, expectedNoBias)
     }
 
     func testConv2DGradient() {
@@ -196,6 +211,13 @@ final class LayerTests: XCTestCase {
         let expected = Tensor<Float>(shape: [2, 2, 1, 1, 2],
                                      scalars: [139, 141, 363, 365, 587, 589, 811, 813])
         XCTAssertEqual(output, expected)
+        
+        let layerNoBias = Conv3D<Float>(filter: filter, bias: nil, activation: identity,
+                                        strides: (1, 2, 1), padding: .valid, dilations: (1, 1, 1))
+        let outputNoBias = layerNoBias.inferring(from: input)
+        let expectedNoBias = Tensor<Float>(shape: [2, 2, 1, 1, 2],
+                                           scalars: [140, 140, 364, 364, 588, 588, 812, 812])
+        XCTAssertEqual(outputNoBias, expectedNoBias)
     }
 
     func testConv3DGradient() {
@@ -312,6 +334,13 @@ final class LayerTests: XCTestCase {
         let expected = Tensor<Float>(shape: [1, 1, 4, 1],
                                      scalars: [8, 9, 12, 18])
         XCTAssertEqual(output, expected)
+        
+        let layerNoBias = TransposedConv1D(filter: filter, bias: nil, activation: identity,
+                                           stride: 1, padding: .same)
+        let outputNoBias = layerNoBias.inferring(from: input)
+        let expectedNoBias = Tensor<Float>(shape: [1, 1, 4, 1],
+                                           scalars: [0, 1, 4, 10])
+        XCTAssertEqual(outputNoBias, expectedNoBias)
     }
 
     func testTransposedConv2D() {
@@ -324,6 +353,13 @@ final class LayerTests: XCTestCase {
         let expected = Tensor<Float>(shape: [1, 4, 2, 1],
                                      scalars: [8, 12, 12, 28, 24, 64, 48, 112])
         XCTAssertEqual(output, expected)
+        
+        let layerNoBias = TransposedConv2D(filter: filter, bias: nil, activation: identity,
+                                           strides: (1, 1), padding: .same)
+        let outputNoBias = layerNoBias.inferring(from: input)
+        let expectedNoBias = Tensor<Float>(shape: [1, 4, 2, 1],
+                                           scalars: [0, 4, 4, 20, 16, 56, 40, 104])
+        XCTAssertEqual(outputNoBias, expectedNoBias)
     }  
 
     
@@ -337,6 +373,13 @@ final class LayerTests: XCTestCase {
         let expected = Tensor<Float>(shape: [1, 2, 2, 2, 1],
                                      scalars: [8, 8, 8, 12, 8, 16, 24, 64])
         XCTAssertEqual(output, expected)
+        
+        let layerNoBias = TransposedConv3D(filter: filter, bias: nil, activation: identity,
+                                           strides: (1, 1, 1), padding: .same)
+        let outputNoBias = layerNoBias.inferring(from: input)
+        let expectedNoBias = Tensor<Float>(shape: [1, 2, 2, 2, 1],
+                                           scalars: [0, 0, 0, 4, 0, 8, 16, 56])
+        XCTAssertEqual(outputNoBias, expectedNoBias)
     }
 
     func testSeparableConv1D() {
@@ -353,6 +396,16 @@ final class LayerTests: XCTestCase {
         let output = layer.inferring(from: input)
         let expected = Tensor<Float>(shape: [2, 2, 1], scalars: [17, 45, 73, 101])
         XCTAssertEqual(output, expected)
+        
+        let layerNoBias = SeparableConv1D<Float>(depthwiseFilter: depthwiseFilter,
+                                           pointwiseFilter: pointwiseFilter,
+                                           bias: nil,
+                                           activation: identity,
+                                           stride: 1,
+                                           padding: .same)
+        let outputNoBias = layerNoBias.inferring(from: input)
+        let expectedNoBias = Tensor<Float>(shape: [2, 2, 1], scalars: [13, 41, 69, 97])
+        XCTAssertEqual(outputNoBias, expectedNoBias)
     }
 
     func testSeparableConv2D() {
@@ -370,6 +423,17 @@ final class LayerTests: XCTestCase {
         let expected = Tensor<Float>(shape: [2, 1, 1, 1],
                                      scalars: [1016, 2616])
         XCTAssertEqual(output, expected)
+        
+        let layerNoBias = SeparableConv2D<Float>(depthwiseFilter: depthwiseFilter,
+                                           pointwiseFilter: pointwiseFilter,
+                                           bias: nil,
+                                           activation: identity,
+                                           strides: (2, 2),
+                                           padding: .valid)
+        let outputNoBias = layerNoBias.inferring(from: input)
+        let expectedNoBias = Tensor<Float>(shape: [2, 1, 1, 1],
+                                     scalars: [1012, 2612])
+        XCTAssertEqual(outputNoBias, expectedNoBias)
     }
 
     func testSeparableConv2DGradient() {
@@ -1075,6 +1139,12 @@ final class LayerTests: XCTestCase {
         let expected = Tensor<Float>([[11.0, 15.0]])
         XCTAssertEqual(output, expected)
         XCTAssertFalse(layer.batched)
+        
+        let layerNoBias = Dense<Float>(weight: weight, bias: nil, activation: identity)
+        let outputNoBias = layerNoBias.inferring(from: input)
+        let expectedNoBias = Tensor<Float>([[10.0, 13.0]])
+        XCTAssertEqual(outputNoBias, expectedNoBias)
+        XCTAssertFalse(layerNoBias.batched)
 
         let weightBatched = Tensor<Float>(shape: [2, 2, 3], scalars: (0..<12).map(Float.init))
         let biasBatched = Tensor<Float>([[1.0, 2.0, 3.0]])

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -120,8 +120,8 @@ final class LayerTests: XCTestCase {
         let layerNoBias = Conv2D<Float>(filter: filter, bias: nil, activation: identity,
                                         strides: (2, 2), padding: .valid)
         let outputNoBias = layerNoBias.inferring(from: input)
-        let expectedNoBias = Tensor<Float>(shape: [2, 1, 1, 2],
-                                           scalars: [15, 15, 63, 63])
+        let expectedNoBias = Tensor<Float>(shape: [2, 1, 1, 1],
+                                           scalars: [14, 62])
         XCTAssertEqual(outputNoBias, expectedNoBias)
     }
 
@@ -215,8 +215,8 @@ final class LayerTests: XCTestCase {
         let layerNoBias = Conv3D<Float>(filter: filter, bias: nil, activation: identity,
                                         strides: (1, 2, 1), padding: .valid, dilations: (1, 1, 1))
         let outputNoBias = layerNoBias.inferring(from: input)
-        let expectedNoBias = Tensor<Float>(shape: [2, 2, 1, 1, 2],
-                                           scalars: [140, 140, 364, 364, 588, 588, 812, 812])
+        let expectedNoBias = Tensor<Float>(shape: [2, 2, 1, 1, 1],
+                                           scalars: [140, 364, 588, 812])
         XCTAssertEqual(outputNoBias, expectedNoBias)
     }
 


### PR DESCRIPTION
This PR makes bias optional in the dense layer and all convolutional layers. This is necessary since most models (ResNets and variants) use convolutionla layers with no bias.

Since AD does not support optionals yet, this is implemented behind the scene using a boolean flag. That flag can be removed once AD deals properly with optionals, and we can keep the same inits.