### PR TITLE
Allow Runtime.swift to compile in x10 and then compiling both x10 and tf_eager ops together.

### DIFF
--- a/Sources/TensorFlow/Bindings/RawOpsAugmented.swift
+++ b/Sources/TensorFlow/Bindings/RawOpsAugmented.swift
@@ -16,7 +16,7 @@
 // shape attributes rather than requiring that they be passed as `Int32` tensors.
 // This is useful for implementations that do not require the parameters be
 // passed as Tensors.
-extension _Raw {
+extension _RawTFEager {
   public static func argMax<
     T: TensorFlowNumeric,
     OutputType: TensorFlowIndex

--- a/Sources/TensorFlow/Bindings/RawOpsDispatching.swift
+++ b/Sources/TensorFlow/Bindings/RawOpsDispatching.swift
@@ -1,0 +1,28 @@
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@available(
+  *, deprecated, renamed: "_Raw",
+  message:
+    """
+  'Raw' has been renamed to '_Raw' to indicate that it is not a guaranteed/stable API.
+  """
+)
+public typealias Raw = _Raw
+
+#if USING_X10_BACKEND
+public typealias _Raw = _RawXLA
+#else
+public typealias _Raw = _RawTFEager
+#endif

--- a/Sources/TensorFlow/Bindings/RawOpsGenerated.swift
+++ b/Sources/TensorFlow/Bindings/RawOpsGenerated.swift
@@ -21,16 +21,7 @@ func makeOp(_ name: String, _ nOutputs: Int) -> TFTensorOperation {
   _ExecutionContext.makeOp(name, nOutputs)
 }
 
-@available(
-  *, deprecated, renamed: "_Raw",
-  message:
-    """
-  'Raw' has been renamed to '_Raw' to indicate that it is not a guaranteed/stable API.
-  """
-)
-public typealias Raw = _Raw
-
-public enum _Raw {
+public enum _RawTFEager {
 
   static let generatedTensorFlowVersion = "2.1.0"
   static let generatedTensorFlowGitVersion = "v2.1.0-rc2-17-ge5bf8de410"

--- a/Sources/TensorFlow/CMakeLists.txt
+++ b/Sources/TensorFlow/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(TensorFlow SHARED
   Bindings/RawOpsGenerated.swift
   Bindings/TFTensorOperation.swift
   Bindings/RawOpsAugmented.swift
+  Bindings/RawOpsDispatching.swift
 
   Core/ArrayOps.swift
   Core/CopyableToDevice.swift

--- a/Sources/TensorFlow/Core/DataTypes.swift
+++ b/Sources/TensorFlow/Core/DataTypes.swift
@@ -132,7 +132,6 @@ extension Int64: TensorFlowScalar {
   }
 }
 
-#if !USING_X10_BACKEND
 extension UInt8: TensorFlowScalar {
   @inlinable
   public static var tensorFlowDataType: TensorDataType {
@@ -140,6 +139,7 @@ extension UInt8: TensorFlowScalar {
   }
 }
 
+#if !USING_X10_BACKEND
 extension UInt16: TensorFlowScalar {
   @inlinable
   public static var tensorFlowDataType: TensorDataType {

--- a/Sources/TensorFlow/Core/StringTensor.swift
+++ b/Sources/TensorFlow/Core/StringTensor.swift
@@ -128,6 +128,6 @@ extension StringTensor {
   /// - Note: `elementsEqual` supports broadcasting.
   @inlinable
   public func elementsEqual(_ other: StringTensor) -> Tensor<Bool> {
-    return _Raw.equal(self, other)
+    return _RawTFEager.equal(self, other)
   }
 }

--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -672,8 +672,8 @@ extension Tensor: AdditiveArithmetic where Scalar: Numeric {
   /// The scalar zero tensor.
   #if USING_X10_BACKEND
     public static var zero: Tensor {
-      var zero = Tensor(0, on: _ThreadLocalState.local.currentDevice)
-      if _ThreadLocalState.local.isReducedPrecision {
+      var zero = Tensor(0, on: _DeviceThreadLocalState.local.currentDevice)
+      if _DeviceThreadLocalState.local.isReducedPrecision {
         zero = zero.toReducedPrecision
       }
       return zero

--- a/Sources/x10/CMakeLists.txt
+++ b/Sources/x10/CMakeLists.txt
@@ -24,16 +24,22 @@ add_library(x10_tensor SHARED
   swift_bindings/apis/DeviceScope.swift
   swift_bindings/apis/RawOpsManual.swift
 
-  swift_bindings/TensorFlow/Core/Runtime.swift
 
   swift_bindings/XLAScalarType.swift
   swift_bindings/XLATensor.swift)
 target_sources(x10_tensor PRIVATE
+  ../TensorFlow/Bindings/EagerExecution.swift
+  ../TensorFlow/Bindings/RawOpsGenerated.swift
+  ../TensorFlow/Bindings/RawOpsAugmented.swift
+  ../TensorFlow/Bindings/RawOpsDispatching.swift
+  ../TensorFlow/Bindings/TFTensorOperation.swift
+
   ../TensorFlow/Core/BroadcastingPullback.swift
   ../TensorFlow/Core/CopyableToDevice.swift
   ../TensorFlow/Core/DifferentialOperators.swift
   ../TensorFlow/Core/PythonConversion.swift
   ../TensorFlow/Core/ShapedArray.swift
+  ../TensorFlow/Core/Execution.swift
   ../TensorFlow/Core/TensorShape.swift
   ../TensorFlow/Core/Threading.swift
   ../TensorFlow/Core/Utilities.swift
@@ -41,6 +47,9 @@ target_sources(x10_tensor PRIVATE
   ../TensorFlow/Core/TensorHandle.swift
   ../TensorFlow/Core/DataTypes.swift
   ../TensorFlow/Core/MixedPrecision.swift
+  ../TensorFlow/Core/Runtime.swift
+  ../TensorFlow/Core/StringTensor.swift
+  ../TensorFlow/Core/TensorGroup.swift
 
   ../TensorFlow/Layers/Convolutional.swift
   ../TensorFlow/Layers/Core.swift

--- a/Sources/x10/swift_bindings/XLAScalarType.swift
+++ b/Sources/x10/swift_bindings/XLAScalarType.swift
@@ -76,6 +76,13 @@ extension Int8: XLAScalarType {
     return XLATensorScalarType_Int8
   }
 }
+extension UInt8: XLAScalarType {
+  public var xlaScalar: XLAScalar { XLAScalar(Int64(self)) }
+
+  static public var xlaTensorScalarType: XLATensorScalarType {
+    return XLATensorScalarType_UInt8
+  }
+}
 
 extension Bool: XLAScalarType {
   public var xlaScalar: XLAScalar { XLAScalar(Int64(self ? 1 : 0)) }

--- a/Sources/x10/swift_bindings/XLATensor.swift
+++ b/Sources/x10/swift_bindings/XLATensor.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import x10_device
+@_exported import x10_device
 import x10_xla_tensor_tf_ops
 import x10_xla_tensor_wrapper
 

--- a/Sources/x10/swift_bindings/apis/RawOpsManual.swift
+++ b/Sources/x10/swift_bindings/apis/RawOpsManual.swift
@@ -19,16 +19,7 @@ import x10_device
 import x10_xla_tensor_tf_ops
 import x10_xla_tensor_wrapper
 
-@available(
-  *, deprecated, renamed: "_Raw",
-  message:
-    """
-  'Raw' has been renamed to '_Raw' to indicate that it is not a guaranteed/stable API.
-  """
-)
-public typealias Raw = _Raw
-
-public enum _Raw {
+public enum _RawXLA {
 
   // @_frozen // SR-9739
   public enum DataFormat {


### PR DESCRIPTION
Currently we compiletime dispatch _Raw to _RawXLA and _RawTFEager depending on the compilation mode, but in the future this can become runtime dispatching.