### PR TITLE
Improve compilation time of tests

### DIFF
--- a/Tests/TensorFlowTests/OperatorTests/BasicTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/BasicTests.swift
@@ -380,11 +380,13 @@ final class BasicOperatorTests: XCTestCase {
         XCTAssertEqual(array1D.shape, [2])
 
         /// Test scalars
-        XCTAssertEqual(array3D.scalars,
-                       [Float](stride(from: 20.0, to: 30, by: 2)) +
-                       [Float](stride(from: 45.0, to: 50, by: 1)) +
-                       [Float](stride(from: 30.0, to: 40, by: 2)) +
-                       [Float](stride(from: 55.0, to: 60, by: 1)))
+        var expected: [Float] = []
+        expected.append(contentsOf: stride(from: 20.0, to: 30, by: 2))
+        expected.append(contentsOf: stride(from: 45.0, to: 50, by: 1))
+        expected.append(contentsOf: stride(from: 30.0, to: 40, by: 2))
+        expected.append(contentsOf: stride(from: 55.0, to: 60, by: 1))
+        XCTAssertEqual(array3D.scalars, expected)
+        
         XCTAssertEqual(array2D.scalars, Array(stride(from: 20.0, to: 30, by: 1)))
         XCTAssertEqual(array1D.scalars, Array(stride(from: 3.0, to: 5, by: 1)))
     }

--- a/Tests/TensorFlowTests/TensorAutoDiffTests.swift
+++ b/Tests/TensorFlowTests/TensorAutoDiffTests.swift
@@ -49,9 +49,9 @@ final class TensorAutoDiffTests: XCTestCase {
             }
             return y.0 + y.1 - z.0.0 + z.0.1
         }
-        XCTAssertTrue((value: Tensor(8), gradient: Tensor(2)) == valueWithGradient(at: Tensor(4), in: condNestedTupleVar))
-        XCTAssertTrue((value: Tensor(-20), gradient: Tensor(2)) == valueWithGradient(at: Tensor(-10), in: condNestedTupleVar))
-        XCTAssertTrue((value: Tensor(-2674), gradient: Tensor(2)) == valueWithGradient(at: Tensor(-1337), in: condNestedTupleVar))
+        XCTAssertTrue((value: Tensor<Float>(8), gradient: Tensor<Float>(2)) == valueWithGradient(at: Tensor<Float>(4), in: condNestedTupleVar))
+        XCTAssertTrue((value: Tensor<Float>(-20), gradient: Tensor<Float>(2)) == valueWithGradient(at: Tensor<Float>(-10), in: condNestedTupleVar))
+        XCTAssertTrue((value: Tensor<Float>(-2674), gradient: Tensor<Float>(2)) == valueWithGradient(at: Tensor<Float>(-1337), in: condNestedTupleVar))
 
         func guard2Var(_ x: Tensor<Float>, _ y: Tensor<Float>) -> Tensor<Float> {
             var z = y
@@ -68,10 +68,10 @@ final class TensorAutoDiffTests: XCTestCase {
             }
             return z * y
         }
-        XCTAssertTrue((Tensor(0), Tensor(10)) == gradient(at: Tensor(4), Tensor(5), in: guard2Var))
-        XCTAssertTrue((Tensor(5), Tensor(-1337)) == gradient(at: Tensor(-1337), Tensor(5), in: guard2Var))
-        XCTAssertTrue((Tensor(-2674), Tensor(0)) == gradient(at: Tensor(-1337), Tensor(-5), in: guard2Var))
-        XCTAssertTrue((Tensor(2), Tensor(-3)) == gradient(at: Tensor(-3), Tensor(2), in: guard2Var))
+        XCTAssertTrue((Tensor<Float>(0), Tensor<Float>(10)) == gradient(at: Tensor<Float>(4), Tensor<Float>(5), in: guard2Var))
+        XCTAssertTrue((Tensor<Float>(5), Tensor<Float>(-1337)) == gradient(at: Tensor<Float>(-1337), Tensor<Float>(5), in: guard2Var))
+        XCTAssertTrue((Tensor<Float>(-2674), Tensor<Float>(0)) == gradient(at: Tensor<Float>(-1337), Tensor<Float>(-5), in: guard2Var))
+        XCTAssertTrue((Tensor<Float>(2), Tensor<Float>(-3)) == gradient(at: Tensor<Float>(-3), Tensor<Float>(2), in: guard2Var))
     }
 
     func testNestedConditionals() {
@@ -91,10 +91,10 @@ final class TensorAutoDiffTests: XCTestCase {
             }
             return -y
         }
