### PR TITLE
Fix bug in `batchGathering`

### DIFF
--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -598,7 +598,7 @@ extension Tensor {
     let innerShape = shapeTensor[..<(batchDimensionCount + 1)].product(squeezingAxes: [0])
     let flatTensor = reshaped(toShape: innerShape.rankLifted().concatenated(with: outerShape))
     let flatResult = flatTensor.gathering(atIndices: flatIndices)
-    return flatResult.reshaped(toShape: indices.shapeTensor.concatenated(with: outerShape))
+    return flatResult.reshaped(toShape: batchIndices.shapeTensor.concatenated(with: outerShape))
   }
 
   /// Returns a tensor by gathering the values after applying the provided boolean mask to the input.

--- a/Tests/TensorFlowTests/OperatorTests/BasicTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/BasicTests.swift
@@ -42,6 +42,16 @@ final class BasicOperatorTests: XCTestCase {
     XCTAssertEqual(y2, Tensor<Float>([[[2.0], [4.0]]]))
   }
 
+  func testBatchGatheringAcrossBatch() {
+    let x = Tensor<Float>([
+      [1.0, 2.0, 3.0, 4.0],
+      [10, 20, 30, 40],
+    ])
+    let y = x.batchGathering(
+      atIndices: Tensor<Int32>([[0, 1, 3]])) // Simulate flattened upper triangular.
+    XCTAssertEqual(y, Tensor([[1.0, 2.0, 4.0], [10, 20, 40]]))
+  }
+
   func testPadded() {
     let x = Tensor<Float>(ones: [2, 2])
     let target = Tensor<Float>([[3, 3, 3], [1, 1, 3], [1, 1, 3]])
@@ -714,6 +724,7 @@ final class BasicOperatorTests: XCTestCase {
   static var allTests = [
     ("testGathering", testGathering),
     ("testBatchGathering", testBatchGathering),
+    ("testBatchGatheringAcrossBatch", testBatchGatheringAcrossBatch),
     ("testPadded", testPadded),
     ("testPaddedConstant", testPaddedConstant),
     ("testPaddedReflect", testPaddedReflect),


### PR DESCRIPTION
Previously, if `batchGathering` was operating upon a batch of data, it would get
stuck during the final reshape, due to using the wrong input tensor shape. This
change fixes that and includes a test case that caught the bug before the fix was
applied.

```
Test Case '-[TensorFlowTests.BasicOperatorTests testBatchGatheringAcrossBatch]' started.
Fatal error: Input to reshape is a tensor with 6 values, but the requested shape has 3: file /Users/saeta/src/swift-apis/Sources/TensorFlow/Bindings/EagerExecution.swift, line 301
Exited with signal code 4
```