### PR TITLE
Constrain randomCategorialLogits to be TensorFlowFloatingPoint in Tens…

### DIFF
--- a/Sources/TensorFlow/Initializers.swift
+++ b/Sources/TensorFlow/Initializers.swift
@@ -477,7 +477,7 @@ extension Tensor where Scalar: TensorFlowIndex {
   ///
   /// - Returns: 2-D Tensor with shape `[batchSize, sampleCount]`.  Each slice `[i, :]`
   ///     contains the drawn class labels with range `[0, classCount)`.
-  public init<T: TensorFlowNumeric>(
+  public init<T: TensorFlowFloatingPoint>(
     randomCategorialLogits: Tensor<T>,
     sampleCount: Int32,
     seed: TensorFlowSeed = Context.local.randomSeed


### PR DESCRIPTION
It throws such error when I feed in Int type tensor and run on codelab:

Fatal error: Could not find valid device for node.
Node:{{node StatelessMultinomial}}
All kernels registered for op StatelessMultinomial :
  device='XLA_GPU'; T in [DT_FLOAT, DT_BFLOAT16]; output_dtype in [DT_INT32, DT_INT64]; Tseed in [DT_INT32]
  device='XLA_CPU'; T in [DT_FLOAT, DT_BFLOAT16]; output_dtype in [DT_INT32, DT_INT64]; Tseed in [DT_INT32]
  device='XLA_CPU_JIT'; T in [DT_FLOAT, DT_BFLOAT16]; output_dtype in [DT_INT32, DT_INT64]; Tseed in [DT_INT32]
  device='XLA_GPU_JIT'; T in [DT_FLOAT, DT_BFLOAT16]; output_dtype in [DT_INT32, DT_INT64]; Tseed in [DT_INT32]
  device='GPU'; T in [DT_DOUBLE]; output_dtype in [DT_INT64]
  device='GPU'; T in [DT_DOUBLE]; output_dtype in [DT_INT32]
  device='GPU'; T in [DT_FLOAT]; output_dtype in [DT_INT64]
  device='GPU'; T in [DT_FLOAT]; output_dtype in [DT_INT32]
  device='GPU'; T in [DT_HALF]; output_dtype in [DT_INT64]
  device='GPU'; T in [DT_HALF]; output_dtype in [DT_INT32]
  device='CPU'; T in [DT_DOUBLE]; output_dtype in [DT_INT64]
  device='CPU'; T in [DT_DOUBLE]; output_dtype in [DT_INT32]
  device='CPU'; T in [DT_FLOAT]; output_dtype in [DT_INT64]
  device='CPU'; T in [DT_FLOAT]; output_dtype in [DT_INT32]
  device='CPU'; T in [DT_HALF]; output_dtype in [DT_INT64]
  device='CPU'; T in [DT_HALF]; output_dtype in [DT_INT32]

We should constrain it to be TensorFlowFloatingPoint so that compiler will give a more descriptive error.