### PR TITLE
[build] Set macOS minimum deployment version to 10.13.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 //
 // Copyright 2019 The TensorFlow Authors. All Rights Reserved.
@@ -19,6 +19,9 @@ import PackageDescription
 
 let package = Package(
   name: "TensorFlow",
+  platforms: [
+    .macOS(.v10_13),
+  ],
   products: [
     .library(
       name: "TensorFlow",


### PR DESCRIPTION
macOS 10.13 matches the minimum deployment version of PythonKit.

SwiftPM commands like `swift build` now work without the need to specify
`-Xswiftc -target -Xswiftc x86_64-apple-macosx10.13`.

---

Resolves #714.
Verified that `swift build` works on macOS with the [2020-03-03 macOS toolchain](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-03-03-a-osx.pkg).