### PR TITLE
docker: split up the command (NFC)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,15 @@ RUN curl -qL https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key a
 RUN echo 'deb https://apt.kitware.com/ubuntu/ bionic main' >> /etc/apt/sources.list
 RUN apt-get update
 RUN apt-get -yq install --no-install-recommends cmake ninja-build
-RUN cmake -G Ninja -D CMAKE_BUILD_TYPE=Release -D CMAKE_Swift_COMPILER=/swift-tensorflow-toolchain/usr/bin/swiftc -D USE_BUNDLED_CTENSORFLOW=YES -D TensorFlow_INCLUDE_DIR=/swift-tensorflow-toolchain/usr/lib/swift/linux/x86_64/modulemaps/CTensorFlow -D TensorFlow_LIBRARY=/swift-tensorflow-toolchain/usr/lib/swift/linux/libtensorflow.so -B /BinaryCache/tensorflow-swift-apis -S /swift-apis
+RUN cmake                                                                       \
+      -B /BinaryCache/tensorflow-swift-apis                                     \
+      -D CMAKE_BUILD_TYPE=Release                                               \
+      -D CMAKE_Swift_COMPILER=/swift-tensorflow-toolchain/usr/bin/swiftc        \
+      -D TensorFlow_INCLUDE_DIR=/swift-tensorflow-toolchain/usr/lib/swift/linux/x86_64/modulemaps/CTensorFlow \
+      -D TensorFlow_LIBRARY=/swift-tensorflow-toolchain/usr/lib/swift/linux/libtensorflow.so \
+      -D USE_BUNDLED_CTENSORFLOW=YES                                            \
+      -G Ninja                                                                  \
+      -S /swift-apis
 RUN cmake --build /BinaryCache/tensorflow-swift-apis --verbose
 RUN cmake --build /BinaryCache/tensorflow-swift-apis --target test
 


### PR DESCRIPTION
Split up the cmake invocation over multiple lines to make it easier to
see the command arguments when skimming over the file.  This simply adds
a ton of whitespace to the command when executed, but has no functional
difference.  Take the opportunity to sort the arguments.