-        XCTAssertTrue((Tensor(40), Tensor(8)) == gradient(at: Tensor(4), Tensor(20), in: condNested1))
-        XCTAssertTrue((Tensor(0), Tensor(-1)) == gradient(at: Tensor(4), Tensor(21), in: condNested1))
-        XCTAssertTrue((Tensor(1), Tensor(1)) == gradient(at: Tensor(4), Tensor(5), in: condNested1))
-        XCTAssertTrue((Tensor(0), Tensor(-1)) == gradient(at: Tensor(-3), Tensor(-2), in: condNested1))
+        XCTAssertTrue((Tensor<Float>(40), Tensor<Float>(8)) == gradient(at: Tensor<Float>(4), Tensor<Float>(20), in: condNested1))
+        XCTAssertTrue((Tensor<Float>(0), Tensor<Float>(-1)) == gradient(at: Tensor<Float>(4), Tensor<Float>(21), in: condNested1))
+        XCTAssertTrue((Tensor<Float>(1), Tensor<Float>(1)) == gradient(at: Tensor<Float>(4), Tensor<Float>(5), in: condNested1))
+        XCTAssertTrue((Tensor<Float>(0), Tensor<Float>(-1)) == gradient(at: Tensor<Float>(-3), Tensor<Float>(-2), in: condNested1))
 
         // Test tensor-scalar ops.
         func condNested2(_ x: Tensor<Float>, _ y: Float) -> Tensor<Float> {
@@ -181,13 +181,13 @@ final class TensorAutoDiffTests: XCTestCase {
 
     func testPlus() {
         func f(a: Tensor<Float>, b: Tensor<Float>) -> Tensor<Float> { a + b }
-        XCTAssertTrue((Tensor(1), Tensor(1)) == gradient(at: Tensor(0), Tensor(0), in: f))
+        XCTAssertTrue((Tensor<Float>(1), Tensor<Float>(1)) == gradient(at: Tensor<Float>(0), Tensor<Float>(0), in: f))
         XCTAssertTrue(([1], [1]) == pullback(at: [1], [10], in: f)([1]))
     }
 
     func testSubtract() {
         func f(a: Tensor<Float>, b: Tensor<Float>) -> Tensor<Float> { a - b }
-        XCTAssertTrue((Tensor(1), Tensor(-1)) == gradient(at: Tensor(0), Tensor(0), in: f))
+        XCTAssertTrue((Tensor<Float>(1), Tensor<Float>(-1)) == gradient(at: Tensor<Float>(0), Tensor<Float>(0), in: f))
         XCTAssertTrue(([1], [-1]) == pullback(at: [1], [10], in: f)([1]))
     }
 


### PR DESCRIPTION
Some statements in tests were taking long time in my environment.
In this PR I picked statements that taking especially long time and improved them.

Before:
```
$ swift package clean
$ time swift build --build-tests
[98/98] Linking TensorFlowPackageTests

real	3m13.124s
user	6m19.496s
sys	0m15.955s
```

After:
```
$ swift package clean
$ time swift build --build-tests
[98/98] Linking TensorFlowPackageTests

real	1m5.428s
user	3m51.157s
sys	0m13.760s
```