### PR TITLE
Tests: correct dependency tracking

### DIFF
--- a/Tests/TensorFlowTests/CMakeLists.txt
+++ b/Tests/TensorFlowTests/CMakeLists.txt
@@ -35,4 +35,5 @@ add_library(TensorFlowTests
   OperatorTests/MatrixTests.swift)
 target_link_libraries(TensorFlowTests PUBLIC
   TensorFlow
+  Tensor
   XCTest)


### PR DESCRIPTION
These tests require linking against Tensor, add the explicit dependency.