### PR TITLE
build: use `X10_LIBRARY` to reference the x10 library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,16 @@ option(BUILD_X10 "enable the x10 tensor library" OFF)
 option(USE_BUNDLED_CTENSORFLOW
   "Use the CTensorFlow module bundled in the active Swift toolchain" OFF)
 
-find_package(TensorFlow REQUIRED)
+if(BUILD_X10)
+  add_library(x10 IMPORTED GLOBAL UNKNOWN)
+  set_target_properties(x10 PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${X10_INCLUDE_DIR}"
+    IMPORTED_LOCATION ${X10_LIBRARY})
+  add_library(tensorflow ALIAS
+    x10)
+else()
+  find_package(TensorFlow REQUIRED)
+endif()
 
 include(CTest)
 include(SwiftSupport)

--- a/Sources/x10/CMakeLists.txt
+++ b/Sources/x10/CMakeLists.txt
@@ -1,10 +1,5 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-add_library(x10 IMPORTED UNKNOWN)
-set_target_properties(x10 PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${X10_INCLUDE_DIR}"
-  IMPORTED_LOCATION ${X10_LIBRARY})
-
 add_library(x10_c_wrappers STATIC
   swift_bindings/device_wrapper.cc
   swift_bindings/xla_tensor_tf_ops.cc

--- a/Sources/x10/CMakeLists.txt
+++ b/Sources/x10/CMakeLists.txt
@@ -3,7 +3,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 add_library(x10 IMPORTED UNKNOWN)
 set_target_properties(x10 PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${X10_INCLUDE_DIR}"
-  IMPORTED_LOCATION ${TensorFlow_LIBRARY})
+  IMPORTED_LOCATION ${X10_LIBRARY})
 
 add_library(x10_c_wrappers STATIC
   swift_bindings/device_wrapper.cc


### PR DESCRIPTION
This allows explicitly specifying the x10 library rather than a single
tensorflow library which is assumed to be x10.