### PR TITLE
[Dockerfile] Use `rm -f`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,10 @@ RUN cmake --build /BinaryCache/tensorflow-swift-apis --verbose
 
 # Clean out existing artifacts.
 # TODO: move into bash scripts...
-RUN rm /swift-tensorflow-toolchain/usr/lib/swift/linux/x86_64/TensorFlow.swiftinterface
-RUN rm /swift-tensorflow-toolchain/usr/lib/swift/linux/x86_64/TensorFlow.swiftdoc
-RUN rm /swift-tensorflow-toolchain/usr/lib/swift/linux/x86_64/TensorFlow.swiftmodule
-RUN rm /swift-tensorflow-toolchain/usr/lib/swift/linux/libswiftTensorFlow.so
+RUN rm -f /swift-tensorflow-toolchain/usr/lib/swift/linux/x86_64/TensorFlow.swiftinterface
+RUN rm -f /swift-tensorflow-toolchain/usr/lib/swift/linux/x86_64/TensorFlow.swiftdoc
+RUN rm -f /swift-tensorflow-toolchain/usr/lib/swift/linux/x86_64/TensorFlow.swiftmodule
+RUN rm -f /swift-tensorflow-toolchain/usr/lib/swift/linux/libswiftTensorFlow.so
 
 # Benchmark compile times
 RUN python3 Tools/benchmark_compile.py /swift-tensorflow-toolchain/usr/bin/swift benchmark_results.xml


### PR DESCRIPTION
Use `rm -f`, which succeeds even when the argument file doesn't exist.

---

Uncovered during `apple/swift` build changes https://github.com/apple/swift/pull/30018:
```console
Step 14/36 : RUN rm /swift-tensorflow-toolchain/usr/lib/swift/linux/x86_64/TensorFlow.swiftinterface
 ---> Running in 02dc699a647d
[91mrm: cannot remove '/swift-tensorflow-toolchain/usr/lib/swift/linux/x86_64/TensorFlow.swiftinterface': No such file or directory
[0mThe command '/bin/sh -c rm /swift-tensorflow-toolchain/usr/lib/swift/linux/x86_64/TensorFlow.swiftinterface' returned a non-zero code: 1
```