### PR TITLE
Mark `Dense.init(weight:bias:activation)` as `@differentiable`.

### DIFF
--- a/Sources/TensorFlow/Layers/Dense.swift
+++ b/Sources/TensorFlow/Layers/Dense.swift
@@ -38,6 +38,11 @@ public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
   /// The element-wise activation function type.
   public typealias Activation = @differentiable (Tensor<Scalar>) -> Tensor<Scalar>
 
+  /// Creates an instance from the given weight, optional bias, and activation function.
+  ///
+  /// - Note: currently, `weight` is the only differentiability parameter. `bias` can be made a
+  ///   differentiability parameter after `Optional` conditionally conforms to `Differentiable`:
+  ///   TF-499.
   @differentiable(wrt: weight)
   public init(
     weight: Tensor<Scalar>,

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -1427,6 +1427,15 @@ final class LayerTests: XCTestCase {
   func testDenseGradient() {
     let weight = Tensor<Float>(shape: [4, 8], scalars: (0..<32).map(Float.init))
     let bias = Tensor<Float>(shape: [1, 8], scalars: (0..<8).map(Float.init))
+
+    // Test `Dense.init` derivative.
+    let denseInitPullback = pullback(at: weight) { weight in
+      Dense(weight: weight, bias: bias, activation: identity)
+    }
+    let weightGrad = denseInitPullback(.init(weight: Tensor(100), bias: Tensor(1)))
+    XCTAssertEqual(Tensor(100), weightGrad)
+
+    // Test `Dense.callAsFunction` derivative.
     let layer = Dense<Float>(weight: weight, bias: bias, activation: identity)
     let x = Tensor<Float>(shape: [2, 4], scalars: (0..<8).map(Float.init))
     let grad = gradient(at: x, layer) { $1($0).squared().sum() }


### PR DESCRIPTION
Currently, `weight` is the only differentiability parameter.

Making `bias` a differentiability parameter requires `Optional` differentiation:
https://bugs.swift.org/browse/TF-1153.