### PR TITLE
build: run the tests with CMake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update
 RUN apt-get -yq install --no-install-recommends cmake ninja-build
 RUN cmake -G Ninja -D CMAKE_BUILD_TYPE=Release -D CMAKE_Swift_COMPILER=/swift-tensorflow-toolchain/usr/bin/swiftc -D USE_BUNDLED_CTENSORFLOW=YES -D TensorFlow_INCLUDE_DIR=/swift-tensorflow-toolchain/usr/lib/swift/linux/x86_64/modulemaps/CTensorFlow -D TensorFlow_LIBRARY=/swift-tensorflow-toolchain/usr/lib/swift/linux/libtensorflow.so -B /BinaryCache/tensorflow-swift-apis -S /swift-apis
 RUN cmake --build /BinaryCache/tensorflow-swift-apis --verbose
+RUN cmake --build /BinaryCache/tensorflow-swift-apis --target test
 
 # Clean out existing artifacts.
 # TODO: move into bash scripts...


### PR DESCRIPTION
Enable running tests with CMake as well.  This will make it easier to
enable X10 testing.