### PR TITLE
Unify optimizer numerical correctness tests.

### DIFF
--- a/Tests/TensorFlowTests/OptimizerTests.swift
+++ b/Tests/TensorFlowTests/OptimizerTests.swift
@@ -16,6 +16,8 @@ import TensorFlow
 import XCTest
 
 class OptimizerTests: XCTestCase {
+  /// A dense layer for testing optimizer convergence.
+  // TODO: Consider replacing users with `Dense`.
   struct Model: Layer {
     var dense1 = Dense<Float>(weight: [[0.8]], bias: [0.8], activation: identity)
 
@@ -25,7 +27,8 @@ class OptimizerTests: XCTestCase {
     }
   }
 
-  func convergenceTest<Opt: Optimizer>(
+  /// Check that `model` converges after updating it with `optimizer` `stepCount` times.
+  func testConvergence<Opt: Optimizer>(
     optimizer: Opt,
     model: Model,
     file: StaticString = #file,
@@ -44,226 +47,170 @@ class OptimizerTests: XCTestCase {
       }
       optimizer.update(&model, along: grad)
 
+      // Break if model has converged.
       if model(x).isAlmostEqual(to: y) {
         break
       }
     }
 
+    // Check that model has converged.
     XCTAssertTrue(model(x).isAlmostEqual(to: y), file: file, line: line)
   }
 
   func testSGD() {
     let model = Model()
     let optimizer = SGD(for: model)
-    convergenceTest(optimizer: optimizer, model: model)
+    testConvergence(optimizer: optimizer, model: model)
   }
 
   func testRMSProp() {
     let model = Model()
     let optimizer = RMSProp(for: model)
-    convergenceTest(optimizer: optimizer, model: model)
+    testConvergence(optimizer: optimizer, model: model)
   }
 
   func testAdaGrad() {
     let model = Model()
     let optimizer = AdaGrad(for: model, learningRate: 0.01)
-    convergenceTest(optimizer: optimizer, model: model)
+    testConvergence(optimizer: optimizer, model: model)
   }
 
   func testAdaDelta() {
     let model = Model()
     let optimizer = AdaDelta(for: model)
-    convergenceTest(optimizer: optimizer, model: model)
+    testConvergence(optimizer: optimizer, model: model)
   }
 
   func testAdam() {
     let model = Model()
     let optimizer = Adam(for: model)
-    convergenceTest(optimizer: optimizer, model: model)
+    testConvergence(optimizer: optimizer, model: model)
   }
 
   func testAdaMax() {
     let model = Model()
     let optimizer = AdaMax(for: model)
-    convergenceTest(optimizer: optimizer, model: model)
+    testConvergence(optimizer: optimizer, model: model)
   }
 
   func testAMSGrad() {
     let model = Model()
     let optimizer = AMSGrad(for: model)
-    convergenceTest(optimizer: optimizer, model: model)
+    testConvergence(optimizer: optimizer, model: model)
   }
 
   func testRAdam() {
     let model = Model()
     let optimizer = RAdam(for: model)
-    convergenceTest(optimizer: optimizer, model: model)
+    testConvergence(optimizer: optimizer, model: model)
   }
 
-  struct ModelNumerical: Differentiable, KeyPathIterable {
-    var tensor = Tensor<Float>([0, 1, 2])
-    static let grad = ModelNumerical.TangentVector(tensor: [0.0, 0.1, 0.2])
+  /// A `Tensor<Float>` wrapper for testing optimizer numerical correctness.
+  /// - Note: `KeyPathIterable` conformance is needed for `SGD`.
+  struct NumericalValues: Differentiable & KeyPathIterable {
+    var value = Tensor<Float>([0, 0, 0])
+  }
+
+  /// Check expected weight and bias after updating `model` with `optimizer` `stepCount` times.
+  ///
+  /// - Note: optimizer correctness reference implementations exist at
+  ///   `Utilities/ReferenceImplementations/optimizers.py`.
+  func testNumericalCorrectness<Opt: Optimizer>(
+    optimizer: Opt,
+    startingValues: NumericalValues,
+    expectedValues: Tensor<Float>,
+    stepCount: Int = 1000,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) where Opt.Model == NumericalValues {
+    var optimizer = optimizer
+    var values = startingValues
+    let gradient = NumericalValues.TangentVector(value: [-0.5, 0.1, 3])
+    for _ in 0..<stepCount {
+      optimizer.update(&values, along: gradient)
+    }
+    XCTAssertEqual(values.value, expectedValues, file: file, line: line)
   }
 
   func testSGDNumerical() {
-    // The expected value was computed using the following Python code:
-    // ```
-    // import tensorflow as tf
-    // var = tf.Variable([0, 1, 2], dtype=tf.float32)
-    // grad = tf.Variable([0, 0.1, 0.2], dtype=tf.dtypes.float32)
-    // optimizer = tf.keras.optimizers.SGD()
-    // optimizer.apply_gradients(list(zip([grad], [var])))
-    // print(var.read_value())
-    // for i in range(10):
-    //     optimizer.apply_gradients(list(zip([grad], [var])))
-    // print(var.read_value())
-    // ```
-    var model = ModelNumerical()
-    let opt = SGD(for: model)
-    opt.update(&model, along: ModelNumerical.grad)
-    XCTAssertEqual(model.tensor, [0, 0.999, 1.998])
-    for _ in 0..<10 {
-      opt.update(&model, along: ModelNumerical.grad)
-    }
-    XCTAssertEqual(model.tensor, [0, 0.98900014, 1.9780003])
+    let values = NumericalValues()
+    let optimizer = SGD(for: values, learningRate: 1e-3)
+    // FIXME: Investigate large differences with Python reference implementation results:
+    // `[ 0.49999967, -0.00999999, -0.01999998]`.
+    testNumericalCorrectness(
+      optimizer: optimizer, startingValues: values,
+      expectedValues: [0.49999535, -0.10000112, -3.000017])
   }
 
   func testRMSPropNumerical() {
-    // The expected value was computed using the following Python code:
-    // ```
-    // import tensorflow as tf
-    // var = tf.Variable([0, 1, 2], dtype=tf.float32)
-    // grad = tf.Variable([0, 0.1, 0.2], dtype=tf.dtypes.float32)
-    // optimizer = tf.keras.optimizers.RMSProp()
-    // optimizer.apply_gradients(list(zip([grad], [var])))
-    // print(var.read_value())
-    // for i in range(10):
-    //     optimizer.apply_gradients(list(zip([grad], [var])))
-    // print(var.read_value())
-    // ```
-    var model = ModelNumerical()
-    let opt = RMSProp(for: model, epsilon: 1e-7)
-    opt.update(&model, along: ModelNumerical.grad)
-    XCTAssertEqual(model.tensor, [0, 0.99683774, 1.9968377])
-    for _ in 0..<10 {
-      opt.update(&model, along: ModelNumerical.grad)
-    }
-    XCTAssertEqual(model.tensor, [0, 0.9814604, 1.9814601])
+    let values = NumericalValues()
+    let optimizer = RMSProp(for: values, learningRate: 1e-3, epsilon: 1e-7)
+    // FIXME: Investigate small differences with Python reference implementation results:
+    // `[ 1.0091327, -1.0091326, -1.0091326]`.
+    testNumericalCorrectness(
+      optimizer: optimizer, startingValues: values,
+      expectedValues: [1.0091327, -1.0091326, -1.0091327])
   }
 
   func testAdamNumerical() {
-    // The expected value was computed using the following Python code:
-    // ```
-    // import tensorflow as tf
-    // var = tf.Variable([0, 1, 2], dtype=tf.float32)
-    // grad = tf.Variable([0, 0.1, 0.2], dtype=tf.dtypes.float32)
-    // optimizer = tf.keras.optimizers.Adam()
-    // optimizer.apply_gradients(list(zip([grad], [var])))
-    // print(var.read_value())
-    // for i in range(10):
-    //     optimizer.apply_gradients(list(zip([grad], [var])))
-    // print(var.read_value())
-    // ```
-    var model = ModelNumerical()
-    let opt = Adam(for: model, epsilon: 1e-7)
-    opt.update(&model, along: ModelNumerical.grad)
-    XCTAssertEqual(model.tensor, [0, 0.999, 1.9990001])
-    for _ in 0..<10 {
-      opt.update(&model, along: ModelNumerical.grad)
-    }
-    XCTAssertEqual(model.tensor, [0, 0.98900014, 1.9889997])
+    let values = NumericalValues()
+    let optimizer = Adam(for: values, learningRate: 1e-3, epsilon: 1e-7)
+    // FIXME: Investigate small differences with Python reference implementation results:
+    // `[ 0.9999907, -0.9999898, -0.9999904]`.
+    testNumericalCorrectness(
+      optimizer: optimizer, startingValues: values,
+      expectedValues: [0.9999906, -0.9999898, -0.99999064])
   }
 
   func testAdaDeltaNumerical() {
-    // The expected value was computed using the following Python code:
-    // ```
-    // import tensorflow as tf
-    // var = tf.Variable([0, 1, 2], dtype=tf.float32)
-    // grad = tf.Variable([0, 0.1, 0.2], dtype=tf.dtypes.float32)
-    // optimizer = tf.keras.optimizers.Adadelta()
-    // optimizer.apply_gradients(list(zip([grad], [var])))
-    // print(var.read_value())
-    // for i in range(10):
-    //     optimizer.apply_gradients(list(zip([grad], [var])))
-    // print(var.read_value())
-    // ```
-    var model = ModelNumerical()
-    let opt = AdaDelta(for: model, learningRate: 1e-3, epsilon: 1e-7)
-    opt.update(&model, along: ModelNumerical.grad)
-    XCTAssertEqual(model.tensor, [0, 0.99999857, 1.9999986])
-    for _ in 0..<10 {
-      opt.update(&model, along: ModelNumerical.grad)
-    }
-    XCTAssertEqual(model.tensor, [0, 0.99998385, 1.9999841])
+    let values = NumericalValues()
+    let optimizer = AdaDelta(for: values, learningRate: 1e-3, epsilon: 1e-7)
+    // FIXME: Investigate small differences with Python reference implementation results:
+    // `[ 0.00215183, -0.00215151, -0.00215175]`.
+    testNumericalCorrectness(
+      optimizer: optimizer, startingValues: values,
+      expectedValues: [0.0021518078, -0.002151505, -0.0021518408])
   }
 
   func testAMSGradNumerical() {
-    // The expected value was computed using the following Python code:
-    // ```
-    // import tensorflow as tf
-    // var = tf.Variable([0, 1, 2], dtype=tf.float32)
-    // grad = tf.Variable([0, 0.1, 0.2], dtype=tf.dtypes.float32)
-    // optimizer = tf.keras.optimizers.Adam(amsgrad=True)
-    // optimizer.apply_gradients(list(zip([grad], [var])))
-    // print(var.read_value())
-    // for i in range(10):
-    //     optimizer.apply_gradients(list(zip([grad], [var])))
-    // print(var.read_value())
-    // ```
-    var model = ModelNumerical()
-    let opt = AMSGrad(for: model, epsilon: 1e-7)
-    opt.update(&model, along: ModelNumerical.grad)
-    XCTAssertEqual(model.tensor, [0, 0.999, 1.9990001])
-    for _ in 0..<10 {
-      opt.update(&model, along: ModelNumerical.grad)
-    }
-    XCTAssertEqual(model.tensor, [0, 0.98900014, 1.9889997])
+    let values = NumericalValues()
+    let optimizer = AMSGrad(for: values, learningRate: 1e-3, epsilon: 1e-7)
+    // FIXME: Investigate small differences with Python reference implementation results:
+    // `[ 0.9999907, -0.9999898, -0.9999904]`.
+    testNumericalCorrectness(
+      optimizer: optimizer, startingValues: values,
+      expectedValues: [0.9999906, -0.9999898, -0.99999064])
   }
 
   func testAdaMaxNumerical() {
-    // The expected value was computed using the following Python code:
-    // ```
-    // import tensorflow as tf
-    // var = tf.Variable([0, 1, 2], dtype=tf.float32)
-    // grad = tf.Variable([0, 0.1, 0.2], dtype=tf.dtypes.float32)
-    // optimizer = tf.keras.optimizers.Adamax()
-    // optimizer.apply_gradients(list(zip([grad], [var])))
-    // print(var.read_value())
-    // for i in range(10):
-    //     optimizer.apply_gradients(list(zip([grad], [var])))
-    // print(var.read_value())
-    // ```
-    var model = ModelNumerical()
-    let opt = AdaMax(for: model, learningRate: 1e-3, epsilon: 1e-7)
-    opt.update(&model, along: ModelNumerical.grad)
-    XCTAssertEqual(model.tensor, [0, 0.999, 1.999])
-    for _ in 0..<10 {
-      opt.update(&model, along: ModelNumerical.grad)
-    }
-    XCTAssertEqual(model.tensor, [0, 0.98900014, 1.9889995])
+    let values = NumericalValues()
+    let optimizer = AdaMax(for: values, learningRate: 1e-3, epsilon: 1e-7)
+    // FIXME: Investigate small differences with Python reference implementation results:
+    // `[ 0.99999076, -0.99999064, -0.99999064]`.
+    testNumericalCorrectness(
+      optimizer: optimizer, startingValues: values,
+      expectedValues: [0.9999907, -0.99999064, -0.9999907])
   }
 
   func testAdaGradNumerical() {
-    // The expected value was computed using the following Python code:
-    // ```
-    // import tensorflow as tf
-    // var = tf.Variable([0, 1, 2], dtype=tf.float32)
-    // grad = tf.Variable([0, 0.1, 0.2], dtype=tf.dtypes.float32)
-    // optimizer = tf.keras.optimizers.Adagrad()
-    // optimizer.apply_gradients(list(zip([grad], [var])))
-    // print(var.read_value())
-    // for i in range(10):
-    //     optimizer.apply_gradients(list(zip([grad], [var])))
-    // print(var.read_value())
-    // ```
-    var model = ModelNumerical()
-    let opt = AdaGrad(for: model, learningRate: 1e-3, epsilon: 1e-7)
-    opt.update(&model, along: ModelNumerical.grad)
-    XCTAssertEqual(model.tensor, [0, 0.99969846, 1.9994655])
-    for _ in 0..<10 {
-      opt.update(&model, along: ModelNumerical.grad)
-    }
-    XCTAssertEqual(model.tensor, [0, 0.9972076, 1.9959843])
+    let values = NumericalValues()
+    let optimizer = AdaGrad(for: values, learningRate: 1e-3, epsilon: 1e-7)
+    // FIXME: Investigate large differences with Python reference implementation results:
+    // `[ 0.06179592, -0.05709525, -0.05987222]`.
+    testNumericalCorrectness(
+      optimizer: optimizer, startingValues: values,
+      expectedValues: [0.061354622, -0.057095252, -0.061786927])
+  }
+
+  func testRAdamNumerical() {
+    let values = NumericalValues()
+    let optimizer = RAdam(for: values, learningRate: 1e-3, epsilon: 1e-7)
+    // FIXME: Investigate large differences with Python reference implementation results:
+    // `[ 0.46914074, -0.44463935, -0.44513944]`.
+    // Pending fix: https://github.com/tensorflow/swift-apis/pull/700
+    testNumericalCorrectness(
+      optimizer: optimizer, startingValues: values,
+      expectedValues: [ 443.81192, -443.80478, -443.85016])
   }
 
   static var allTests = [

--- a/Tests/TensorFlowTests/OptimizerTests.swift
+++ b/Tests/TensorFlowTests/OptimizerTests.swift
@@ -135,7 +135,7 @@ class OptimizerTests: XCTestCase {
   func testSGDNumerical() {
     let values = NumericalValues()
     let optimizer = SGD(for: values, learningRate: 1e-3)
-    // FIXME: Investigate large differences with Python reference implementation results:
+    // FIXME(TF-759): Investigate large differences with Python reference implementation results:
     // `[ 0.49999967, -0.00999999, -0.01999998]`.
     testNumericalCorrectness(
       optimizer: optimizer, startingValues: values,
@@ -145,7 +145,7 @@ class OptimizerTests: XCTestCase {
   func testRMSPropNumerical() {
     let values = NumericalValues()
     let optimizer = RMSProp(for: values, learningRate: 1e-3, epsilon: 1e-7)
-    // FIXME: Investigate small differences with Python reference implementation results:
+    // FIXME(TF-759): Investigate small differences with Python reference implementation results:
     // `[ 1.0091327, -1.0091326, -1.0091326]`.
     testNumericalCorrectness(
       optimizer: optimizer, startingValues: values,
@@ -155,7 +155,7 @@ class OptimizerTests: XCTestCase {
   func testAdamNumerical() {
     let values = NumericalValues()
     let optimizer = Adam(for: values, learningRate: 1e-3, epsilon: 1e-7)
-    // FIXME: Investigate small differences with Python reference implementation results:
+    // FIXME(TF-759): Investigate small differences with Python reference implementation results:
     // `[ 0.9999907, -0.9999898, -0.9999904]`.
     testNumericalCorrectness(
       optimizer: optimizer, startingValues: values,
@@ -165,7 +165,7 @@ class OptimizerTests: XCTestCase {
   func testAdaDeltaNumerical() {
     let values = NumericalValues()
     let optimizer = AdaDelta(for: values, learningRate: 1e-3, epsilon: 1e-7)
-    // FIXME: Investigate small differences with Python reference implementation results:
+    // FIXME(TF-759): Investigate small differences with Python reference implementation results:
     // `[ 0.00215183, -0.00215151, -0.00215175]`.
     testNumericalCorrectness(
       optimizer: optimizer, startingValues: values,
@@ -175,7 +175,7 @@ class OptimizerTests: XCTestCase {
   func testAMSGradNumerical() {
     let values = NumericalValues()
     let optimizer = AMSGrad(for: values, learningRate: 1e-3, epsilon: 1e-7)
-    // FIXME: Investigate small differences with Python reference implementation results:
+    // FIXME(TF-759): Investigate small differences with Python reference implementation results:
     // `[ 0.9999907, -0.9999898, -0.9999904]`.
     testNumericalCorrectness(
       optimizer: optimizer, startingValues: values,
@@ -185,7 +185,7 @@ class OptimizerTests: XCTestCase {
   func testAdaMaxNumerical() {
     let values = NumericalValues()
     let optimizer = AdaMax(for: values, learningRate: 1e-3, epsilon: 1e-7)
-    // FIXME: Investigate small differences with Python reference implementation results:
+    // FIXME(TF-759): Investigate small differences with Python reference implementation results:
     // `[ 0.99999076, -0.99999064, -0.99999064]`.
     testNumericalCorrectness(
       optimizer: optimizer, startingValues: values,
@@ -195,7 +195,7 @@ class OptimizerTests: XCTestCase {
   func testAdaGradNumerical() {
     let values = NumericalValues()
     let optimizer = AdaGrad(for: values, learningRate: 1e-3, epsilon: 1e-7)
-    // FIXME: Investigate large differences with Python reference implementation results:
+    // FIXME(TF-759): Investigate large differences with Python reference implementation results:
     // `[ 0.06179592, -0.05709525, -0.05987222]`.
     testNumericalCorrectness(
       optimizer: optimizer, startingValues: values,
@@ -205,7 +205,7 @@ class OptimizerTests: XCTestCase {
   func testRAdamNumerical() {
     let values = NumericalValues()
     let optimizer = RAdam(for: values, learningRate: 1e-3, epsilon: 1e-7)
-    // FIXME: Investigate large differences with Python reference implementation results:
+    // FIXME(TF-759): Investigate large differences with Python reference implementation results:
     // `[ 0.46914074, -0.44463935, -0.44513944]`.
     // Pending fix: https://github.com/tensorflow/swift-apis/pull/700
     testNumericalCorrectness(

--- a/Utilities/ReferenceImplementations/optimizers.py
+++ b/Utilities/ReferenceImplementations/optimizers.py
@@ -1,0 +1,36 @@
+# Optimizer correctness reference implementations for
+# Tests/TensorFlowTests/OptimizerTests.swift.
+
+# Tested with:
+# - Python 3.7.6
+# - tensorflow==2.2.0rc0
+# - tensorflow-addons==0.8.3
+
+import numpy as np
+import tensorflow as tf
+from tensorflow.keras.optimizers import Adam, Adadelta, Adagrad, Adamax, RMSprop, SGD
+from tensorflow_addons.optimizers import RectifiedAdam
+
+
+def test_optimizer(optimizer, step_count=1000):
+    var = tf.Variable([0, 0, 0], dtype=tf.float32)
+    grad = tf.Variable([-5, 0.1, 0.2], dtype=tf.dtypes.float32)
+    grads_and_vars = list(zip([grad], [var]))
+    for i in range(step_count):
+        optimizer.apply_gradients(grads_and_vars)
+
+    print(optimizer._name)
+    print(
+        "- After {} steps:".format(step_count),
+        np.array2string(var.read_value().numpy(), separator=", "),
+    )
+
+
+test_optimizer(Adam(lr=1e-3, epsilon=1e-7))
+test_optimizer(Adam(lr=1e-3, epsilon=1e-7, amsgrad=True, name="Adam (amsgrad)"))
+test_optimizer(Adadelta(lr=1e-3, epsilon=1e-7))
+test_optimizer(Adagrad(lr=1e-3, epsilon=1e-7))
+test_optimizer(Adamax(lr=1e-3, epsilon=1e-7))
+test_optimizer(RectifiedAdam(lr=1e-3, epsilon=1e-7))
+test_optimizer(RMSprop(lr=1e-3, epsilon=1e-7))
+test_optimizer(SGD(lr=1e-3))


### PR DESCRIPTION
- Add `func testNumericalCorrectness` helper.
- Add Python TensorFlow reference implementations:
  `Utilities/ReferenceImplementations/optimizers.py`.

---

Unblocks https://github.com/tensorflow/swift-apis/pull/700: `RAdam` numerical correctness.