### PR TITLE
tests: shuffle tests into the tests directory

### DIFF
--- a/Sources/x10/CMakeLists.txt
+++ b/Sources/x10/CMakeLists.txt
@@ -108,26 +108,6 @@ set_target_properties(x10_training_loop PROPERTIES
 target_link_libraries(x10_training_loop PUBLIC
   x10_tensor)
 
-add_executable(ops_test ../../Tests/x10/ops_test.swift)
-target_link_libraries(ops_test PRIVATE
-  x10_device
-  x10_tensor
-  TensorFlow)
-
-add_executable(xla_tensor_test ../../Tests/x10/xla_tensor_test.swift)
-target_link_libraries(xla_tensor_test PRIVATE
-  x10_device
-  x10_tensor)
-
-add_executable(keypathiterable_test ../../Tests/x10/keypathiterable_test.swift)
-target_link_libraries(keypathiterable_test PRIVATE
-  x10_device
-  x10_tensor)
-
-add_executable(tensor_visitor_plan_test ../../Tests/x10/TensorVisitorPlanTest.swift)
-target_link_libraries(tensor_visitor_plan_test PRIVATE
-  x10_optimizers_tensor_visitor_plan)
-
 
 _install_target(x10_device)
 _install_target(x10_tensor)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -22,3 +22,38 @@ add_test(NAME SwiftAPIsTests
 # the `DT_RUNPATH` on the binary is set properly.
 set_tests_properties(SwiftAPIsTests PROPERTIES
   ENVIRONMENT LD_LIBRARY_PATH=$<TARGET_FILE_DIR:Tensor>:$<TARGET_FILE_DIR:TensorFlow>)
+
+if(BUILD_X10)
+  add_executable(ops_test
+    x10/ops_test.swift)
+  target_link_libraries(ops_test PRIVATE
+    x10_device
+    x10_tensor
+    TensorFlow)
+
+  add_executable(xla_tensor_test
+    x10/xla_tensor_test.swift)
+  target_link_libraries(xla_tensor_test PRIVATE
+    x10_device
+    x10_tensor)
+
+  add_executable(keypathiterable_test
+    x10/keypathiterable_test.swift)
+  target_link_libraries(keypathiterable_test PRIVATE
+    x10_device
+    x10_tensor)
+
+  add_executable(tensor_visitor_plan_test
+    x10/TensorVisitorPlanTest.swift)
+  target_link_libraries(tensor_visitor_plan_test PRIVATE
+    x10_optimizers_tensor_visitor_plan)
+
+  add_test(NAME X10Operations
+    COMMAND ops_test)
+  add_test(NAME X10XLATensor
+    COMMAND xla_tensor_test)
+  add_test(NAME X10KeyPathIterable
+    COMMAND keypathiterable_test)
+  add_test(NAME X10VisitorPlan
+    COMMAND tensor_visitor_plan_test)
+endif()


### PR DESCRIPTION
X10 tests were previously located in the X10 directory rather than in
the tests directory.  This consolidates the tests into a single location
which prevents unnecessarily building them if tests are disabled.