### PR TITLE
Support batched Dense without bias

### DIFF
--- a/Sources/TensorFlow/Layers/Dense.swift
+++ b/Sources/TensorFlow/Layers/Dense.swift
@@ -59,8 +59,8 @@ public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
     @differentiable
     public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
         if batched {
-            let hidden = matmul(input.expandingShape(at: 1), weight)
-            return activation(hidden.squeezingShape(at: 1) + bias)
+            let hidden = matmul(input.expandingShape(at: 1), weight).squeezingShape(at: 1)
+            return activation(useBias ? hidden + bias : hidden)
         }
         return activation(useBias ? (matmul(input, weight) + bias) : matmul(input, weight))
     }

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -1156,6 +1156,14 @@ final class LayerTests: XCTestCase {
         let expectedBatched = Tensor<Float>([[4.0, 6.0, 8.0], [40.0, 46.0, 52.0]])
         XCTAssertEqual(outputBatched, expectedBatched)
         XCTAssertTrue(layerBatched.batched)
+        
+        let layerBatchedNoBias = Dense<Float>(weight: weightBatched,
+                                        bias: nil,
+                                        activation: identity)
+        let outputBatchedNoBias = layerBatchedNoBias.inferring(from: inputBatched)
+        let expectedBatchedNoBias = Tensor<Float>([[3.0, 4.0, 5.0], [39.0, 44.0, 49.0]])
+        XCTAssertEqual(outputBatchedNoBias, expectedBatchedNoBias)
+        XCTAssertTrue(layerBatchedNoBias.batched)
     }
 
     func testDenseGradient() {


### PR DESCRIPTION
This PR add support for `Dense` with `batched == true && useBias == false` overlooked in #674.