### PR TITLE
[DNM] X10: do not expose the C X10 interfaces

### DIFF
--- a/Sources/TensorFlow/Core/MixedPrecision.swift
+++ b/Sources/TensorFlow/Core/MixedPrecision.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #if USING_X10_BACKEND
+@_implementationOnly
 import x10_xla_tensor_wrapper
 
 /// A type whose nested floating-point tensor properties and elements can be converted from full

--- a/Sources/x10/swift_bindings/Device.swift
+++ b/Sources/x10/swift_bindings/Device.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@_implementationOnly
 import x10_device_wrapper
 
 extension DeviceType {

--- a/Sources/x10/swift_bindings/Device.swift
+++ b/Sources/x10/swift_bindings/Device.swift
@@ -88,7 +88,7 @@ public struct Device {
     }
   }
 
-  public var cdevice: CDevice {
+  internal var cdevice: CDevice {
     return CDevice(hw_type: kind.deviceType, ordinal: Int32(ordinal))
   }
 
@@ -165,8 +165,8 @@ extension Device: CustomStringConvertible {
   public var description: String { "Device(kind: .\(kind.shortName), ordinal: \(ordinal))" }
 }
 
-extension CDevice {
-  public var device: Device {
+internal extension CDevice {
+  var device: Device {
     return Device(kind: hw_type.kind, ordinal: Int(ordinal))
   }
 }

--- a/Sources/x10/swift_bindings/XLAScalarType.swift
+++ b/Sources/x10/swift_bindings/XLAScalarType.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@_implementationOnly
 import x10_xla_tensor_wrapper
 
 extension XLAScalar {

--- a/Sources/x10/swift_bindings/XLATensor.swift
+++ b/Sources/x10/swift_bindings/XLATensor.swift
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 import x10_device
+@_implementationOnly
 import x10_xla_tensor_tf_ops
+@_implementationOnly
 import x10_xla_tensor_wrapper
 
 /// Type-erased tensor type on which the fundamental operators are implemented.

--- a/Sources/x10/swift_bindings/apis/RawOpsManual.swift
+++ b/Sources/x10/swift_bindings/apis/RawOpsManual.swift
@@ -16,7 +16,9 @@
 // support the current tensorflow API.
 
 import x10_device
+@_implementationOnly
 import x10_xla_tensor_tf_ops
+@_implementationOnly
 import x10_xla_tensor_wrapper
 
 @available(

--- a/Sources/x10/swift_bindings/training_loop.swift
+++ b/Sources/x10/swift_bindings/training_loop.swift
@@ -14,6 +14,7 @@
 
 import x10_device
 import x10_tensor
+@_implementationOnly
 import x10_xla_tensor_wrapper
 
 /// Collects correct prediction counters and loss totals.

--- a/Tests/x10/keypathiterable_test.swift
+++ b/Tests/x10/keypathiterable_test.swift
@@ -3,6 +3,7 @@
 import XCTest
 import x10_device
 import x10_tensor
+@_implementationOnly
 import x10_xla_tensor_wrapper
 
 extension KeyPathIterable {

--- a/Tests/x10/ops_test.swift
+++ b/Tests/x10/ops_test.swift
@@ -2,6 +2,7 @@ import TensorFlow
 import XCTest
 import x10_device
 import x10_tensor
+@_implementationOnly
 import x10_xla_tensor_wrapper
 
 typealias TFTensor_ = TensorFlow.Tensor

--- a/Tests/x10/xla_tensor_test.swift
+++ b/Tests/x10/xla_tensor_test.swift
@@ -1,6 +1,7 @@
 import XCTest
 import x10_device
 import x10_tensor
+@_implementationOnly
 import x10_xla_tensor_wrapper
 
 /// Direct tests of xla tensor.


### PR DESCRIPTION
This avoids the user from having to transitively include the X10 C++
interfaces when using the X10 Swift interface.