### PR TITLE
NFC: typo fix.

### DIFF
--- a/Sources/TensorFlow/Core/DataTypes.swift
+++ b/Sources/TensorFlow/Core/DataTypes.swift
@@ -80,7 +80,7 @@ extension Int64: TensorFlowIndex {}
 /// A floating-point data type that conforms to `Differentiable` and is compatible with TensorFlow.
 ///
 /// - Note: `Tensor` conditionally conforms to `Differentiable` when the `Scalar` associated type
-///   conforms `TensorFlowFloatingPoint`.
+///   conforms to `TensorFlowFloatingPoint`.
 public protocol TensorFlowFloatingPoint:
   TensorFlowScalar & BinaryFloatingPoint & Differentiable & ElementaryFunctions
 where


### PR DESCRIPTION
"conforms `TensorFlowFloatingPoint`" -> "conforms to `TensorFlowFloatingPoint`"