### PR TITLE
build: add a `FindX10` module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,11 @@ option(BUILD_X10 "enable the x10 tensor library" OFF)
 option(USE_BUNDLED_CTENSORFLOW
   "Use the CTensorFlow module bundled in the active Swift toolchain" OFF)
 
-find_package(TensorFlow REQUIRED)
+if(BUILD_X10)
+  find_package(X10 REQUIRED)
+else()
+  find_package(TensorFlow REQUIRED)
+endif()
 
 include(CTest)
 include(SwiftSupport)

--- a/Sources/x10/CMakeLists.txt
+++ b/Sources/x10/CMakeLists.txt
@@ -1,10 +1,5 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-add_library(x10 IMPORTED UNKNOWN)
-set_target_properties(x10 PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${X10_INCLUDE_DIR}"
-  IMPORTED_LOCATION ${TensorFlow_LIBRARY})
-
 add_library(x10_c_wrappers STATIC
   swift_bindings/device_wrapper.cc
   swift_bindings/xla_tensor_tf_ops.cc

--- a/cmake/modules/FindX10.cmake
+++ b/cmake/modules/FindX10.cmake
@@ -1,0 +1,31 @@
+find_path(X10_INCLUDE_DIR
+          NAMES
+            device_wrapper.h
+            xla_tensor_tf_ops.h
+            xla_tensor_wrapper.h
+          HINTS
+            ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+find_library(X10_LIBRARY
+             NAMES
+               x10
+             HINTS
+               ${CMAKE_INSTALL_FULL_LIBDIR})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(X10
+  FOUND_VAR
+    X10_FOUND
+  REQUIRED_VARS
+    X10_INCLUDE_DIR
+    X10_LIBRARY
+  VERSION_VAR
+    X10_VERSION)
+
+if(X10_FOUND AND NOT TARGET x10)
+  add_library(x10 UNKNOWN IMPORTED)
+  set_target_properties(x10 PROPERTIES
+    IMPORTED_LOCATION ${X10_LIBRARY}
+    INTERFACE_INCLUDE_DIRECTORIES ${X10_INCLUDE_DIR})
+endif()
+
+mark_as_advanced(X10_INCLUDE_DIR X10_LIBRARY)


### PR DESCRIPTION
This adds support for enabling external builds of x10 as well as
internal builds.  Treat x10 as a normal library and let the find
create the imported library target.