### PR TITLE
Remove Tensorflow dep from ops_test.

### DIFF
--- a/Sources/TensorFlow/Bindings/RawOpsAugmented.swift
+++ b/Sources/TensorFlow/Bindings/RawOpsAugmented.swift
@@ -28,7 +28,7 @@ extension _RawTFEager {
     _ input: Tensor<T>,
     dimension: Int64
   ) -> Tensor<OutputType> {
-    argMax(input, dimension: Tensor<Int32>(Int32(dimension)))
+    argMax(input, dimension: Tensor<Int32>(Int32(dimension), on: .defaultTFEager))
   }
 
   public static func mean<
@@ -39,7 +39,8 @@ extension _RawTFEager {
     keepDims: Bool = false
   ) -> Tensor<T> {
     mean(
-      input, reductionIndices: Tensor<Int32>(reductionIndices.map { Int32($0) }),
+      input,
+      reductionIndices: Tensor<Int32>(reductionIndices.map { Int32($0) }, on: .defaultTFEager),
       keepDims: keepDims)
   }
 
@@ -49,7 +50,7 @@ extension _RawTFEager {
     _ tensor: Tensor<T>,
     shape: [Int64]
   ) -> Tensor<T> {
-    reshape(tensor, shape: Tensor<Int32>(shape.map { Int32($0) }))
+    reshape(tensor, shape: Tensor<Int32>(shape.map { Int32($0) }, on: .defaultTFEager))
   }
 
   public static func sum<
@@ -60,7 +61,8 @@ extension _RawTFEager {
     keepDims: Bool = false
   ) -> Tensor<T> {
     sum(
-      input, reductionIndices: Tensor<Int32>(reductionIndices.map { Int32($0) }),
+      input,
+      reductionIndices: Tensor<Int32>(reductionIndices.map { Int32($0) }, on: .defaultTFEager),
       keepDims: keepDims)
   }
 
@@ -70,7 +72,7 @@ extension _RawTFEager {
     _ input: Tensor<T>,
     shape: [Int64]
   ) -> Tensor<T> {
-    broadcastTo(input, shape: Tensor<Int32>(shape.map { Int32($0) }))
+    broadcastTo(input, shape: Tensor<Int32>(shape.map { Int32($0) }, on: .defaultTFEager))
   }
 
   public static func conv2DBackpropFilter<T: FloatingPoint & TensorFlowScalar>(
@@ -85,7 +87,7 @@ extension _RawTFEager {
     dilations: [Int32] = [1, 1, 1, 1]
   ) -> Tensor<T> {
     conv2DBackpropFilter(
-      input, filterSizes: Tensor<Int32>(filterSizes.map { Int32($0) }),
+      input, filterSizes: Tensor<Int32>(filterSizes.map { Int32($0) }, on: .defaultTFEager),
       outBackprop: outBackprop, strides: strides, useCudnnOnGpu: useCudnnOnGpu,
       padding: padding, explicitPaddings: explicitPaddings, dataFormat: dataFormat,
       dilations: dilations)
@@ -103,7 +105,7 @@ extension _RawTFEager {
     dilations: [Int32] = [1, 1, 1, 1]
   ) -> Tensor<T> {
     conv2DBackpropInput(
-      inputSizes: Tensor<Int32>(inputSizes.map { Int32($0) }), filter: filter,
+      inputSizes: Tensor<Int32>(inputSizes.map { Int32($0) }, on: .defaultTFEager), filter: filter,
       outBackprop: outBackprop,
       strides: strides, useCudnnOnGpu: useCudnnOnGpu, padding: padding,
       explicitPaddings: explicitPaddings, dataFormat: dataFormat, dilations: dilations)
@@ -117,8 +119,9 @@ extension _RawTFEager {
     dataFormat: DataFormat2 = .nhwc
   ) -> Tensor<T> {
     maxPoolV2(
-      input, ksize: Tensor<Int32>(ksize.map { Int32($0) }),
-      strides: Tensor<Int32>(strides.map { Int32($0) }), padding: padding, dataFormat: dataFormat)
+      input, ksize: Tensor<Int32>(ksize.map { Int32($0) }, on: .defaultTFEager),
+      strides: Tensor<Int32>(strides.map { Int32($0) }, on: .defaultTFEager), padding: padding,
+      dataFormat: dataFormat)
   }
 
   public static func maxPoolGradV2<T: TensorFlowNumeric>(
@@ -132,16 +135,20 @@ extension _RawTFEager {
   ) -> Tensor<T> {
     maxPoolGradV2(
       origInput: origInput, origOutput: origOutput, grad: grad,
-      ksize: Tensor<Int32>(ksize.map { Int32($0) }),
-      strides: Tensor<Int32>(strides.map { Int32($0) }),
+      ksize: Tensor<Int32>(ksize.map { Int32($0) }, on: .defaultTFEager),
+      strides: Tensor<Int32>(strides.map { Int32($0) }, on: .defaultTFEager),
       padding: padding, dataFormat: dataFormat)
   }
 }
 
 #if USING_X10_BACKEND
   extension _Raw {
-    public static func commonBackend(_ a: Device.Backend, _ b: Device.Backend) -> Device.Backend {
-      if a != b { fatalError("Op must have the same backend type: \(a) vs \(b)") }
+    public static func commonBackend(
+      _ a: Device.Backend, _ b: Device.Backend, file: StaticString = #file, line: UInt = #line
+    ) -> Device.Backend {
+      if a != b {
+        fatalError("Op must have the same backend type: \(a) vs \(b)", file: file, line: line)
+      }
       return a
     }
 
@@ -162,7 +169,8 @@ extension _RawTFEager {
       case .XLA:
         return _RawXLA.argMax(input, dimension: dimension)
       case .TF_EAGER:
-        return _RawTFEager.argMax(input, dimension: Tensor<Int32>(Int32(dimension)))
+        return _RawTFEager.argMax(
+          input, dimension: Tensor<Int32>(Int32(dimension), on: .defaultTFEager))
       }
     }
 
@@ -180,7 +188,8 @@ extension _RawTFEager {
           keepDims: keepDims)
       case .TF_EAGER:
         return _RawTFEager.mean(
-          input, reductionIndices: Tensor<Int32>(reductionIndices.map { Int32($0) }),
+          input,
+          reductionIndices: Tensor<Int32>(reductionIndices.map { Int32($0) }, on: .defaultTFEager),
           keepDims: keepDims)
       }
     }
@@ -195,7 +204,8 @@ extension _RawTFEager {
       case .XLA:
         return _RawXLA.reshape(tensor, shape: shape)
       case .TF_EAGER:
-        return _RawTFEager.reshape(tensor, shape: Tensor<Int32>(shape.map { Int32($0) }))
+        return _RawTFEager.reshape(
+          tensor, shape: Tensor<Int32>(shape.map { Int32($0) }, on: .defaultTFEager))
       }
     }
 
@@ -213,7 +223,8 @@ extension _RawTFEager {
           keepDims: keepDims)
       case .TF_EAGER:
         return _RawTFEager.sum(
-          input, reductionIndices: Tensor<Int32>(reductionIndices.map { Int32($0) }),
+          input,
+          reductionIndices: Tensor<Int32>(reductionIndices.map { Int32($0) }, on: .defaultTFEager),
           keepDims: keepDims)
       }
     }
@@ -228,7 +239,8 @@ extension _RawTFEager {
       case .XLA:
         return _RawXLA.broadcastTo(input, shape: shape)
       case .TF_EAGER:
-        return _RawTFEager.broadcastTo(input, shape: Tensor<Int32>(shape.map { Int32($0) }))
+        return _RawTFEager.broadcastTo(
+          input, shape: Tensor<Int32>(shape.map { Int32($0) }, on: .defaultTFEager))
       }
     }
 
@@ -252,7 +264,7 @@ extension _RawTFEager {
           dilations: dilations)
       case .TF_EAGER:
         return _RawTFEager.conv2DBackpropFilter(
-          input, filterSizes: Tensor<Int32>(filterSizes.map { Int32($0) }),
+          input, filterSizes: Tensor<Int32>(filterSizes.map { Int32($0) }, on: .defaultTFEager),
           outBackprop: outBackprop, strides: strides, useCudnnOnGpu: useCudnnOnGpu,
           padding: padding, explicitPaddings: explicitPaddings, dataFormat: dataFormat,
           dilations: dilations)
@@ -279,7 +291,8 @@ extension _RawTFEager {
           explicitPaddings: explicitPaddings, dataFormat: dataFormat, dilations: dilations)
       case .TF_EAGER:
         return _RawTFEager.conv2DBackpropInput(
-          inputSizes: Tensor<Int32>(inputSizes.map { Int32($0) }), filter: filter,
+          inputSizes: Tensor<Int32>(inputSizes.map { Int32($0) }, on: .defaultTFEager),
+          filter: filter,
           outBackprop: outBackprop,
           strides: strides, useCudnnOnGpu: useCudnnOnGpu, padding: padding,
           explicitPaddings: explicitPaddings, dataFormat: dataFormat, dilations: dilations)
@@ -300,8 +313,8 @@ extension _RawTFEager {
           strides: strides, padding: padding, dataFormat: dataFormat)
       case .TF_EAGER:
         return _RawTFEager.maxPoolV2(
-          input, ksize: Tensor<Int32>(ksize.map { Int32($0) }),
-          strides: Tensor<Int32>(strides.map { Int32($0) }), padding: padding,
+          input, ksize: Tensor<Int32>(ksize.map { Int32($0) }, on: .defaultTFEager),
+          strides: Tensor<Int32>(strides.map { Int32($0) }, on: .defaultTFEager), padding: padding,
           dataFormat: dataFormat)
       }
     }
@@ -325,8 +338,8 @@ extension _RawTFEager {
       case .TF_EAGER:
         return _RawTFEager.maxPoolGradV2(
           origInput: origInput, origOutput: origOutput, grad: grad,
-          ksize: Tensor<Int32>(ksize.map { Int32($0) }),
-          strides: Tensor<Int32>(strides.map { Int32($0) }),
+          ksize: Tensor<Int32>(ksize.map { Int32($0) }, on: .defaultTFEager),
+          strides: Tensor<Int32>(strides.map { Int32($0) }, on: .defaultTFEager),
           padding: padding, dataFormat: dataFormat)
       }
     }

--- a/Sources/TensorFlow/Core/Device.swift
+++ b/Sources/TensorFlow/Core/Device.swift
@@ -3,6 +3,7 @@
 /// Currently, this is a stub because TensorFlow transfers tensors between devices on demand.
 public struct Device {
   public static var `default`: Device { Device() }
+  public static var defaultTFEager: Device { Device() }
 
   /// Backend used to dispatch the tensor operations.
   public enum Backend {

--- a/Sources/TensorFlow/Core/MixedPrecision.swift
+++ b/Sources/TensorFlow/Core/MixedPrecision.swift
@@ -13,134 +13,134 @@
 // limitations under the License.
 
 #if USING_X10_BACKEND
-import x10_xla_tensor_wrapper
+  import x10_xla_tensor_wrapper
 
-/// A type whose nested floating-point tensor properties and elements can be converted from full
-/// precision to reduced precision and vice versa.
-///
-/// - Note: Do not ever use this API directly. This is an implementation detail to support
-///   `KeyPathIterable.convertToReducedPrecision` and `KeyPathIterable.convertToFullPrecision`.
-///
-/// - Note: this workaround is necessary because `ReducedPrecisionConvertible` is a protocol with
-///   `Self` requirements, so `x as? ReducedPrecisionConvertible` does not work.
-public protocol _ReducedPrecisionConvertible {
-  /// Given an `inout Root` root value and a `PartialKeyPath<Root>` key path, converts the value at
-  /// the key path in the root value to reduced precision.
-  static func _convertToReducedPrecision<Root>(
-    _ root: inout Root, _ rootKeyPath: PartialKeyPath<Root>)
-
-  /// Given an `inout Root` root value and a `PartialKeyPath<Root>` key path, converts the value at
-  /// the key path in the root value to full precision.
-  static func _convertToFullPrecision<Root>(
-    _ root: inout Root, _ rootKeyPath: PartialKeyPath<Root>)
-}
-
-/// A type whose nested floating-point tensor properties and elements can be converted from full
-/// precision to reduced precision and vice versa.
-public protocol ReducedPrecisionConvertible: _ReducedPrecisionConvertible {
-  /// Returns a copy of `self`, converting nested floating-point tensor properties and elements
-  /// from full precision to reduced precision.
-  var toReducedPrecision: Self { get }
-
-  /// Returns a copy of `self`, converting nested floating-point tensor properties and elements
-  /// from full precision to reduced precision.
-  var toFullPrecision: Self { get }
-}
-
-extension ReducedPrecisionConvertible {
-  /// Given an `inout Root` root value and a `PartialKeyPath<Root>` key path, converts the physical
-  /// scalar type of the value at the key path in the root value to `BFloat16`.
+  /// A type whose nested floating-point tensor properties and elements can be converted from full
+  /// precision to reduced precision and vice versa.
   ///
   /// - Note: Do not ever use this API directly. This is an implementation detail to support
   ///   `KeyPathIterable.convertToReducedPrecision` and `KeyPathIterable.convertToFullPrecision`.
-  public static func _convertToReducedPrecision<Root>(
-    _ root: inout Root, _ rootKeyPath: PartialKeyPath<Root>
-  ) {
-    guard let keyPath = rootKeyPath as? WritableKeyPath<Root, Self> else {
-      fatalError(
-        "Failed conversion from \(rootKeyPath) to 'WritableKeyPath<\(Root.self), \(Self.self)>'")
-    }
-    root[keyPath: keyPath] = root[keyPath: keyPath].toReducedPrecision
-  }
-
-  /// Given an `inout Root` root value and a `PartialKeyPath<Root>` key path, converts the physical
-  /// scalar type of the value at the key path in the root value from `BFloat16` to a different
-  /// floating-point type.
   ///
-  /// - Note: Do not ever use this API directly. This is an implementation detail to support
-  ///   `KeyPathIterable.convertToReducedPrecision` and `KeyPathIterable.convertToFullPrecision`.
-  public static func _convertToFullPrecision<Root>(
-    _ root: inout Root, _ rootKeyPath: PartialKeyPath<Root>
-  ) {
-    guard let keyPath = rootKeyPath as? WritableKeyPath<Root, Self> else {
-      fatalError(
-        "Failed conversion from \(rootKeyPath) to 'WritableKeyPath<\(Root.self), \(Self.self)>'")
-    }
-    root[keyPath: keyPath] = root[keyPath: keyPath].toFullPrecision
-  }
-}
+  /// - Note: this workaround is necessary because `ReducedPrecisionConvertible` is a protocol with
+  ///   `Self` requirements, so `x as? ReducedPrecisionConvertible` does not work.
+  public protocol _ReducedPrecisionConvertible {
+    /// Given an `inout Root` root value and a `PartialKeyPath<Root>` key path, converts the value at
+    /// the key path in the root value to reduced precision.
+    static func _convertToReducedPrecision<Root>(
+      _ root: inout Root, _ rootKeyPath: PartialKeyPath<Root>)
 
-extension _KeyPathIterableBase {
-  /// Recursively converts all `_ReducedPrecisionConvertible`-conforming nested properties and
-  /// elements in `root` to reduced precision.
-  public func _convertToReducedPrecision<Root>(
-    _ root: inout Root, _ rootKeyPath: PartialKeyPath<Root>
-  ) {
-    for kp in _allKeyPathsTypeErased {
-      let joinedKeyPath = rootKeyPath.appending(path: kp)!
-      if let valueType = type(of: joinedKeyPath).valueType as? _ReducedPrecisionConvertible.Type {
-        valueType._convertToReducedPrecision(&root, joinedKeyPath)
-      } else if let nested = self[keyPath: kp] as? _KeyPathIterableBase {
-        nested._convertToReducedPrecision(&root, joinedKeyPath)
+    /// Given an `inout Root` root value and a `PartialKeyPath<Root>` key path, converts the value at
+    /// the key path in the root value to full precision.
+    static func _convertToFullPrecision<Root>(
+      _ root: inout Root, _ rootKeyPath: PartialKeyPath<Root>)
+  }
+
+  /// A type whose nested floating-point tensor properties and elements can be converted from full
+  /// precision to reduced precision and vice versa.
+  public protocol ReducedPrecisionConvertible: _ReducedPrecisionConvertible {
+    /// Returns a copy of `self`, converting nested floating-point tensor properties and elements
+    /// from full precision to reduced precision.
+    var toReducedPrecision: Self { get }
+
+    /// Returns a copy of `self`, converting nested floating-point tensor properties and elements
+    /// from full precision to reduced precision.
+    var toFullPrecision: Self { get }
+  }
+
+  extension ReducedPrecisionConvertible {
+    /// Given an `inout Root` root value and a `PartialKeyPath<Root>` key path, converts the physical
+    /// scalar type of the value at the key path in the root value to `BFloat16`.
+    ///
+    /// - Note: Do not ever use this API directly. This is an implementation detail to support
+    ///   `KeyPathIterable.convertToReducedPrecision` and `KeyPathIterable.convertToFullPrecision`.
+    public static func _convertToReducedPrecision<Root>(
+      _ root: inout Root, _ rootKeyPath: PartialKeyPath<Root>
+    ) {
+      guard let keyPath = rootKeyPath as? WritableKeyPath<Root, Self> else {
+        fatalError(
+          "Failed conversion from \(rootKeyPath) to 'WritableKeyPath<\(Root.self), \(Self.self)>'")
+      }
+      root[keyPath: keyPath] = root[keyPath: keyPath].toReducedPrecision
+    }
+
+    /// Given an `inout Root` root value and a `PartialKeyPath<Root>` key path, converts the physical
+    /// scalar type of the value at the key path in the root value from `BFloat16` to a different
+    /// floating-point type.
+    ///
+    /// - Note: Do not ever use this API directly. This is an implementation detail to support
+    ///   `KeyPathIterable.convertToReducedPrecision` and `KeyPathIterable.convertToFullPrecision`.
+    public static func _convertToFullPrecision<Root>(
+      _ root: inout Root, _ rootKeyPath: PartialKeyPath<Root>
+    ) {
+      guard let keyPath = rootKeyPath as? WritableKeyPath<Root, Self> else {
+        fatalError(
+          "Failed conversion from \(rootKeyPath) to 'WritableKeyPath<\(Root.self), \(Self.self)>'")
+      }
+      root[keyPath: keyPath] = root[keyPath: keyPath].toFullPrecision
+    }
+  }
+
+  extension _KeyPathIterableBase {
+    /// Recursively converts all `_ReducedPrecisionConvertible`-conforming nested properties and
+    /// elements in `root` to reduced precision.
+    public func _convertToReducedPrecision<Root>(
+      _ root: inout Root, _ rootKeyPath: PartialKeyPath<Root>
+    ) {
+      for kp in _allKeyPathsTypeErased {
+        let joinedKeyPath = rootKeyPath.appending(path: kp)!
+        if let valueType = type(of: joinedKeyPath).valueType as? _ReducedPrecisionConvertible.Type {
+          valueType._convertToReducedPrecision(&root, joinedKeyPath)
+        } else if let nested = self[keyPath: kp] as? _KeyPathIterableBase {
+          nested._convertToReducedPrecision(&root, joinedKeyPath)
+        }
+      }
+    }
+
+    /// Recursively converts all `_ReducedPrecisionConvertible`-conforming nested properties and
+    /// elements in `root` to full precision.
+    public func _convertToFullPrecision<Root>(
+      _ root: inout Root, _ rootKeyPath: PartialKeyPath<Root>
+    ) {
+      for kp in _allKeyPathsTypeErased {
+        let joinedKeyPath = rootKeyPath.appending(path: kp)!
+        if let valueType = type(of: joinedKeyPath).valueType as? _ReducedPrecisionConvertible.Type {
+          valueType._convertToFullPrecision(&root, joinedKeyPath)
+        } else if let nested = self[keyPath: kp] as? _KeyPathIterableBase {
+          nested._convertToFullPrecision(&root, joinedKeyPath)
+        }
       }
     }
   }
 
-  /// Recursively converts all `_ReducedPrecisionConvertible`-conforming nested properties and
-  /// elements in `root` to full precision.
-  public func _convertToFullPrecision<Root>(
-    _ root: inout Root, _ rootKeyPath: PartialKeyPath<Root>
-  ) {
-    for kp in _allKeyPathsTypeErased {
-      let joinedKeyPath = rootKeyPath.appending(path: kp)!
-      if let valueType = type(of: joinedKeyPath).valueType as? _ReducedPrecisionConvertible.Type {
-        valueType._convertToFullPrecision(&root, joinedKeyPath)
-      } else if let nested = self[keyPath: kp] as? _KeyPathIterableBase {
-        nested._convertToFullPrecision(&root, joinedKeyPath)
-      }
+  extension KeyPathIterable {
+    /// Recursively converts all `_ReducedPrecisionConvertible`-conforming nested properties and elements
+    /// to reduced precision.
+    public mutating func convertToReducedPrecision() {
+      _convertToReducedPrecision(&self, \.self)
+    }
+
+    /// Recursively converts all `_ReducedPrecisionConvertible`-conforming nested properties and elements
+    /// to full precision.
+    public mutating func convertToFullPrecision() {
+      _convertToFullPrecision(&self, \.self)
+    }
+
+    /// Returns a copy of `self`, converting all `_ReducedPrecisionConvertible`-conforming nested
+    /// properties and elements to reduced precision.
+    public var toReducedPrecision: Self {
+      var result = self
+      result.convertToReducedPrecision()
+      return result
+    }
+
+    /// Returns a copy of `self`, converting all `_ReducedPrecisionConvertible`-conforming nested
+    /// properties and elements to full precision.
+    public var toFullPrecision: Self {
+      var result = self
+      result.convertToFullPrecision()
+      return result
     }
   }
-}
-
-extension KeyPathIterable {
-  /// Recursively converts all `_ReducedPrecisionConvertible`-conforming nested properties and elements
-  /// to reduced precision.
-  public mutating func convertToReducedPrecision() {
-    _convertToReducedPrecision(&self, \.self)
-  }
-
-  /// Recursively converts all `_ReducedPrecisionConvertible`-conforming nested properties and elements
-  /// to full precision.
-  public mutating func convertToFullPrecision() {
-    _convertToFullPrecision(&self, \.self)
-  }
-
-  /// Returns a copy of `self`, converting all `_ReducedPrecisionConvertible`-conforming nested
-  /// properties and elements to reduced precision.
-  public var toReducedPrecision: Self {
-    var result = self
-    result.convertToReducedPrecision()
-    return result
-  }
-
-  /// Returns a copy of `self`, converting all `_ReducedPrecisionConvertible`-conforming nested
-  /// properties and elements to full precision.
-  public var toFullPrecision: Self {
-    var result = self
-    result.convertToFullPrecision()
-    return result
-  }
-}
 #endif
 
 extension Tensor {
@@ -148,60 +148,61 @@ extension Tensor {
   ///
   /// Currently, reduced precision physical scalar types include only `BFloat16`.
   public var isReducedPrecision: Bool {
-#if USING_X10_BACKEND
-    return xlaTensor.physicalScalarType == XLATensorScalarType_BFloat16
-#else
-    // TODO: Implement.
-    return false
-#endif
+    #if USING_X10_BACKEND
+      return device.backend == .XLA && xlaTensor.physicalScalarType == XLATensorScalarType_BFloat16
+    #else
+      // TODO: Implement.
+      return false
+    #endif
   }
 
   /// Promotes a scalar to a tensor with the same device and precision as the given tensor.
   @differentiable( where Scalar: TensorFlowFloatingPoint)
   public init(_ value: Scalar, deviceAndPrecisionLike tensor: Tensor) {
-    let tmp = Tensor(value, on: tensor.device)
+    let device = tensor.device
+    let tmp = Tensor(value, on: device)
     self = tensor.isReducedPrecision ? tmp.toReducedPrecision : tmp
   }
 }
 
 #if USING_X10_BACKEND
-extension Tensor: ReducedPrecisionConvertible, _ReducedPrecisionConvertible {
-  /// Returns a copy of `self` converted to `BFloat16` physical scalar type.
-  public var toReducedPrecision: Self {
-    if isReducedPrecision {
-      fatalError("Must not already have reduced precision")
+  extension Tensor: ReducedPrecisionConvertible, _ReducedPrecisionConvertible {
+    /// Returns a copy of `self` converted to `BFloat16` physical scalar type.
+    public var toReducedPrecision: Self {
+      if isReducedPrecision {
+        fatalError("Must not already have reduced precision")
+      }
+      if Scalar.self != Float.self {
+        fatalError("Reduced precision is only supported for Float tensors")
+      }
+      return _Raw.physicalCast(self, destType: XLATensorScalarType_BFloat16)
     }
-    if Scalar.self != Float.self {
-      fatalError("Reduced precision is only supported for Float tensors")
-    }
-    return _Raw.physicalCast(self, destType: XLATensorScalarType_BFloat16)
-  }
 
-  /// Returns a copy of `self` converted to `Scalar` physical scalar type.
-  public var toFullPrecision: Self {
-    if !isReducedPrecision {
-      fatalError("Must have reduced precision")
+    /// Returns a copy of `self` converted to `Scalar` physical scalar type.
+    public var toFullPrecision: Self {
+      if !isReducedPrecision {
+        fatalError("Must have reduced precision")
+      }
+      if Scalar.self != Float.self {
+        fatalError("Reduced precision is only supported for Float tensors")
+      }
+      return _Raw.physicalCast(self, destType: Scalar.xlaTensorScalarType)
     }
-    if Scalar.self != Float.self {
-      fatalError("Reduced precision is only supported for Float tensors")
-    }
-    return _Raw.physicalCast(self, destType: Scalar.xlaTensorScalarType)
   }
-}
 #else
-extension Tensor {
-  /// Returns a copy of `self` converted to `BFloat16` physical scalar type.
-  public var toReducedPrecision: Self {
-    // TODO: Implement.
-    return self
-  }
+  extension Tensor {
+    /// Returns a copy of `self` converted to `BFloat16` physical scalar type.
+    public var toReducedPrecision: Self {
+      // TODO: Implement.
+      return self
+    }
 
-  /// Returns a copy of `self` converted to `Scalar` physical scalar type.
-  public var toFullPrecision: Self {
-    // TODO: Implement.
-    return self
+    /// Returns a copy of `self` converted to `Scalar` physical scalar type.
+    public var toFullPrecision: Self {
+      // TODO: Implement.
+      return self
+    }
   }
-}
 #endif
 
 extension Tensor where Scalar: TensorFlowFloatingPoint {

--- a/Sources/TensorFlow/Initializers.swift
+++ b/Sources/TensorFlow/Initializers.swift
@@ -35,10 +35,13 @@ extension Tensor {
   ///   - shape: The dimensions of the tensor.
   @inlinable
   @differentiable( where Scalar: TensorFlowFloatingPoint)
-  public init(repeating repeatedValue: Scalar, shape: TensorShape) {
+  public init(
+    repeating repeatedValue: Scalar, shape: TensorShape,
+    on device: Device = .default
+  ) {
     self = _Raw.fill(
-      dims: Tensor<Int32>(shape.dimensions.map(Int32.init)),
-      value: Tensor(repeatedValue))
+      dims: Tensor<Int32>(shape.dimensions.map(Int32.init), on: device),
+      value: Tensor(repeatedValue, on: device))
   }
 
   /// Creates a tensor by broadcasting the given scalar to a given rank with
@@ -60,13 +63,14 @@ extension Tensor {
 
 extension Tensor where Scalar: TensorFlowFloatingPoint {
   @inlinable
-  @derivative(of: init(repeating:shape:))
+  @derivative(of: init(repeating:shape:on:))
   static func _vjpInit(
     repeating repeatedValue: __owned Scalar,
-    shape: __owned TensorShape
+    shape: __owned TensorShape,
+    on device: Device
   ) -> (value: Tensor, pullback: (Tensor) -> Scalar) {
     return (
-      Tensor(repeating: repeatedValue, shape: shape),
+      Tensor(repeating: repeatedValue, shape: shape, on: device),
       {
         $0.sum().scalarized()
       }
@@ -185,7 +189,7 @@ extension Tensor {
   @differentiable( where Scalar: TensorFlowFloatingPoint)
   public init(concatenating tensors: [Tensor], alongAxis axis: Int = 0) {
     precondition(tensors.count > 0)
-    self = _Raw.concatV2(tensors, axis: Tensor<Int32>(Int32(axis)))
+    self = _Raw.concatV2(tensors, axis: Tensor<Int32>(Int32(axis), on: tensors.first!.device))
   }
 }
 
@@ -282,8 +286,13 @@ extension Tensor where Scalar: Numeric {
   ///   - stride: The amount to step by with each iteration. `stride` must be
   ///     positive.
   @inlinable
-  public init(rangeFrom start: Scalar, to end: Scalar, stride: Scalar) {
-    self = _Raw.range(start: Tensor(start), limit: Tensor(end), delta: Tensor(stride))
+  public init(
+    rangeFrom start: Scalar, to end: Scalar, stride: Scalar,
+    on device: Device = .default
+  ) {
+    self = _Raw.range(
+      start: Tensor(start, on: device), limit: Tensor(end, on: device),
+      delta: Tensor(stride, on: device))
   }
 
   /// Creates a 1-D tensor representing a sequence from a starting value to, but not including, an
@@ -335,11 +344,12 @@ extension Tensor where Scalar: Numeric {
     offValue: Scalar = 0,
     axis: Int = -1
   ) {
+    let device = indices.device
     self = _Raw.oneHot(
       indices: indices,
-      depth: Tensor<Int32>(Int32(depth)),
-      onValue: Tensor(onValue),
-      offValue: Tensor(offValue),
+      depth: Tensor<Int32>(Int32(depth), on: device),
+      onValue: Tensor(onValue, on: device),
+      offValue: Tensor(offValue, on: device),
       axis: Int64(axis))
   }
 }
@@ -394,11 +404,12 @@ extension Tensor where Scalar: TensorFlowIndex {
     randomUniform shape: TensorShape,
     lowerBound: Tensor<Scalar> = Tensor<Scalar>(0),
     upperBound: Tensor<Scalar> = Tensor<Scalar>(1),
-    seed: TensorFlowSeed = Context.local.randomSeed
+    seed: TensorFlowSeed = Context.local.randomSeed,
+    on device: Device = .default
   ) {
     self = _Raw.statelessRandomUniformInt(
-      shape: Tensor<Int32>((0..<shape.rank).map { Int32(shape[$0]) }),
-      seed: Tensor<Int32>([seed.graph, seed.op]),
+      shape: Tensor<Int32>((0..<shape.rank).map { Int32(shape[$0]) }, on: device),
+      seed: Tensor<Int32>([seed.graph, seed.op], on: device),
       minval: lowerBound,
       maxval: upperBound)
   }
@@ -417,11 +428,12 @@ extension Tensor where Scalar: TensorFlowFloatingPoint {
     randomUniform shape: TensorShape,
     lowerBound: Tensor<Scalar> = Tensor<Scalar>(0),
     upperBound: Tensor<Scalar> = Tensor<Scalar>(1),
-    seed: TensorFlowSeed = Context.local.randomSeed
+    seed: TensorFlowSeed = Context.local.randomSeed,
+    on device: Device = .default
   ) {
     let sample: Tensor<Scalar> = _Raw.statelessRandomUniform(
-      shape: Tensor<Int32>((0..<shape.rank).map { Int32(shape[$0]) }),
-      seed: Tensor<Int32>([seed.graph, seed.op]))
+      shape: Tensor<Int32>((0..<shape.rank).map { Int32(shape[$0]) }, on: device),
+      seed: Tensor<Int32>([seed.graph, seed.op], on: device))
     self = (upperBound - lowerBound) * sample + lowerBound
   }
 
@@ -437,7 +449,8 @@ extension Tensor where Scalar: TensorFlowFloatingPoint {
     randomNormal shape: TensorShape,
     mean: Tensor<Scalar> = Tensor<Scalar>(0),
     standardDeviation: Tensor<Scalar> = Tensor<Scalar>(1),
-    seed: TensorFlowSeed = Context.local.randomSeed
+    seed: TensorFlowSeed = Context.local.randomSeed,
+    on device: Device = .default
   ) {
     let sample: Tensor<Scalar> = _Raw.statelessRandomNormal(
       shape: Tensor<Int32>((0..<shape.rank).map { Int32(shape[$0]) }),
@@ -457,11 +470,12 @@ extension Tensor where Scalar: TensorFlowFloatingPoint {
     randomTruncatedNormal shape: TensorShape,
     mean: Tensor<Scalar> = Tensor<Scalar>(0),
     standardDeviation: Tensor<Scalar> = Tensor<Scalar>(1),
-    seed: TensorFlowSeed = Context.local.randomSeed
+    seed: TensorFlowSeed = Context.local.randomSeed,
+    on device: Device = .default
   ) {
     let sample: Tensor<Scalar> = _Raw.statelessTruncatedNormal(
-      shape: Tensor<Int32>((0..<shape.rank).map { Int32(shape[$0]) }),
-      seed: Tensor<Int32>([seed.graph, seed.op]))
+      shape: Tensor<Int32>((0..<shape.rank).map { Int32(shape[$0]) }, on: device),
+      seed: Tensor<Int32>([seed.graph, seed.op], on: device))
     self = standardDeviation * sample + mean
   }
 }

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -1229,7 +1229,7 @@ public func softmax<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 @differentiable
 public func softmax<T: TensorFlowFloatingPoint>(_ x: Tensor<T>, alongAxis axis: Int) -> Tensor<T> {
   let xExp = exp(x)
-  return xExp / xExp.sum(alongAxes: Tensor<Int32>(Int32(axis)))
+  return xExp / xExp.sum(alongAxes: Tensor<Int32>(Int32(axis), on: xExp.device))
 }
 
 @inlinable
@@ -1674,7 +1674,7 @@ extension Tensor where Scalar == Bool {
   // `all(squeezingAxes:)` with zero indices.
   @inlinable
   public func all() -> Bool {
-    let axes = Tensor<Int32>(rangeFrom: 0, to: Int32(rank), stride: 1)
+    let axes = Tensor<Int32>(rangeFrom: 0, to: Int32(rank), stride: 1, on: device)
     return _Raw.all(self, reductionIndices: axes).scalarized()
   }
 
@@ -1683,7 +1683,7 @@ extension Tensor where Scalar == Bool {
   // `any(squeezingAxes:)` with zero indices.
   @inlinable
   public func any() -> Bool {
-    let axes = Tensor<Int32>(rangeFrom: 0, to: Int32(rank), stride: 1)
+    let axes = Tensor<Int32>(rangeFrom: 0, to: Int32(rank), stride: 1, on: device)
     return _Raw.any(self, reductionIndices: axes).scalarized()
   }
 
@@ -1695,7 +1695,7 @@ extension Tensor where Scalar == Bool {
   public func all(squeezingAxes axes: Int...) -> Tensor {
     ensureValid(axes: axes)
     let axes = axes.map(Int32.init)
-    return _Raw.all(self, reductionIndices: Tensor<Int32>(axes), keepDims: false)
+    return _Raw.all(self, reductionIndices: Tensor<Int32>(axes, on: device), keepDims: false)
   }
 
   /// Performs a logical AND operation along the specified axes. The reduced dimensions are
@@ -1706,7 +1706,7 @@ extension Tensor where Scalar == Bool {
   public func any(squeezingAxes axes: Int...) -> Tensor {
     ensureValid(axes: axes)
     let axes = axes.map(Int32.init)
-    return _Raw.any(self, reductionIndices: Tensor<Int32>(axes), keepDims: false)
+    return _Raw.any(self, reductionIndices: Tensor<Int32>(axes, on: device), keepDims: false)
   }
 
   /// Performs a logical AND operation along the specified axes. The reduced dimensions are
@@ -1717,7 +1717,7 @@ extension Tensor where Scalar == Bool {
   public func all(alongAxes axes: Int...) -> Tensor {
     ensureValid(axes: axes)
     let axes = axes.map(Int32.init)
-    return _Raw.all(self, reductionIndices: Tensor<Int32>(axes), keepDims: true)
+    return _Raw.all(self, reductionIndices: Tensor<Int32>(axes, on: device), keepDims: true)
   }
 
   /// Performs a logical OR operation along the specified axes. The reduced
@@ -1728,7 +1728,7 @@ extension Tensor where Scalar == Bool {
   public func any(alongAxes axes: Int...) -> Tensor {
     ensureValid(axes: axes)
     let axes = axes.map(Int32.init)
-    return _Raw.any(self, reductionIndices: Tensor<Int32>(axes), keepDims: true)
+    return _Raw.any(self, reductionIndices: Tensor<Int32>(axes, on: device), keepDims: true)
   }
 }
 
@@ -1738,7 +1738,7 @@ extension Tensor where Scalar: Numeric & Comparable {
   @inlinable
   @differentiable( where Scalar: TensorFlowFloatingPoint)
   public func min() -> Tensor {
-    let axes = Tensor<Int32>(rangeFrom: 0, to: Int32(rank), stride: 1)
+    let axes = Tensor<Int32>(rangeFrom: 0, to: Int32(rank), stride: 1, on: device)
     return min(squeezingAxes: axes)
   }
 
@@ -1747,7 +1747,7 @@ extension Tensor where Scalar: Numeric & Comparable {
   @inlinable
   @differentiable( where Scalar: TensorFlowFloatingPoint)
   public func max() -> Tensor {
-    let axes = Tensor<Int32>(rangeFrom: 0, to: Int32(rank), stride: 1)
+    let axes = Tensor<Int32>(rangeFrom: 0, to: Int32(rank), stride: 1, on: device)
     return max(squeezingAxes: axes)
   }
 
@@ -1769,7 +1769,7 @@ extension Tensor where Scalar: Numeric & Comparable {
   public func max(squeezingAxes axes: [Int]) -> Tensor {
     // TODO(TF-433): Remove workaround for differentiating `map`.
     let axes = { axes.map(Int32.init) }()
-    return max(squeezingAxes: Tensor<Int32>(axes))
+    return max(squeezingAxes: Tensor<Int32>(axes, on: device))
   }
 
   /// Returns the maximum values along the specified axes. The reduced dimensions are removed.
@@ -1799,7 +1799,7 @@ extension Tensor where Scalar: Numeric & Comparable {
   public func min(squeezingAxes axes: [Int]) -> Tensor {
     // TODO(TF-433): Remove workaround for differentiating `map`.
     let axes = { axes.map(Int32.init) }()
-    return min(squeezingAxes: Tensor<Int32>(axes))
+    return min(squeezingAxes: Tensor<Int32>(axes, on: device))
   }
 
   /// Returns the minimum values along the specified axes. The reduced dimensions are removed.
@@ -1828,7 +1828,7 @@ extension Tensor where Scalar: Numeric & Comparable {
   @inlinable
   public func argmin(squeezingAxis axis: Int) -> Tensor<Int32> {
     ensureValid(axes: [axis])
-    return _Raw.argMin(self, dimension: Tensor<Int32>(Int32(axis)))
+    return _Raw.argMin(self, dimension: Tensor<Int32>(Int32(axis), on: device))
   }
 
   /// Returns the minimum along the specified axes. The reduced dimensions are retained with
@@ -1851,7 +1851,7 @@ extension Tensor where Scalar: Numeric & Comparable {
   public func min(alongAxes axes: [Int]) -> Tensor {
     // TODO(TF-433): Remove workaround for differentiating `map`.
     let axes = { axes.map(Int32.init) }()
-    return min(alongAxes: Tensor<Int32>(axes))
+    return min(alongAxes: Tensor<Int32>(axes, on: device))
   }
 
   /// Returns the minimum along the specified axes. The reduced dimensions are retained with
@@ -1884,7 +1884,7 @@ extension Tensor where Scalar: Numeric & Comparable {
   public func max(alongAxes axes: [Int]) -> Tensor {
     // TODO(TF-433): Remove workaround for differentiating `map`.
     let axes = { axes.map(Int32.init) }()
-    return max(alongAxes: Tensor<Int32>(axes))
+    return max(alongAxes: Tensor<Int32>(axes, on: device))
   }
 
   /// Returns the minimum along the specified axes. The reduced dimensions are retained with
@@ -2093,7 +2093,7 @@ extension Tensor where Scalar: Numeric {
   public func product(squeezingAxes axes: [Int]) -> Tensor {
     // TODO(TF-433): Remove workaround for differentiating `map`.
     let axes = { axes.map(Int32.init) }()
-    return product(squeezingAxes: Tensor<Int32>(axes))
+    return product(squeezingAxes: Tensor<Int32>(axes, on: device))
   }
 
   /// Returns the product along the specified axes. The reduced dimensions are removed.
@@ -2130,7 +2130,7 @@ extension Tensor where Scalar: Numeric {
   public func product(alongAxes axes: [Int]) -> Tensor {
     // TODO(TF-433): Remove workaround for differentiating `map`.
     let axes = { axes.map(Int32.init) }()
-    return product(alongAxes: Tensor<Int32>(axes))
+    return product(alongAxes: Tensor<Int32>(axes, on: device))
   }
 
   /// Returns the product along the specified axes. The reduced dimensions are retained with
@@ -2236,7 +2236,7 @@ extension Tensor where Scalar: Numeric {
   public func variance(squeezingAxes axes: [Int]) -> Tensor {
     // TODO(TF-433): Remove workaround for differentiating `map`.
     let axes = { axes.map(Int32.init) }()
-    return variance(squeezingAxes: Tensor<Int32>(axes))
+    return variance(squeezingAxes: Tensor<Int32>(axes, on: device))
   }
 
   /// Returns the variance along the specified axes. The reduced dimensions are retained with
@@ -2278,7 +2278,7 @@ extension Tensor where Scalar: Numeric {
   public func variance(alongAxes axes: [Int]) -> Tensor {
     // TODO(TF-433): Remove workaround for differentiating `map`.
     let axes = { axes.map(Int32.init) }()
-    return variance(alongAxes: Tensor<Int32>(axes))
+    return variance(alongAxes: Tensor<Int32>(axes, on: device))
   }
 
   /// Returns the variance along the specified axes. The reduced dimensions are retained with
@@ -2324,7 +2324,7 @@ extension Tensor where Scalar: Numeric {
     reverse: Bool = false
   ) -> Tensor {
     cumulativeSum(
-      alongAxis: Tensor<Int32>(Int32(axis)),
+      alongAxis: Tensor<Int32>(Int32(axis), on: device),
       exclusive: exclusive,
       reverse: reverse)
   }
@@ -2399,7 +2399,7 @@ extension Tensor where Scalar: Numeric {
     reverse: Bool = false
   ) -> Tensor {
     cumulativeProduct(
-      alongAxis: Tensor<Int32>(Int32(axis)),
+      alongAxis: Tensor<Int32>(Int32(axis), on: device),
       exclusive: exclusive,
       reverse: reverse)
   }
@@ -2604,9 +2604,9 @@ extension Tensor where Scalar: TensorFlowFloatingPoint {
 
         // Pack all reduced dimensions into a single one, so we can perform the
         // `cumulativeProduct` operations.
-        let idx = Tensor<Int32>(0..<Int32(self.rank))
+        let idx = Tensor<Int32>(0..<Int32(self.rank), on: device)
         let other = Tensor<Int32>(
-          Array(Set(idx.scalars).symmetricDifference(reductionIndices.scalars)))
+          Array(Set(idx.scalars).symmetricDifference(reductionIndices.scalars)), on: device)
         let perm = reductionIndices.concatenated(with: other)
         let reducedNum = Int(
           self.shapeTensor.gathering(atIndices: reductionIndices).product().scalarized())
@@ -2700,7 +2700,7 @@ extension Tensor where Scalar: TensorFlowFloatingPoint {
   public func standardDeviation(alongAxes axes: [Int]) -> Tensor {
     // TODO(TF-433): Remove workaround for differentiating `map`.
     let axes = { axes.map(Int32.init) }()
-    return standardDeviation(alongAxes: Tensor<Int32>(axes))
+    return standardDeviation(alongAxes: Tensor<Int32>(axes, on: device))
   }
 
   /// Returns the standard deviation of the elements along the specified axes. The reduced
@@ -2751,7 +2751,7 @@ extension Tensor where Scalar: TensorFlowFloatingPoint {
   public func logSumExp(squeezingAxes axes: [Int]) -> Tensor {
     // TODO(TF-433): Remove workaround for differentiating `map`.
     let axes = withoutDerivative(at: axes) { $0.map(Int32.init) }
-    return logSumExp(squeezingAxes: Tensor<Int32>(axes))
+    return logSumExp(squeezingAxes: Tensor<Int32>(axes, on: device))
   }
 
   /// Returns `log(exp(self).sum(squeezingAxes: axes))`. The reduced dimensions are removed.
@@ -2816,7 +2816,7 @@ extension Tensor where Scalar: TensorFlowFloatingPoint {
   public func logSumExp(alongAxes axes: [Int]) -> Tensor {
     // TODO(TF-433): Remove workaround for differentiating `map`.
     let axes = withoutDerivative(at: axes) { $0.map(Int32.init) }
-    return logSumExp(alongAxes: Tensor<Int32>(axes))
+    return logSumExp(alongAxes: Tensor<Int32>(axes, on: device))
   }
 
   /// Returns `log(exp(self).sum(alongAxes: axes))`. The reduced dimensions are retained with

--- a/Sources/x10/swift_bindings/Device.swift
+++ b/Sources/x10/swift_bindings/Device.swift
@@ -114,15 +114,20 @@ public struct Device {
 
   /// The default `Device`.
   public static var `default`: Device {
-  #if DEFAULT_BACKEND_EAGER
-    return Device.defaultTFEager
-  #else
-    let cdevice = DefaultDevice()
-    return cdevice.device
-  #endif
+    #if DEFAULT_BACKEND_EAGER
+      return Device.defaultTFEager
+    #else
+      return Device.defaultXLA
+    #endif
   }
 
-  /// Run using the current TF Eager device.
+  /// The default XLA device.
+  public static var defaultXLA: Device {
+    let cdevice = DefaultDevice()
+    return cdevice.device
+  }
+
+  /// The current TF Eager device.
   public static var defaultTFEager: Device {
     // TODO: Pull this from withDevice() {} mechanism?
     return Device(kind: .CPU, ordinal: 0, backend: .TF_EAGER)

--- a/Tests/x10/ops_test.swift
+++ b/Tests/x10/ops_test.swift
@@ -1,55 +1,37 @@
-import TensorFlow
 import XCTest
-import x10_device
 import x10_tensor
 import x10_xla_tensor_wrapper
 
-typealias TFTensor_ = TensorFlow.Tensor
-typealias X10Tensor_ = x10_tensor.Tensor
-typealias TFTensor = TensorFlow.Tensor<Float>
-typealias X10Tensor = x10_tensor.Tensor<Float>
-typealias TensorRange = x10_tensor.TensorRange
-typealias Conv2D = x10_tensor.Conv2D
+// TODO(b/130689556): Remove this environment setting once the bug is fixed.
+setenv("XLA_FLAGS", "--xla_cpu_fast_math_honor_nans=true --xla_cpu_fast_math_honor_infs=true", 1)
+SetMatMulPrecision(true)
+let x10 = Device.defaultXLA
+let tf = Device.defaultTFEager
 
-private func TF<T>(_ x: x10_tensor.Tensor<T>) -> TensorFlow.Tensor<T> {
-  return TensorFlow.Tensor<T>(shape: TensorFlow.TensorShape(x.shape.dimensions), scalars: x.scalars)
+private func X10<T>(_ x: Tensor<T>) -> Tensor<T> {
+  return Tensor<T>(copying: x, to: x10)
+}
+private func TF<T>(_ x: Tensor<T>) -> Tensor<T> {
+  return Tensor<T>(copying: x, to: tf)
 }
 
 /// Returns true iff the absolute difference between all elements is at most `absTolerance`.
 private func allClose(
-  actual: TFTensor, expected: TFTensor, relTolerance: Float = 1e-5, absTolerance: Float = 1e-7
+  actual: Tensor<Float>, expected: Tensor<Float>, relTolerance: Float = 1e-5,
+  absTolerance: Float = 1e-7
 ) -> Bool {
   return (abs(actual - expected) .<= absTolerance + relTolerance * abs(expected)).all()
 }
 
-private func TF(_ range: TensorRange) -> TensorFlow.TensorRange {
-  switch range {
-  case .ellipsis:
-    return .ellipsis
-  case .newAxis:
-    return .newAxis
-  case .squeezeAxis:
-    return .squeezeAxis
-  case let .index(i):
-    return .index(i)
-  case let .range(r, s):
-    return .range(r, stride: s)
-  case let .closedRange(r, s):
-    return .closedRange(r, stride: s)
-  case let .partialRangeFrom(r, s):
-    return .partialRangeFrom(r, stride: s)
-  case let .partialRangeUpTo(r, s):
-    return .partialRangeUpTo(r, stride: s)
-  case let .partialRangeThrough(r, s):
-    return .partialRangeThrough(r, stride: s)
-  }
+private func TF(_ range: TensorRange) -> TensorRange {
+  return range
 }
 
 private func assertEqualUnaryOperationGradients(
-  _ xlaOp: @differentiable (X10Tensor) -> X10Tensor,
-  _ tensorFlowOp: @differentiable (TFTensor) -> TFTensor,
-  _ x: X10Tensor,
-  _ outGrad: X10Tensor,
+  _ xlaOp: @differentiable (Tensor<Float>) -> Tensor<Float>,
+  _ tensorFlowOp: @differentiable (Tensor<Float>) -> Tensor<Float>,
+  _ x: Tensor<Float>,
+  _ outGrad: Tensor<Float>,
   relTolerance: Float = 1e-5,
   absTolerance: Float = 1e-7,
   file: StaticString = #file, line: UInt = #line
@@ -81,11 +63,11 @@ private func assertEqualUnaryOperationGradients(
 }
 
 private func assertEqualBinaryOperationGradients(
-  _ xlaOp: @differentiable (X10Tensor, X10Tensor) -> X10Tensor,
-  _ tensorFlowOp: @differentiable (TFTensor, TFTensor) -> TFTensor,
-  _ x: X10Tensor,
-  _ y: X10Tensor,
-  _ outGrad: X10Tensor,
+  _ xlaOp: @differentiable (Tensor<Float>, Tensor<Float>) -> Tensor<Float>,
+  _ tensorFlowOp: @differentiable (Tensor<Float>, Tensor<Float>) -> Tensor<Float>,
+  _ x: Tensor<Float>,
+  _ y: Tensor<Float>,
+  _ outGrad: Tensor<Float>,
   relTolerance: Float = 1e-5,
   absTolerance: Float = 1e-7,
   file: StaticString = #file, line: UInt = #line
@@ -137,28 +119,28 @@ extension Bool: IntOrBool {
 
 extension Int32: IntOrBool {}
 
-extension X10Tensor {
-  private static var randSeed = 0
+var randSeed = 0
 
-  static func rand(_ dims: [Int]) -> X10Tensor {
+extension Tensor {
+  static func rand(_ dims: [Int]) -> Tensor<Float> {
     randSeed = randSeed + 1
     return _Raw.rand(dims, randSeed)
   }
 
-  static func randint<T: IntOrBool>(_ low: Int, _ high: Int, _ shape: [Int]) -> X10Tensor_<T> {
+  static func randint<T: IntOrBool>(_ low: Int, _ high: Int, _ shape: [Int]) -> Tensor<T> {
     let numel = shape.reduce(1, *)
-    return X10Tensor_<T>(
+    return Tensor<T>(
       shape: TensorShape(
-        shape), scalars: (0..<numel).map { _ in T(Int.random(in: low..<high)) })
+        shape), scalars: (0..<numel).map { _ in T(Int.random(in: low..<high)) }, on: x10)
   }
 }
 
 final class TensorTests: XCTestCase {
   func testAbs() throws {
     let dims = [3, 2]
-    let off = X10Tensor(
-      shape: TensorShape(dims), scalars: [Float](repeating: 0.5, count: dims.reduce(1, *)))
-    var x = X10Tensor.rand(dims) - off
+    let off = Tensor<Float>(
+      shape: TensorShape(dims), scalars: [Float](repeating: 0.5, count: dims.reduce(1, *)), on: x10)
+    var x = Tensor<Float>.rand(dims) - off
     let expected = abs(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -177,7 +159,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testAcos() throws {
-    var x = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
     let expected = acos(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -197,7 +179,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testAcosh() throws {
-    var x = X10Tensor.rand([3, 2]) + 1
+    var x = Tensor<Float>.rand([3, 2]) + 1
     let expected = acosh(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -217,8 +199,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testAdd() throws {
-    var x = X10Tensor(shape: [2], scalars: [1, 2])
-    var y = X10Tensor(shape: [2], scalars: [7, 19])
+    var x = Tensor<Float>(shape: [2], scalars: [1, 2], on: x10)
+    var y = Tensor<Float>(shape: [2], scalars: [7, 19], on: x10)
     let expected = TF(x) + TF(y)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -238,13 +220,13 @@ final class TensorTests: XCTestCase {
   }
 
   func testAddInterop() throws {
-    let x = X10Tensor(shape: [2], scalars: [1, 2], on: Device.defaultTFEager)
-    let y = X10Tensor(shape: [2], scalars: [7, 19], on: Device.defaultTFEager)
+    let x = Tensor<Float>(shape: [2], scalars: [1, 2], on: tf)
+    let y = Tensor<Float>(shape: [2], scalars: [7, 19], on: tf)
     XCTAssertEqual((x + y).scalars, [8, 21])
   }
 
   func testAll() throws {
-    let x: X10Tensor_<Bool> = X10Tensor.randint(0, 2, [2, 3, 4])
+    let x: Tensor<Bool> = Tensor<Float>.randint(0, 2, [2, 3, 4])
     for axis in -x.rank..<x.rank {
       let actual = TF(x.all(alongAxes: axis))
       let expected = TF(x).all(alongAxes: axis)
@@ -256,8 +238,8 @@ final class TensorTests: XCTestCase {
       XCTAssertEqual(actual, expected)
     }
     let dims = [2, 3, 4]
-    let allTrue = X10Tensor_<Bool>(
-      shape: TensorShape(dims), scalars: [Bool](repeating: true, count: dims.reduce(1, *)))
+    let allTrue = Tensor<Bool>(
+      shape: TensorShape(dims), scalars: [Bool](repeating: true, count: dims.reduce(1, *)), on: x10)
     for axis in -allTrue.rank..<allTrue.rank {
       let actual = TF(allTrue.all(alongAxes: axis))
       let expected = TF(allTrue).all(alongAxes: axis)
@@ -271,7 +253,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testAny() throws {
-    let x: X10Tensor_<Bool> = X10Tensor.randint(0, 2, [2, 3, 4])
+    let x: Tensor<Bool> = Tensor<Float>.randint(0, 2, [2, 3, 4])
     for axis in -x.rank..<x.rank {
       let actual = TF(x.any(alongAxes: axis))
       let expected = TF(x).any(alongAxes: axis)
@@ -283,8 +265,8 @@ final class TensorTests: XCTestCase {
       XCTAssertEqual(actual, expected)
     }
     let dims = [2, 3, 4]
-    let allFalse = X10Tensor_<Bool>(
-      shape: TensorShape(dims), scalars: [Bool](repeating: true, count: dims.reduce(1, *)))
+    let allFalse = Tensor<Bool>(
+      shape: TensorShape(dims), scalars: [Bool](repeating: true, count: dims.reduce(1, *)), on: x10)
     for axis in -allFalse.rank..<allFalse.rank {
       let actual = TF(allFalse.any(alongAxes: axis))
       let expected = TF(allFalse).any(alongAxes: axis)
@@ -300,8 +282,8 @@ final class TensorTests: XCTestCase {
   func testApproximateEqual() throws {
     for useReducedPrecision in [false, true] {
       for tolerance in [0.2, 0.05] {
-        var x = X10Tensor.rand([3, 2])
-        var noise = X10Tensor(onesLike: x) * 0.1
+        var x = Tensor<Float>.rand([3, 2])
+        var noise = Tensor(onesLike: x) * 0.1
         if useReducedPrecision {
           x = x.toReducedPrecision
         }
@@ -317,7 +299,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testArgmax() throws {
-    var x = X10Tensor(shape: [3, 2], scalars: [1, 5, 43, 24, 64, 32])
+    var x = Tensor<Float>(shape: [3, 2], scalars: [1, 5, 43, 24, 64, 32], on: x10)
     let tfX = TF(x)
     let expected = tfX.argmax(squeezingAxis: 0)
     for useReducedPrecision in [false, true] {
@@ -331,7 +313,7 @@ final class TensorTests: XCTestCase {
 
   func testArgmin() throws {
     for useReducedPrecision in [false, true] {
-      var x = X10Tensor(shape: [3, 2], scalars: [1, 5, 43, 24, 64, 32])
+      var x = Tensor<Float>(shape: [3, 2], scalars: [1, 5, 43, 24, 64, 32], on: x10)
       if useReducedPrecision {
         x = x.toReducedPrecision
       }
@@ -345,7 +327,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testAsin() throws {
-    var x = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
     let expected = asin(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -365,7 +347,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testAsinh() throws {
-    var x = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
     let expected = asinh(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -385,15 +367,15 @@ final class TensorTests: XCTestCase {
   }
 
   func testAtan2() throws {
-    let y = X10Tensor([3, 5])
-    let x = X10Tensor([2, 3])
+    let y = Tensor<Float>([3, 5], on: x10)
+    let x = Tensor<Float>([2, 3], on: x10)
     let actual = _Raw.atan2(y, x)
     let expected = _Raw.atan2(TF(y), TF(x))
     XCTAssert(allClose(actual: TF(actual), expected: expected))
   }
 
   func testAtan() throws {
-    var x = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
     let expected = atan(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -413,7 +395,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testAtanh() throws {
-    var x = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
     let expected = atanh(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -436,7 +418,7 @@ final class TensorTests: XCTestCase {
     for useReducedPrecision in [false, true] {
       for stride in 1..<3 {
         for padSame in [false, true] {
-          var x = X10Tensor.rand([4, 28, 28, 1])
+          var x = Tensor<Float>.rand([4, 28, 28, 1])
           let expected = avgPool2D(
             TF(x), filterSize: (1, 2, 2, 1), strides: (1, stride, stride, 1),
             padding: padSame ? Padding.same : Padding.valid)
@@ -465,24 +447,24 @@ final class TensorTests: XCTestCase {
     for useReducedPrecision in [false, true] {
       for stride in 1..<3 {
         for padSame in [false, true] {
-          var x = X10Tensor.rand([4, 28, 28, 1])
+          var x = Tensor<Float>.rand([4, 28, 28, 1])
           let outShape = avgPool2D(
             TF(x), filterSize: (1, 2, 2, 1), strides: (1, stride, stride, 1),
             padding: padSame ? Padding.same : Padding.valid
           ).shape
-          var outGrad = X10Tensor.rand(outShape.dimensions)
+          var outGrad = Tensor<Float>.rand(outShape.dimensions)
           if useReducedPrecision {
             x = x.toReducedPrecision
             outGrad = outGrad.toReducedPrecision
           }
           let relTolerance: Float = useReducedPrecision ? 1e-2 : 1e-5
           assertEqualUnaryOperationGradients(
-            { (_ x: X10Tensor) -> X10Tensor in
+            { (_ x: Tensor<Float>) -> Tensor<Float> in
               avgPool2D(
                 x, filterSize: (1, 2, 2, 1), strides: (1, stride, stride, 1),
                 padding: padSame ? Padding.same : Padding.valid)
             },
-            { (_ x: TFTensor) -> TFTensor in
+            { (_ x: Tensor<Float>) -> Tensor<Float> in
               avgPool2D(
                 x, filterSize: (1, 2, 2, 1), strides: (1, stride, stride, 1),
                 padding: padSame ? Padding.same : Padding.valid)
@@ -496,24 +478,24 @@ final class TensorTests: XCTestCase {
     for useReducedPrecision in [false, true] {
       for stride in 1..<3 {
         for padSame in [false, true] {
-          var x = X10Tensor.rand([4, 28, 28, 28, 1])
+          var x = Tensor<Float>.rand([4, 28, 28, 28, 1])
           let outShape = avgPool3D(
             TF(x), filterSize: (1, 2, 2, 2, 1), strides: (1, stride, stride, stride, 1),
             padding: padSame ? Padding.same : Padding.valid
           ).shape
-          var outGrad = X10Tensor.rand(outShape.dimensions)
+          var outGrad = Tensor<Float>.rand(outShape.dimensions)
           if useReducedPrecision {
             x = x.toReducedPrecision
             outGrad = outGrad.toReducedPrecision
           }
           let relTolerance: Float = useReducedPrecision ? 2e-2 : 1e-5
           assertEqualUnaryOperationGradients(
-            { (_ x: X10Tensor) -> X10Tensor in
+            { (_ x: Tensor<Float>) -> Tensor<Float> in
               avgPool3D(
                 x, filterSize: (1, 2, 2, 2, 1), strides: (1, stride, stride, stride, 1),
                 padding: padSame ? Padding.same : Padding.valid)
             },
-            { (_ x: TFTensor) -> TFTensor in
+            { (_ x: Tensor<Float>) -> Tensor<Float> in
               avgPool3D(
                 x, filterSize: (1, 2, 2, 2, 1), strides: (1, stride, stride, stride, 1),
                 padding: padSame ? Padding.same : Padding.valid)
@@ -525,16 +507,14 @@ final class TensorTests: XCTestCase {
 
   func testBatchNorm() throws {
     let featureCount = 3
-    let tfModel = TensorFlow.BatchNorm<Float>(featureCount: featureCount)
+    let tfModel = BatchNorm<Float>(copying: BatchNorm<Float>(featureCount: featureCount), to: tf)
     for trainingPhase in [false, true] {
-      x10_tensor.Context.local.learningPhase =
-        trainingPhase ? .training : .inference
-      TensorFlow.Context.local.learningPhase = trainingPhase ? .training : .inference
-      var model = x10_tensor.BatchNorm<Float>(featureCount: featureCount)
+      Context.local.learningPhase = trainingPhase ? .training : .inference
+      var model = BatchNorm<Float>(copying: BatchNorm<Float>(featureCount: featureCount), to: x10)
       let shape = [2, 3, 4, featureCount]
-      var x = X10Tensor(
+      var x = Tensor<Float>(
         shape: TensorShape(shape),
-        scalars: Array(stride(from: 0.0, to: Float(shape.reduce(1, *)), by: 1)))
+        scalars: Array(stride(from: 0.0, to: Float(shape.reduce(1, *)), by: 1)), on: x10)
       let expected = tfModel(TF(x))
       for useReducedPrecision in [false, true] {
         if useReducedPrecision {
@@ -556,20 +536,18 @@ final class TensorTests: XCTestCase {
 
   func testBatchNormGrad() throws {
     let featureCount = 3
-    let tfModel = TensorFlow.BatchNorm<Float>(featureCount: featureCount)
+    let tfModel = BatchNorm<Float>(copying: BatchNorm<Float>(featureCount: featureCount), to: tf)
     let shape = [2, 3, 2, featureCount]
     for trainingPhase in [false, true] {
-      x10_tensor.Context.local.learningPhase =
-        trainingPhase ? .training : .inference
-      TensorFlow.Context.local.learningPhase = trainingPhase ? .training : .inference
-      var model = x10_tensor.BatchNorm<Float>(featureCount: featureCount)
-      var x = X10Tensor(
+      Context.local.learningPhase = trainingPhase ? .training : .inference
+      var model = BatchNorm<Float>(copying: BatchNorm<Float>(featureCount: featureCount), to: x10)
+      var x = Tensor<Float>(
         shape: TensorShape(shape),
-        scalars: Array(stride(from: 0.0, to: Float(shape.reduce(1, *)), by: 1)))
+        scalars: Array(stride(from: 0.0, to: Float(shape.reduce(1, *)), by: 1)), on: x10)
       for useReducedPrecision in [false, true] {
         let 𝛁tfModel = gradient(
           at: tfModel,
-          in: { tfModel -> TFTensor in
+          in: { tfModel -> Tensor<Float> in
             tfModel(TF(x)).sum()
           })
         if useReducedPrecision {
@@ -578,7 +556,7 @@ final class TensorTests: XCTestCase {
         }
         let 𝛁model = gradient(
           at: model,
-          in: { model -> X10Tensor in
+          in: { model -> Tensor<Float> in
             model(x).sum()
           })
         XCTAssertEqual(𝛁model.offset.isReducedPrecision, useReducedPrecision)
@@ -595,7 +573,7 @@ final class TensorTests: XCTestCase {
     let inChannels = 1
     let batchSize = 1
     let dims = [batchSize, 7, 7, inChannels]
-    let input = X10Tensor.rand(dims)
+    let input = Tensor<Float>.rand(dims)
     let inputBF16 = input.toReducedPrecision
     let inputF32 = inputBF16.toFullPrecision
     // Materialize the converted tensors so that the graph inputs are the type we want to test
@@ -605,8 +583,9 @@ final class TensorTests: XCTestCase {
     let model = Conv2D<Float>(
       filterShape: (5, 5, inChannels, outChannels), padding: .same, activation: relu,
       filterInitializer: { shape in
-        X10Tensor(
-          shape: shape, scalars: [Float](repeating: 0.5, count: shape.dimensions.reduce(1, *)))
+        Tensor<Float>(
+          shape: shape, scalars: [Float](repeating: 0.5, count: shape.dimensions.reduce(1, *)),
+          on: x10)
       })
     // Materialize the model weights to reflect the steady state by leaving random initialization
     // out of the interesting computation.
@@ -626,12 +605,13 @@ final class TensorTests: XCTestCase {
 
   func testBF16Construct() {
     let scalars: [Float] = [1, 2, 3, 4, 5, 6]
-    var actual = X10Tensor(shape: [3, 2], scalars: scalars,
-                           toReducedPrecision: true, directlyOn: .default)
+    var actual = Tensor<Float>(
+      shape: [3, 2], scalars: scalars,
+      toReducedPrecision: true, directlyOn: x10)
     XCTAssert(actual.isReducedPrecision)
     actual = actual.toFullPrecision
     XCTAssert(!actual.isReducedPrecision)
-    let expected = TFTensor(shape: [3, 2], scalars: scalars)
+    let expected = Tensor<Float>(shape: [3, 2], scalars: scalars, on: tf)
     XCTAssertEqual(TF(actual), expected)
   }
 
@@ -639,7 +619,7 @@ final class TensorTests: XCTestCase {
     let inChannels = 1
     let batchSize = 1
     let dims = [batchSize, 7, 7, inChannels]
-    let input = X10Tensor.rand(dims)
+    let input = Tensor<Float>.rand(dims)
     let inputBF16 = input.toReducedPrecision
     let inputF32 = inputBF16.toFullPrecision
     // Materialize the converted tensors so that the graph inputs are the type we want to test
@@ -649,8 +629,9 @@ final class TensorTests: XCTestCase {
     let model = Conv2D<Float>(
       filterShape: (5, 5, inChannels, outChannels), padding: .same, activation: relu,
       filterInitializer: { shape in
-        X10Tensor(
-          shape: shape, scalars: [Float](repeating: 0.5, count: shape.dimensions.reduce(1, *)))
+        Tensor(
+          shape: shape, scalars: [Float](repeating: 0.5, count: shape.dimensions.reduce(1, *)),
+          on: x10)
       })
     // Materialize the model weights to reflect the steady state by leaving random initialization
     // out of the interesting computation.
@@ -658,14 +639,14 @@ final class TensorTests: XCTestCase {
     let mixedPrecisionModel = model.toReducedPrecision
     let 𝛁model = x10_tensor.gradient(
       at: mixedPrecisionModel,
-      in: { mixedPrecisionModel -> X10Tensor in
+      in: { mixedPrecisionModel -> Tensor<Float> in
         let ŷ = mixedPrecisionModel(inputBF16)
         let loss = ŷ.sum()
         return loss
       })
     let 𝛁modelViaBF16 = x10_tensor.gradient(
       at: model,
-      in: { model -> X10Tensor in
+      in: { model -> Tensor<Float> in
         let ŷ = model(inputF32)
         let loss = ŷ.sum()
         return loss
@@ -678,8 +659,9 @@ final class TensorTests: XCTestCase {
 
   func testBF16Loopback() {
     let dims = [3, 2]
-    let input = X10Tensor(
-      shape: TensorShape(dims), scalars: [Float](repeating: 123456.7, count: dims.reduce(1, *)))
+    let input = Tensor<Float>(
+      shape: TensorShape(dims), scalars: [Float](repeating: 123456.7, count: dims.reduce(1, *)),
+      on: x10)
     let inputBF16 = input.toReducedPrecision
     XCTAssert(inputBF16.isReducedPrecision)
     // Materialize the input tensor so that the graph input is of BF16 type.
@@ -690,8 +672,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testBF16SparseSoftmaxCrossEntropyWithLogits() throws {
-    let labels = X10Tensor_<Int32>(shape: [2], scalars: [3, 4])
-    let logits = X10Tensor.rand([2, 5])
+    let labels = Tensor<Int32>(shape: [2], scalars: [3, 4], on: x10)
+    let logits = Tensor<Float>.rand([2, 5])
     let logitsBF16 = logits.toReducedPrecision
     let logitsF32 = logitsBF16.toFullPrecision
     LazyTensorBarrier(on: logits.device)
@@ -711,7 +693,7 @@ final class TensorTests: XCTestCase {
 
   func testBF16Sum() {
     let dims = [3, 2]
-    let input = X10Tensor.rand(dims)
+    let input = Tensor<Float>.rand(dims)
     let inputBF16 = input.toReducedPrecision
     let inputF32 = inputBF16.toFullPrecision
     LazyTensorBarrier(on: input.device)
@@ -725,7 +707,7 @@ final class TensorTests: XCTestCase {
   func testBroadcastDims() throws {
     for useReducedPrecision in [false, true] {
       for i in -3..<4 {
-        var x = X10Tensor(shape: [2, 2, 2], scalars: [1, 5, 43, 24, 64, 32, 3, 4])
+        var x = Tensor<Float>(shape: [2, 2, 2], scalars: [1, 5, 43, 24, 64, 32, 3, 4], on: x10)
         let expected = TF(x).expandingShape(at: i)
         if useReducedPrecision {
           x = x.toReducedPrecision
@@ -742,7 +724,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testBroadcastTo() throws {
-    var x = X10Tensor(shape: [2, 1, 3], scalars: [1, 5, 43, 24, 64, 32])
+    var x = Tensor<Float>(shape: [2, 1, 3], scalars: [1, 5, 43, 24, 64, 32], on: x10)
     let expected = TF(x).broadcasted(to: [9, 2, 8, 3])
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -763,8 +745,8 @@ final class TensorTests: XCTestCase {
       _ a: [Int], _ b: [Int],
       file: StaticString = #file, line: UInt = #line
     ) {
-      let at = X10Tensor_<Int64>(a.map(Int64.init))
-      let bt = X10Tensor_<Int64>(b.map(Int64.init))
+      let at = Tensor<Int64>(a.map(Int64.init), on: x10)
+      let bt = Tensor<Int64>(b.map(Int64.init), on: x10)
       let actual = _Raw.broadcastGradientArgs(s0: at, s1: bt)
       let expected = _Raw.broadcastGradientArgs(s0: TF(at), s1: TF(bt))
       XCTAssertEqual(TF(actual.r0), expected.r0, file: file, line: line)
@@ -776,19 +758,19 @@ final class TensorTests: XCTestCase {
   }
 
   func testCast() throws {
-    var x = X10Tensor(shape: [2], scalars: [1, 2])
-    let expected = TFTensor_<Double>(TF(x))
+    var x = Tensor<Float>(shape: [2], scalars: [1, 2], on: x10)
+    let expected = Tensor<Double>(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         x = x.toReducedPrecision
       }
-      let actual = TF(X10Tensor_<Double>(x))
+      let actual = TF(Tensor<Double>(x))
       XCTAssertEqual(actual, expected)
     }
   }
 
   func testCeil() throws {
-    var x = X10Tensor.rand([3, 2]) * 8
+    var x = Tensor<Float>.rand([3, 2]) * 8
     let expected = ceil(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -811,13 +793,15 @@ final class TensorTests: XCTestCase {
     let high: Float = 0.7
     for useReducedPrecision in [false, true] {
       for scalarClipValues in [false, true] {
-        var x = X10Tensor.rand(dims)
+        var x = Tensor<Float>.rand(dims)
         var clipValueMin =
           scalarClipValues
-          ? X10Tensor(low) : X10Tensor(repeating: low, shape: TensorShape(dims))
+          ? Tensor<Float>(low, on: x10)
+          : Tensor<Float>(repeating: low, shape: TensorShape(dims), on: x10)
         var clipValueMax =
           scalarClipValues
-          ? X10Tensor(high) : X10Tensor(repeating: high, shape: TensorShape(dims))
+          ? Tensor<Float>(high, on: x10)
+          : Tensor<Float>(repeating: high, shape: TensorShape(dims), on: x10)
         let expected = TF(x).clipped(min: TF(clipValueMin), max: TF(clipValueMax))
         if useReducedPrecision {
           x = x.toReducedPrecision
@@ -839,13 +823,13 @@ final class TensorTests: XCTestCase {
   }
 
   func testConcat() throws {
-    var xs = [[3, 1, 2], [3, 8, 2], [3, 4, 2]].map { X10Tensor.rand($0) }
-    let expected = TFTensor(concatenating: xs.map(TF), alongAxis: 1)
+    var xs = [[3, 1, 2], [3, 8, 2], [3, 4, 2]].map { Tensor<Float>.rand($0) }
+    let expected = Tensor<Float>(concatenating: xs.map(TF), alongAxis: 1)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         xs = xs.toReducedPrecision
       }
-      var actual = X10Tensor(concatenating: xs, alongAxis: 1)
+      var actual = Tensor(concatenating: xs, alongAxis: 1)
       if useReducedPrecision {
         XCTAssert(actual.isReducedPrecision)
         actual = actual.toFullPrecision
@@ -866,8 +850,8 @@ final class TensorTests: XCTestCase {
       for stride in 1..<4 {
         for dilation in 1..<3 {
           for padSame in [false, true] {
-            var input = X10Tensor.rand([batch, inputSize, inputSize, inChannels])
-            var filter = X10Tensor.rand([kernelSize, kernelSize, inChannels, outChannels])
+            var input = Tensor<Float>.rand([batch, inputSize, inputSize, inChannels])
+            var filter = Tensor<Float>.rand([kernelSize, kernelSize, inChannels, outChannels])
             let expected = conv2D(
               TF(input), filter: TF(filter), strides: (1, stride, stride, 1),
               padding: padSame ? Padding.same : Padding.valid, dilations: (1, dilation, dilation, 1)
@@ -909,14 +893,14 @@ final class TensorTests: XCTestCase {
     for useReducedPrecision in [false, true] {
       for stride in 1..<4 {
         for padSame in [false, true] {
-          var input = X10Tensor.rand([batch, inputSize, inputSize, inChannels])
-          var filter = X10Tensor.rand([kernelSize, kernelSize, inChannels, outChannels])
+          var input = Tensor<Float>.rand([batch, inputSize, inputSize, inChannels])
+          var filter = Tensor<Float>.rand([kernelSize, kernelSize, inChannels, outChannels])
           let outShape = conv2D(
             TF(input), filter: TF(filter), strides: (1, stride, stride, 1),
             padding: padSame ? Padding.same : Padding.valid, dilations: (1, dilation, dilation, 1)
           )
           .shape
-          var outGrad = X10Tensor.rand(outShape.dimensions)
+          var outGrad = Tensor<Float>.rand(outShape.dimensions)
           if useReducedPrecision {
             input = input.toReducedPrecision
             filter = filter.toReducedPrecision
@@ -925,14 +909,14 @@ final class TensorTests: XCTestCase {
           let relTolerance: Float = useReducedPrecision ? 1e-2 : 1e-5
           assertEqualBinaryOperationGradients(
             {
-              (_ input: X10Tensor, _ filter: X10Tensor) -> X10Tensor in
+              (_ input: Tensor<Float>, _ filter: Tensor<Float>) -> Tensor<Float> in
               conv2D(
                 input, filter: filter, strides: (1, stride, stride, 1),
                 padding: padSame ? Padding.same : Padding.valid,
                 dilations: (1, dilation, dilation, 1)
               )
             },
-            { (_ input: TFTensor, _ filter: TFTensor) -> TFTensor in
+            { (_ input: Tensor<Float>, _ filter: Tensor<Float>) -> Tensor<Float> in
               conv2D(
                 input, filter: filter, strides: (1, stride, stride, 1),
                 padding: padSame ? Padding.same : Padding.valid,
@@ -953,14 +937,16 @@ final class TensorTests: XCTestCase {
     for useReducedPrecision in [false, true] {
       for stride in 1..<4 {
         for padSame in [false, true] {
-          var input = X10Tensor.rand([batch, inputSize, inputSize, inputSize, inChannels])
-          var filter = X10Tensor.rand([kernelSize, kernelSize, kernelSize, inChannels, outChannels])
+          var input = Tensor<Float>.rand([batch, inputSize, inputSize, inputSize, inChannels])
+          var filter = Tensor<Float>.rand([
+            kernelSize, kernelSize, kernelSize, inChannels, outChannels,
+          ])
           let outShape = conv3D(
             TF(input), filter: TF(filter), strides: (1, stride, stride, stride, 1),
             padding: padSame ? Padding.same : Padding.valid
           )
           .shape
-          var outGrad = X10Tensor.rand(outShape.dimensions)
+          var outGrad = Tensor<Float>.rand(outShape.dimensions)
           if useReducedPrecision {
             input = input.toReducedPrecision
             filter = filter.toReducedPrecision
@@ -969,13 +955,13 @@ final class TensorTests: XCTestCase {
           let relTolerance: Float = useReducedPrecision ? 1e-2 : 1e-5
           assertEqualBinaryOperationGradients(
             {
-              (_ input: X10Tensor, _ filter: X10Tensor) -> X10Tensor in
+              (_ input: Tensor<Float>, _ filter: Tensor<Float>) -> Tensor<Float> in
               conv3D(
                 input, filter: filter, strides: (1, stride, stride, stride, 1),
                 padding: padSame ? Padding.same : Padding.valid
               )
             },
-            { (_ input: TFTensor, _ filter: TFTensor) -> TFTensor in
+            { (_ input: Tensor<Float>, _ filter: Tensor<Float>) -> Tensor<Float> in
               conv3D(
                 input, filter: filter, strides: (1, stride, stride, stride, 1),
                 padding: padSame ? Padding.same : Padding.valid
@@ -987,7 +973,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testCos() throws {
-    var x = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
     let expected = cos(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -1007,7 +993,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testCosh() throws {
-    var x = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
     let expected = cosh(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -1029,7 +1015,7 @@ final class TensorTests: XCTestCase {
   func testCumprod() throws {
     for useReducedPrecision in [false, true] {
       for (exclusive, reverse) in [(false, false), (true, false), (false, true), (true, true)] {
-        var x = X10Tensor.rand([2, 4, 2])
+        var x = Tensor<Float>.rand([2, 4, 2])
         if useReducedPrecision {
           x = x.toReducedPrecision
         }
@@ -1051,7 +1037,7 @@ final class TensorTests: XCTestCase {
   func testCumsum() throws {
     for useReducedPrecision in [false, true] {
       for (exclusive, reverse) in [(false, false), (true, false), (false, true), (true, true)] {
-        var x = X10Tensor.rand([2, 4, 2])
+        var x = Tensor<Float>.rand([2, 4, 2])
         if useReducedPrecision {
           x = x.toReducedPrecision
         }
@@ -1079,14 +1065,14 @@ final class TensorTests: XCTestCase {
     for useReducedPrecision in [false, true] {
       for stride in 1..<4 {
         for padSame in [false, true] {
-          var input = X10Tensor.rand([batch, inputSize, inputSize, inChannels])
-          var filter = X10Tensor.rand([kernelSize, kernelSize, inChannels, channelMultiplier])
+          var input = Tensor<Float>.rand([batch, inputSize, inputSize, inChannels])
+          var filter = Tensor<Float>.rand([kernelSize, kernelSize, inChannels, channelMultiplier])
           let outShape = depthwiseConv2D(
             TF(input), filter: TF(filter), strides: (1, stride, stride, 1),
             padding: padSame ? Padding.same : Padding.valid
           )
           .shape
-          var outGrad = X10Tensor.rand(outShape.dimensions)
+          var outGrad = Tensor<Float>.rand(outShape.dimensions)
           if useReducedPrecision {
             input = input.toReducedPrecision
             filter = filter.toReducedPrecision
@@ -1095,13 +1081,13 @@ final class TensorTests: XCTestCase {
           let relTolerance: Float = useReducedPrecision ? 1e-2 : 1e-5
           assertEqualBinaryOperationGradients(
             {
-              (_ input: X10Tensor, _ filter: X10Tensor) -> X10Tensor in
+              (_ input: Tensor<Float>, _ filter: Tensor<Float>) -> Tensor<Float> in
               depthwiseConv2D(
                 input, filter: filter, strides: (1, stride, stride, 1),
                 padding: padSame ? Padding.same : Padding.valid
               )
             },
-            { (_ input: TFTensor, _ filter: TFTensor) -> TFTensor in
+            { (_ input: Tensor<Float>, _ filter: Tensor<Float>) -> Tensor<Float> in
               depthwiseConv2D(
                 input, filter: filter, strides: (1, stride, stride, 1),
                 padding: padSame ? Padding.same : Padding.valid
@@ -1114,8 +1100,8 @@ final class TensorTests: XCTestCase {
 
   func testDiv() throws {
     for useReducedPrecision in [false, true] {
-      var x = X10Tensor(shape: [2], scalars: [1, 2])
-      var y = X10Tensor(shape: [2], scalars: [7, 19])
+      var x = Tensor<Float>(shape: [2], scalars: [1, 2], on: x10)
+      var y = Tensor<Float>(shape: [2], scalars: [7, 19], on: x10)
       let expected = TF(x) / TF(y)
       if useReducedPrecision {
         x = x.toReducedPrecision
@@ -1136,13 +1122,13 @@ final class TensorTests: XCTestCase {
     // TODO(b/146675105): Implement `_Raw.matrixDiagPart`, used by `Tensor.diagonalPart`.
     #if false
       do {
-        let x = X10Tensor.rand([5, 5])
+        let x = Tensor<Float>.rand([5, 5])
         let actual = TF(x.diagonalPart())
         let expected = TF(x).diagonalPart()
         XCTAssertEqual(actual, expected)
       }
       do {
-        let x = X10Tensor.rand([5, 3, 5, 3])
+        let x = Tensor<Float>.rand([5, 3, 5, 3])
         let actual = TF(x.diagonalPart())
         let expected = TF(x).diagonalPart()
         XCTAssertEqual(actual, expected)
@@ -1151,8 +1137,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testElu() throws {
-    var x = X10Tensor(shape: [6], scalars: [-1.0, -0.5, 0.5, 3.0, 4.0, 7.0])
-    var outGrad = X10Tensor.rand(x.shape.dimensions)
+    var x = Tensor<Float>(shape: [6], scalars: [-1.0, -0.5, 0.5, 3.0, 4.0, 7.0], on: x10)
+    var outGrad = Tensor<Float>.rand(x.shape.dimensions)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         x = x.toReducedPrecision
@@ -1165,8 +1151,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testEqual() throws {
-    var x = X10Tensor(shape: [4], scalars: [1, 22, 3, 5])
-    var y = X10Tensor(shape: [4], scalars: [7, 19, 3, 5])
+    var x = Tensor<Float>(shape: [4], scalars: [1, 22, 3, 5], on: x10)
+    var y = Tensor<Float>(shape: [4], scalars: [7, 19, 3, 5], on: x10)
     let expected = TF(x) .== TF(y)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -1179,7 +1165,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testExp() throws {
-    var x = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
     let expected = exp(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -1199,7 +1185,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testExpm1() throws {
-    var x = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
     let expected = expm1(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -1219,13 +1205,13 @@ final class TensorTests: XCTestCase {
   }
 
   func testFill() throws {
-    let actual = TF(X10Tensor(repeating: 1.0, shape: [3, 4]))
-    let expected = TFTensor(repeating: 1.0, shape: [3, 4])
+    let actual = TF(Tensor<Float>(repeating: 1.0, shape: [3, 4], on: x10))
+    let expected = Tensor<Float>(repeating: 1.0, shape: [3, 4], on: tf)
     XCTAssertEqual(actual, expected)
   }
 
   func testFloor() throws {
-    var x = X10Tensor.rand([3, 2]) * 10
+    var x = Tensor<Float>.rand([3, 2]) * 10
     let expected = floor(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -1244,8 +1230,8 @@ final class TensorTests: XCTestCase {
 
   func testGather() throws {
     let size = 4
-    var params = X10Tensor.rand([size, size])
-    let indices: X10Tensor_<Int32> = X10Tensor.randint(0, size, [5, 2, 3])
+    var params = Tensor<Float>.rand([size, size])
+    let indices: Tensor<Int32> = Tensor<Float>.randint(0, size, [5, 2, 3])
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         params = params.toReducedPrecision
@@ -1263,14 +1249,14 @@ final class TensorTests: XCTestCase {
 
   func testGatherV2() throws {
     let size = 4
-    let indices: X10Tensor_<Int32> = X10Tensor.randint(0, size, [5, 2, 3])
+    let indices: Tensor<Int32> = Tensor<Float>.randint(0, size, [5, 2, 3])
     for useReducedPrecision in [false, true] {
-      var params = X10Tensor.rand([size, size])
+      var params = Tensor<Float>.rand([size, size])
       if useReducedPrecision {
         params = params.toReducedPrecision
       }
       for axis in -params.rank..<params.rank {
-        let axisDim = X10Tensor_<Int32>(shape: [], scalars: [Int32(axis)])
+        let axisDim = Tensor<Int32>(shape: [], scalars: [Int32(axis)], on: x10)
         var actual = _Raw.gatherV2(params: params, indices: indices, axis: axisDim)
         if useReducedPrecision {
           XCTAssert(actual.isReducedPrecision)
@@ -1291,8 +1277,8 @@ final class TensorTests: XCTestCase {
         if broadcastDim < originalDims.count {
           dims[broadcastDim] = 1
         }
-        var x = X10Tensor.rand(originalDims)
-        var y = X10Tensor.rand(dims)
+        var x = Tensor<Float>.rand(originalDims)
+        var y = Tensor<Float>.rand(dims)
         if useReducedPrecision {
           x = x.toReducedPrecision
           y = y.toReducedPrecision
@@ -1315,8 +1301,8 @@ final class TensorTests: XCTestCase {
         if broadcastDim < originalDims.count {
           dims[broadcastDim] = 1
         }
-        var x = X10Tensor.rand(originalDims)
-        var y = X10Tensor.rand(dims)
+        var x = Tensor<Float>.rand(originalDims)
+        var y = Tensor<Float>.rand(dims)
         if useReducedPrecision {
           x = x.toReducedPrecision
           y = y.toReducedPrecision
@@ -1327,8 +1313,8 @@ final class TensorTests: XCTestCase {
         let actualYX = TF(y .>= x)
         let expectedYX = TF(y) .>= TF(x)
         XCTAssertEqual(actualYX, expectedYX)
-        let onesLhs = X10Tensor(onesLike: x)
-        let onesRhs = X10Tensor(onesLike: y)
+        let onesLhs = Tensor(onesLike: x)
+        let onesRhs = Tensor(onesLike: y)
         let actualOnes = TF(onesLhs .>= onesRhs)
         let expectedOnes = TF(onesLhs) .>= TF(onesRhs)
         XCTAssertEqual(actualOnes, expectedOnes)
@@ -1337,7 +1323,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testIndexAdvanced() throws {
-    var tensor3D = X10Tensor(shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)))
+    var tensor3D = Tensor<Float>(
+      shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)), on: x10)
     let slice2DExpected = TF(tensor3D)[1..<3, 0, 3...]
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -1354,10 +1341,11 @@ final class TensorTests: XCTestCase {
   }
 
   func testIndexAdvancedGrad() throws {
-    var tensor3D = X10Tensor(shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)))
+    var tensor3D = Tensor<Float>(
+      shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)), on: x10)
     for useReducedPrecision in [false, true] {
       let slice2DShape = tensor3D[1..<3, 0, 3...].shape
-      var outGrad = X10Tensor.rand(slice2DShape.dimensions)
+      var outGrad = Tensor<Float>.rand(slice2DShape.dimensions)
       if useReducedPrecision {
         tensor3D = tensor3D.toReducedPrecision
         outGrad = outGrad.toReducedPrecision
@@ -1369,7 +1357,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testIndexElement() throws {
-    var tensor3D = X10Tensor(shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)))
+    var tensor3D = Tensor<Float>(
+      shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)), on: x10)
     let element2DExpected = TF(tensor3D)[2]
     let element1DExpected = TF(tensor3D)[1][3]
     let element0DExpected = TF(tensor3D)[2][0][3]
@@ -1399,11 +1388,13 @@ final class TensorTests: XCTestCase {
 
   func testIndexElementAssignment() throws {
     for useReducedPrecision in [false, true] {
-      var tensor3D = X10Tensor(shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)))
+      var tensor3D = Tensor<Float>(
+        shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)), on: x10)
       var tfTensor3D = TF(tensor3D)
-      tensor3D[2] = X10Tensor(
-        shape: [4, 5], scalars: Array(stride(from: 20.0, to: 40, by: 1)))
-      tfTensor3D[2] = TFTensor(shape: [4, 5], scalars: Array(stride(from: 20.0, to: 40, by: 1)))
+      tensor3D[2] = Tensor<Float>(
+        shape: [4, 5], scalars: Array(stride(from: 20.0, to: 40, by: 1)), on: x10)
+      tfTensor3D[2] = Tensor<Float>(
+        shape: [4, 5], scalars: Array(stride(from: 20.0, to: 40, by: 1)), on: tf)
       let element2DExpected = tfTensor3D[2]
       let element1DExpected = tfTensor3D[1][3]
       let element0DExpected = tfTensor3D[2][0][3]
@@ -1431,13 +1422,14 @@ final class TensorTests: XCTestCase {
   }
 
   func testIndexElementGrad() throws {
-    var tensor3D = X10Tensor(shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)))
+    var tensor3D = Tensor<Float>(
+      shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)), on: x10)
     let element2DShape = tensor3D[2].shape
     let element1DShape = tensor3D[1][3].shape
     let element0DShape = tensor3D[2][0][3].shape
-    var outGrad2D = X10Tensor.rand(element2DShape.dimensions)
-    var outGrad1D = X10Tensor.rand(element1DShape.dimensions)
-    var outGrad0D = X10Tensor.rand(element0DShape.dimensions)
+    var outGrad2D = Tensor<Float>.rand(element2DShape.dimensions)
+    var outGrad1D = Tensor<Float>.rand(element1DShape.dimensions)
+    var outGrad0D = Tensor<Float>.rand(element0DShape.dimensions)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         tensor3D = tensor3D.toReducedPrecision
@@ -1455,7 +1447,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testIndexEllipsis() throws {
-    var tensor3D = X10Tensor(shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)))
+    var tensor3D = Tensor<Float>(
+      shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)), on: x10)
     let slice3DExpected = TF(tensor3D)[2..., TF(TensorRange.ellipsis)]
     let slice2DExpected = TF(tensor3D)[1][0..<2]
     let slice1DExpected = TF(tensor3D)[0][0][3..<5]
@@ -1484,13 +1477,14 @@ final class TensorTests: XCTestCase {
   }
 
   func testIndexEllipsisGrad() throws {
-    var tensor3D = X10Tensor(shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)))
+    var tensor3D = Tensor<Float>(
+      shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)), on: x10)
     let slice3DShape = tensor3D[2..., TensorRange.ellipsis].shape
     let slice2DShape = tensor3D[1][0..<2].shape
     let slice1DShape = tensor3D[0][0][3..<5].shape
-    var outGrad3D = X10Tensor.rand(slice3DShape.dimensions)
-    var outGrad2D = X10Tensor.rand(slice2DShape.dimensions)
-    var outGrad1D = X10Tensor.rand(slice1DShape.dimensions)
+    var outGrad3D = Tensor<Float>.rand(slice3DShape.dimensions)
+    var outGrad2D = Tensor<Float>.rand(slice2DShape.dimensions)
+    var outGrad1D = Tensor<Float>.rand(slice1DShape.dimensions)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         tensor3D = tensor3D.toReducedPrecision
@@ -1510,7 +1504,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testIndexNestedElement() throws {
-    var tensor3D = X10Tensor(shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)))
+    var tensor3D = Tensor<Float>(
+      shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)), on: x10)
     let element1DExpected = TF(tensor3D)[1, 3]
     let element0DExpected = TF(tensor3D)[2, 0, 3]
     for useReducedPrecision in [false, true] {
@@ -1533,11 +1528,12 @@ final class TensorTests: XCTestCase {
   }
 
   func testIndexNestedElementGrad() throws {
-    var tensor3D = X10Tensor(shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)))
+    var tensor3D = Tensor<Float>(
+      shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)), on: x10)
     let element1DShape = tensor3D[1, 3].shape
     let element0DShape = tensor3D[2, 0, 3].shape
-    var outGrad1D = X10Tensor.rand(element1DShape.dimensions)
-    var outGrad0D = X10Tensor.rand(element0DShape.dimensions)
+    var outGrad1D = Tensor<Float>.rand(element1DShape.dimensions)
+    var outGrad0D = Tensor<Float>.rand(element0DShape.dimensions)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         tensor3D = tensor3D.toReducedPrecision
@@ -1552,7 +1548,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testIndexNewAxis() throws {
-    var tensor3D = X10Tensor(shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)))
+    var tensor3D = Tensor<Float>(
+      shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)), on: x10)
     let newAxis = TensorRange.newAxis
     let ellipsis = TensorRange.ellipsis
     let slice3DExpected = TF(tensor3D)[2..., TF(newAxis), TF(ellipsis)]
@@ -1583,15 +1580,16 @@ final class TensorTests: XCTestCase {
   }
 
   func testIndexNewAxisGrad() throws {
-    var tensor3D = X10Tensor(shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)))
+    var tensor3D = Tensor<Float>(
+      shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)), on: x10)
     let newAxis = TensorRange.newAxis
     let ellipsis = TensorRange.ellipsis
     let slice3DShape = tensor3D[2..., newAxis, ellipsis].shape
     let slice2DShape = tensor3D[1, newAxis][0..<1, 0..<2].shape
     let slice1DShape = TF(tensor3D[0][newAxis, 0][0..<1, 3..<5, newAxis]).shape
-    var outGrad3D = X10Tensor.rand(slice3DShape.dimensions)
-    var outGrad2D = X10Tensor.rand(slice2DShape.dimensions)
-    var outGrad1D = X10Tensor.rand(slice1DShape.dimensions)
+    var outGrad3D = Tensor<Float>.rand(slice3DShape.dimensions)
+    var outGrad2D = Tensor<Float>.rand(slice2DShape.dimensions)
+    var outGrad1D = Tensor<Float>.rand(slice1DShape.dimensions)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         tensor3D = tensor3D.toReducedPrecision
@@ -1613,7 +1611,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testIndexSlice() throws {
-    var tensor3D = X10Tensor(shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)))
+    var tensor3D = Tensor<Float>(
+      shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)), on: x10)
     let slice3DExpected = TF(tensor3D)[2...]
     let slice2DExpected = TF(tensor3D)[1][0..<2]
     let slice1DExpected = TF(tensor3D)[0][0][3..<5]
@@ -1643,12 +1642,13 @@ final class TensorTests: XCTestCase {
 
   func testIndexSliceAssignment() throws {
     for useReducedPrecision in [false, true] {
-      var tensor3D = X10Tensor(shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)))
+      var tensor3D = Tensor<Float>(
+        shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)), on: x10)
       var tfTensor3D = TF(tensor3D)
-      tensor3D[2, 0..<5, 0..<6] = X10Tensor(
-        shape: [4, 5], scalars: Array(stride(from: 20.0, to: 40, by: 1)))
-      tfTensor3D[2, 0..<5, 0..<6] = TFTensor(
-        shape: [4, 5], scalars: Array(stride(from: 20.0, to: 40, by: 1)))
+      tensor3D[2, 0..<5, 0..<6] = Tensor<Float>(
+        shape: [4, 5], scalars: Array(stride(from: 20.0, to: 40, by: 1)), on: x10)
+      tfTensor3D[2, 0..<5, 0..<6] = Tensor<Float>(
+        shape: [4, 5], scalars: Array(stride(from: 20.0, to: 40, by: 1)), on: tf)
       let slice3DExpected = tfTensor3D[2...]
       let slice2DExpected = tfTensor3D[1][0..<2]
       let slice1DExpected = tfTensor3D[0][0][3..<5]
@@ -1676,13 +1676,14 @@ final class TensorTests: XCTestCase {
   }
 
   func testIndexSliceGrad() throws {
-    var tensor3D = X10Tensor(shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)))
+    var tensor3D = Tensor<Float>(
+      shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)), on: x10)
     let slice3DShape = tensor3D[2...].shape
     let slice2DShape = tensor3D[1][0..<2].shape
     let slice1DShape = tensor3D[0][0][3..<5].shape
-    var outGrad3D = X10Tensor.rand(slice3DShape.dimensions)
-    var outGrad2D = X10Tensor.rand(slice2DShape.dimensions)
-    var outGrad1D = X10Tensor.rand(slice1DShape.dimensions)
+    var outGrad3D = Tensor<Float>.rand(slice3DShape.dimensions)
+    var outGrad2D = Tensor<Float>.rand(slice2DShape.dimensions)
+    var outGrad1D = Tensor<Float>.rand(slice1DShape.dimensions)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         tensor3D = tensor3D.toReducedPrecision
@@ -1703,7 +1704,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testIndexSqueezeAxis() throws {
-    var tensor3D = X10Tensor(shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)))
+    var tensor3D = Tensor<Float>(
+      shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)), on: x10)
     let newAxis = TensorRange.newAxis
     let ellipsis = TensorRange.ellipsis
     let squeezeAxis = TensorRange.squeezeAxis
@@ -1737,16 +1739,17 @@ final class TensorTests: XCTestCase {
   }
 
   func testIndexSqueezeAxisGrad() throws {
-    var tensor3D = X10Tensor(shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)))
+    var tensor3D = Tensor<Float>(
+      shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)), on: x10)
     let newAxis = TensorRange.newAxis
     let ellipsis = TensorRange.ellipsis
     let squeezeAxis = TensorRange.squeezeAxis
     let slice3DShape = tensor3D[2..., newAxis, ellipsis][squeezeAxis, squeezeAxis].shape
     let slice2DShape = tensor3D[1, newAxis][squeezeAxis, 0..<2].shape
     let slice1DShape = tensor3D[0..<1, 0, 3..<5, newAxis][squeezeAxis, ellipsis, squeezeAxis].shape
-    var outGrad3D = X10Tensor.rand(slice3DShape.dimensions)
-    var outGrad2D = X10Tensor.rand(slice2DShape.dimensions)
-    var outGrad1D = X10Tensor.rand(slice1DShape.dimensions)
+    var outGrad3D = Tensor<Float>.rand(slice3DShape.dimensions)
+    var outGrad2D = Tensor<Float>.rand(slice2DShape.dimensions)
+    var outGrad1D = Tensor<Float>.rand(slice1DShape.dimensions)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         tensor3D = tensor3D.toReducedPrecision
@@ -1770,7 +1773,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testIndexStridedSlice() throws {
-    var tensor3D = X10Tensor(shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)))
+    var tensor3D = Tensor<Float>(
+      shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)), on: x10)
     let slice3DExpected = TF(tensor3D)[2...]
     let r1 = TensorRange.range(0..<3, stride: 2)
     let slice2DExpected = TF(tensor3D)[1][TF(r1)]
@@ -1801,15 +1805,16 @@ final class TensorTests: XCTestCase {
   }
 
   func testIndexStridedSliceGrad() throws {
-    var tensor3D = X10Tensor(shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)))
+    var tensor3D = Tensor<Float>(
+      shape: [3, 4, 5], scalars: Array(stride(from: 0.0, to: 60, by: 1)), on: x10)
     let slice3DShape = tensor3D[2...].shape
     let r1 = TensorRange.range(0..<3, stride: 2)
     let slice2DShape = tensor3D[1][r1].shape
     let r2 = TensorRange.range(1..<5, stride: 2)
     let slice1DShape = TF(tensor3D[0][0][r2]).shape
-    var outGrad3D = X10Tensor.rand(slice3DShape.dimensions)
-    var outGrad2D = X10Tensor.rand(slice2DShape.dimensions)
-    var outGrad1D = X10Tensor.rand(slice1DShape.dimensions)
+    var outGrad3D = Tensor<Float>.rand(slice3DShape.dimensions)
+    var outGrad2D = Tensor<Float>.rand(slice2DShape.dimensions)
+    var outGrad1D = Tensor<Float>.rand(slice1DShape.dimensions)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         tensor3D = tensor3D.toReducedPrecision
@@ -1828,14 +1833,14 @@ final class TensorTests: XCTestCase {
 
   func testInvertPermutation() throws {
     let scalars: [Int32] = [3, 4, 0, 2, 1]
-    let input = X10Tensor_<Int32>(shape: [scalars.count], scalars: scalars)
+    let input = Tensor<Int32>(shape: [scalars.count], scalars: scalars, on: x10)
     let actual = TF(_Raw.invertPermutation(input))
     let expected = _Raw.invertPermutation(TF(input))
     XCTAssertEqual(actual, expected)
   }
 
   func testIsFinite() throws {
-    var x = X10Tensor(shape: [4], scalars: [Float.nan, Float.infinity, 0.5, 3.0])
+    var x = Tensor<Float>(shape: [4], scalars: [Float.nan, Float.infinity, 0.5, 3.0], on: x10)
     let expected = TF(x).isFinite
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -1847,7 +1852,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testIsInfinite() throws {
-    var x = X10Tensor(shape: [4], scalars: [Float.nan, Float.infinity, 0.5, 3.0])
+    var x = Tensor<Float>(shape: [4], scalars: [Float.nan, Float.infinity, 0.5, 3.0], on: x10)
     let expected = TF(x).isInfinite
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -1859,7 +1864,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testIsNaN() throws {
-    var x = X10Tensor(shape: [4], scalars: [Float.nan, Float.infinity, 0.5, 3.0])
+    var x = Tensor<Float>(shape: [4], scalars: [Float.nan, Float.infinity, 0.5, 3.0], on: x10)
     let expected = TF(x).isNaN
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -1871,7 +1876,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testLeakyRelu() throws {
-    var x = X10Tensor(shape: [4], scalars: [-0.5, -0.25, 0.5, 3.0])
+    var x = Tensor<Float>(shape: [4], scalars: [-0.5, -0.25, 0.5, 3.0], on: x10)
     let expected = leakyRelu(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -1891,14 +1896,14 @@ final class TensorTests: XCTestCase {
   }
 
   func testLeakyReluGrad() throws {
-    func leakyReluX10(_ arg: X10Tensor) -> X10Tensor {
+    func leakyReluX10(_ arg: Tensor<Float>) -> Tensor<Float> {
       return leakyRelu(arg)
     }
-    func leakyReluTF(_ arg: TFTensor) -> TFTensor {
+    func leakyReluTF(_ arg: Tensor<Float>) -> Tensor<Float> {
       return leakyRelu(arg)
     }
-    var x = X10Tensor(shape: [4], scalars: [-0.5, -0.25, 0.5, 3.0])
-    var outGrad = X10Tensor(shape: [4], scalars: [1.5, 1.0, 2.5, 2.0])
+    var x = Tensor<Float>(shape: [4], scalars: [-0.5, -0.25, 0.5, 3.0], on: x10)
+    var outGrad = Tensor<Float>(shape: [4], scalars: [1.5, 1.0, 2.5, 2.0], on: x10)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         x = x.toReducedPrecision
@@ -1918,8 +1923,8 @@ final class TensorTests: XCTestCase {
         if broadcastDim < originalDims.count {
           dims[broadcastDim] = 1
         }
-        var x = X10Tensor.rand(originalDims)
-        var y = X10Tensor.rand(dims)
+        var x = Tensor<Float>.rand(originalDims)
+        var y = Tensor<Float>.rand(dims)
         if useReducedPrecision {
           x = x.toReducedPrecision
           y = y.toReducedPrecision
@@ -1942,8 +1947,8 @@ final class TensorTests: XCTestCase {
         if broadcastDim < originalDims.count {
           dims[broadcastDim] = 1
         }
-        var x = X10Tensor.rand(originalDims)
-        var y = X10Tensor.rand(dims)
+        var x = Tensor<Float>.rand(originalDims)
+        var y = Tensor<Float>.rand(dims)
         if useReducedPrecision {
           x = x.toReducedPrecision
           y = y.toReducedPrecision
@@ -1954,8 +1959,8 @@ final class TensorTests: XCTestCase {
         let actualYX = TF(y .<= x)
         let expectedYX = TF(y) .<= TF(x)
         XCTAssertEqual(actualYX, expectedYX)
-        let onesLhs = X10Tensor(onesLike: x)
-        let onesRhs = X10Tensor(onesLike: y)
+        let onesLhs = Tensor<Float>(onesLike: x)
+        let onesRhs = Tensor<Float>(onesLike: y)
         let actualOnes = TF(onesLhs .<= onesRhs)
         let expectedOnes = TF(onesLhs) .<= TF(onesRhs)
         XCTAssertEqual(actualOnes, expectedOnes)
@@ -1965,23 +1970,23 @@ final class TensorTests: XCTestCase {
 
   func testLinSpace() throws {
     func testRanges(start: Float, stop: Float, num: Int32, useReducedPrecision: Bool) {
-      var startTensor = X10Tensor(start)
-      var stopTensor = X10Tensor(stop)
+      var start = Tensor(start, on: x10)
+      var stop = Tensor(stop, on: x10)
       if useReducedPrecision {
-        startTensor = startTensor.toReducedPrecision
-        stopTensor = stopTensor.toReducedPrecision
+        start = start.toReducedPrecision
+        stop = stop.toReducedPrecision
       }
-      var x10 = _Raw.linSpace(
-        start: startTensor, stop: stopTensor, num: X10Tensor_<Int32>(num),
+      var tx10 = _Raw.linSpace(
+        start: start, stop: stop, num: Tensor<Int32>(num, on: x10),
         device: .default)
       if useReducedPrecision {
-        XCTAssert(x10.isReducedPrecision)
-        x10 = x10.toFullPrecision
+        XCTAssert(tx10.isReducedPrecision)
+        tx10 = tx10.toFullPrecision
       }
-      XCTAssert(!x10.isReducedPrecision)
+      XCTAssert(!tx10.isReducedPrecision)
       let tf = _Raw.linSpace(
-        start: TFTensor(start), stop: TFTensor(stop), num: TFTensor_<Int32>(num))
-      XCTAssert(allClose(actual: TF(x10), expected: tf, absTolerance: 1e-5))
+        start: TF(start), stop: TF(stop), num: TF(Tensor<Int32>(num, on: x10)))
+      XCTAssert(allClose(actual: TF(tx10), expected: tf, absTolerance: 1e-5))
     }
     for useReducedPrecision in [false, true] {
       testRanges(start: 0.0, stop: 5.0, num: 6, useReducedPrecision: useReducedPrecision)
@@ -1993,7 +1998,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testLog() throws {
-    var x = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
     let expected = log(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -2013,7 +2018,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testLog1p() throws {
-    var x = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
     let expected = log1p(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -2033,31 +2038,32 @@ final class TensorTests: XCTestCase {
   }
 
   func testLogicalAnd() throws {
-    let x: X10Tensor_<Bool> = X10Tensor.randint(0, 2, [2, 3, 4])
-    let y: X10Tensor_<Bool> = X10Tensor.randint(0, 2, [2, 3, 4])
+    let x: Tensor<Bool> = Tensor<Float>.randint(0, 2, [2, 3, 4])
+    let y: Tensor<Bool> = Tensor<Float>.randint(0, 2, [2, 3, 4])
     let actual = TF(x.elementsLogicalOr(y))
     let expected = TF(x).elementsLogicalOr(TF(y))
     XCTAssertEqual(actual, expected)
   }
 
   func testLogicalNot() throws {
-    let x: X10Tensor_<Bool> = X10Tensor.randint(0, 2, [2, 3, 4])
+    let x: Tensor<Bool> = Tensor<Float>.randint(0, 2, [2, 3, 4])
     let actual = TF(x.elementsLogicalNot())
     let expected = TF(x).elementsLogicalNot()
     XCTAssertEqual(actual, expected)
   }
 
   func testLogicalOr() throws {
-    let x: X10Tensor_<Bool> = X10Tensor.randint(0, 2, [2, 3, 4])
-    let y: X10Tensor_<Bool> = X10Tensor.randint(0, 2, [2, 3, 4])
+    let x: Tensor<Bool> = Tensor<Float>.randint(0, 2, [2, 3, 4])
+    let y: Tensor<Bool> = Tensor<Float>.randint(0, 2, [2, 3, 4])
     let actual = TF(x.elementsLogicalAnd(y))
     let expected = TF(x).elementsLogicalAnd(TF(y))
     XCTAssertEqual(actual, expected)
   }
 
   func testLogSoftmax() throws {
-    var x = X10Tensor(
-      shape: [2, 5], scalars: [0.98, 0.65, 0.832, 0.324, 0.3676, 0.777, 0.244, 0.950, 0.544, 0.445])
+    var x = Tensor<Float>(
+      shape: [2, 5], scalars: [0.98, 0.65, 0.832, 0.324, 0.3676, 0.777, 0.244, 0.950, 0.544, 0.445],
+      on: x10)
     let expected = logSoftmax(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -2084,8 +2090,8 @@ final class TensorTests: XCTestCase {
         ([2, 2, 3, 8], [2, 9, 3], true, true),
         ([2, 2, 2, 2], [2, 2], true, true),
       ] {
-        var x = X10Tensor.rand(xShape)
-        var y = X10Tensor.rand(yShape)
+        var x = Tensor<Float>.rand(xShape)
+        var y = Tensor<Float>.rand(yShape)
         let expected = matmul(TF(x), transposed: transposeX, TF(y), transposed: transposeY)
         if useReducedPrecision {
           x = x.toReducedPrecision
@@ -2108,7 +2114,7 @@ final class TensorTests: XCTestCase {
   func testMax() throws {
     for useReducedPrecision in [false, true] {
       for (shape, dims) in [([2, 3, 4], [1, 2]), ([3, 3, 2], [-2])] {
-        let xFull = X10Tensor.rand(shape)
+        let xFull = Tensor<Float>.rand(shape)
         do {
           var x = xFull
           if useReducedPrecision {
@@ -2148,8 +2154,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testMaximum() throws {
-    var x = X10Tensor.rand([4, 5])
-    var y = X10Tensor.rand([4, 5])
+    var x = Tensor<Float>.rand([4, 5])
+    var y = Tensor<Float>.rand([4, 5])
     let expected = max(TF(x), TF(y))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -2173,7 +2179,7 @@ final class TensorTests: XCTestCase {
     for useReducedPrecision in [false, true] {
       for stride in 1..<3 {
         for padSame in [false, true] {
-          var x = X10Tensor.rand([4, 28, 28, 1])
+          var x = Tensor<Float>.rand([4, 28, 28, 1])
           let expected = maxPool2D(
             TF(x), filterSize: (1, 2, 2, 1), strides: (1, stride, stride, 1),
             padding: padSame ? Padding.same : Padding.valid)
@@ -2202,24 +2208,24 @@ final class TensorTests: XCTestCase {
     for useReducedPrecision in [false, true] {
       for stride in 1..<3 {
         for padSame in [false, true] {
-          var x = X10Tensor.rand([4, 28, 28, 1])
+          var x = Tensor<Float>.rand([4, 28, 28, 1])
           let outShape = maxPool2D(
             TF(x), filterSize: (1, 2, 2, 1), strides: (1, stride, stride, 1),
             padding: padSame ? Padding.same : Padding.valid
           ).shape
-          var outGrad = X10Tensor.rand(outShape.dimensions)
+          var outGrad = Tensor<Float>.rand(outShape.dimensions)
           if useReducedPrecision {
             x = x.toReducedPrecision
             outGrad = outGrad.toReducedPrecision
           }
           let relTolerance: Float = useReducedPrecision ? 1e-2 : 1e-5
           assertEqualUnaryOperationGradients(
-            { (_ x: X10Tensor) -> X10Tensor in
+            { (_ x: Tensor<Float>) -> Tensor<Float> in
               maxPool2D(
                 x, filterSize: (1, 2, 2, 1), strides: (1, stride, stride, 1),
                 padding: padSame ? Padding.same : Padding.valid)
             },
-            { (_ x: TFTensor) -> TFTensor in
+            { (_ x: Tensor<Float>) -> Tensor<Float> in
               maxPool2D(
                 x, filterSize: (1, 2, 2, 1), strides: (1, stride, stride, 1),
                 padding: padSame ? Padding.same : Padding.valid)
@@ -2233,8 +2239,9 @@ final class TensorTests: XCTestCase {
     // TODO(asuhan): Figure out what's going on at higher sizes with bf16.
     let dims = [1, 6, 6, 6, 1]
     let elementCount = dims.reduce(1, *)
-    let input = X10Tensor(
-      shape: TensorShape(dims), scalars: Array(stride(from: 0.0, to: Float(elementCount), by: 1)))
+    let input = Tensor<Float>(
+      shape: TensorShape(dims), scalars: Array(stride(from: 0.0, to: Float(elementCount), by: 1)),
+      on: x10)
     for useReducedPrecision in [false, true] {
       for stride in 1..<3 {
         for padSame in [false, true] {
@@ -2243,18 +2250,19 @@ final class TensorTests: XCTestCase {
             TF(x), filterSize: (1, 2, 2, 2, 1), strides: (1, stride, stride, stride, 1),
             padding: padSame ? Padding.same : Padding.valid
           ).shape
-          var outGrad = X10Tensor(repeating: 1.0, shape: TensorShape(outShape.dimensions))
+          var outGrad = Tensor<Float>(
+            repeating: 1.0, shape: TensorShape(outShape.dimensions), on: x10)
           if useReducedPrecision {
             x = x.toReducedPrecision
             outGrad = outGrad.toReducedPrecision
           }
           assertEqualUnaryOperationGradients(
-            { (_ x: X10Tensor) -> X10Tensor in
+            { (_ x: Tensor<Float>) -> Tensor<Float> in
               maxPool3D(
                 x, filterSize: (1, 2, 2, 2, 1), strides: (1, stride, stride, stride, 1),
                 padding: padSame ? Padding.same : Padding.valid)
             },
-            { (_ x: TFTensor) -> TFTensor in
+            { (_ x: Tensor<Float>) -> Tensor<Float> in
               maxPool3D(
                 x, filterSize: (1, 2, 2, 2, 1), strides: (1, stride, stride, stride, 1),
                 padding: padSame ? Padding.same : Padding.valid)
@@ -2265,7 +2273,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testMean() throws {
-    var x = X10Tensor(shape: [3, 2], scalars: [1, 5, 43, 24, 64, 32])
+    var x = Tensor<Float>(shape: [3, 2], scalars: [1, 5, 43, 24, 64, 32], on: x10)
     let expected = TF(x).mean(squeezingAxes: [0])
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -2283,16 +2291,16 @@ final class TensorTests: XCTestCase {
   }
 
   func testMeanBool() throws {
-    let x: X10Tensor_<Bool> = X10Tensor_(shape: [4], scalars: [true, false, true, true])
-    let expected = TFTensor(TF(x)).mean()
-    let actual = TF(X10Tensor(x).mean())
+    let x = Tensor<Bool>(shape: [4], scalars: [true, false, true, true], on: x10)
+    let expected = Tensor<Float>(TF(x)).mean()
+    let actual = TF(Tensor<Float>(x).mean())
     XCTAssertEqual(actual, expected)
   }
 
   func testMin() throws {
     for useReducedPrecision in [false, true] {
       for (shape, dims) in [([2, 3, 4], [1, 2]), ([3, 3, 2], [-2])] {
-        let xFull = X10Tensor.rand(shape)
+        let xFull = Tensor<Float>.rand(shape)
         do {
           var x = xFull
           if useReducedPrecision {
@@ -2332,8 +2340,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testMinimum() throws {
-    var x = X10Tensor.rand([4, 5])
-    var y = X10Tensor.rand([4, 5])
+    var x = Tensor<Float>.rand([4, 5])
+    var y = Tensor<Float>.rand([4, 5])
     for useReducedPrecision in [false, true] {
       let expected = min(TF(x), TF(y))
       if useReducedPrecision {
@@ -2357,7 +2365,7 @@ final class TensorTests: XCTestCase {
     let paddings = [(1, 2), (3, 4), (5, 6)]
     for useReducedPrecision in [false, true] {
       for reflect in [true, false] {
-        var x = X10Tensor.rand([5, 7, 13])
+        var x = Tensor<Float>.rand([5, 7, 13])
         let expected = TF(x).padded(forSizes: paddings, mode: reflect ? .reflect : .symmetric)
         if useReducedPrecision {
           x = x.toReducedPrecision
@@ -2380,9 +2388,9 @@ final class TensorTests: XCTestCase {
     let paddings = [(1, 2), (3, 4), (5, 6)]
     for useReducedPrecision in [false, true] {
       for reflect in [true, false] {
-        var x = X10Tensor.rand([5, 7, 13])
+        var x = Tensor<Float>.rand([5, 7, 13])
         let outShape = TF(x).padded(forSizes: paddings, mode: reflect ? .reflect : .symmetric).shape
-        var outGrad = X10Tensor.rand(outShape.dimensions)
+        var outGrad = Tensor<Float>.rand(outShape.dimensions)
         if useReducedPrecision {
           x = x.toReducedPrecision
           outGrad = outGrad.toReducedPrecision
@@ -2390,11 +2398,11 @@ final class TensorTests: XCTestCase {
         let relTolerance: Float = useReducedPrecision ? 1e-2 : 1e-5
         assertEqualUnaryOperationGradients(
           {
-            (_ x: X10Tensor) -> X10Tensor in
+            (_ x: Tensor<Float>) -> Tensor<Float> in
             x.padded(forSizes: paddings, mode: reflect ? .reflect : .symmetric)
           },
           {
-            (_ x: TFTensor) -> TFTensor in
+            (_ x: Tensor<Float>) -> Tensor<Float> in
             x.padded(forSizes: paddings, mode: reflect ? .reflect : .symmetric)
           }, x, outGrad, relTolerance: relTolerance)
       }
@@ -2403,8 +2411,8 @@ final class TensorTests: XCTestCase {
 
   func testMod() throws {
     for useReducedPrecision in [false, true] {
-      var x = X10Tensor((-30..<30).map { (v: Int64) -> Float in Float.init(v) })
-      var y = X10Tensor(8)
+      var x = Tensor<Float>((-30..<30).map { (v: Int64) -> Float in Float.init(v) }, on: x10)
+      var y = Tensor<Float>(8, on: x10)
       if useReducedPrecision {
         x = x.toReducedPrecision
         y = y.toReducedPrecision
@@ -2421,8 +2429,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testMul() throws {
-    var x = X10Tensor(shape: [2], scalars: [1, 3])
-    var y = X10Tensor(shape: [2], scalars: [7, 19])
+    var x = Tensor<Float>(shape: [2], scalars: [1, 3], on: x10)
+    var y = Tensor<Float>(shape: [2], scalars: [7, 19], on: x10)
     for useReducedPrecision in [false, true] {
       let expected = TF(x) * TF(y)
       if useReducedPrecision {
@@ -2440,8 +2448,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testNotEqual() throws {
-    var x = X10Tensor(shape: [4], scalars: [1, 22, 3, 5])
-    var y = X10Tensor(shape: [4], scalars: [7, 19, 3, 5])
+    var x = Tensor<Float>(shape: [4], scalars: [1, 22, 3, 5], on: x10)
+    var y = Tensor<Float>(shape: [4], scalars: [7, 19, 3, 5], on: x10)
     for useReducedPrecision in [false, true] {
       let expected = TF(x) .!= TF(y)
       if useReducedPrecision {
@@ -2454,20 +2462,20 @@ final class TensorTests: XCTestCase {
   }
 
   func testOneHot() throws {
-    let labels = X10Tensor_<Int32>(shape: [2], scalars: [3, 4])
-    let actual = TF(X10Tensor(oneHotAtIndices: labels, depth: 8))
-    let expected = TFTensor(oneHotAtIndices: TF(labels), depth: 8)
+    let labels = Tensor<Int32>(shape: [2], scalars: [3, 4], on: x10)
+    let actual = TF(Tensor<Float>(oneHotAtIndices: labels, depth: 8))
+    let expected = Tensor<Float>(oneHotAtIndices: TF(labels), depth: 8)
     XCTAssertEqual(actual, expected)
   }
 
   func testOnesLike() throws {
-    var x = X10Tensor.rand([3, 2, 8])
-    let expected = TFTensor(onesLike: TF(x))
+    var x = Tensor<Float>.rand([3, 2, 8])
+    let expected = Tensor(onesLike: TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         x = x.toReducedPrecision
       }
-      var actual = X10Tensor(onesLike: x)
+      var actual = Tensor(onesLike: x)
       if useReducedPrecision {
         XCTAssert(actual.isReducedPrecision)
         actual = actual.toFullPrecision
@@ -2480,12 +2488,12 @@ final class TensorTests: XCTestCase {
   func testPack() throws {
     for useReducedPrecision in [false, true] {
       for dim in 0..<3 {
-        var xs = [[3, 2, 2], [3, 2, 2], [3, 2, 2]].map { X10Tensor.rand($0) }
-        let expected = TFTensor(stacking: xs.map(TF), alongAxis: dim)
+        var xs = [[3, 2, 2], [3, 2, 2], [3, 2, 2]].map { Tensor<Float>.rand($0) }
+        let expected = Tensor(stacking: xs.map(TF), alongAxis: dim)
         if useReducedPrecision {
           xs = xs.toReducedPrecision
         }
-        var actual = X10Tensor(stacking: xs, alongAxis: dim)
+        var actual = Tensor(stacking: xs, alongAxis: dim)
         if useReducedPrecision {
           XCTAssert(actual.isReducedPrecision)
           actual = actual.toFullPrecision
@@ -2500,8 +2508,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testPadV1() throws {
-    let paddings = X10Tensor_<Int32>(shape: [3, 2], scalars: [1, 2, 3, 4, 5, 6])
-    var x = X10Tensor.rand([5, 7, 3])
+    let paddings = Tensor<Int32>(shape: [3, 2], scalars: [1, 2, 3, 4, 5, 6], on: x10)
+    var x = Tensor<Float>.rand([5, 7, 3])
     let expected = _Raw.pad(TF(x), paddings: TF(paddings))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -2522,7 +2530,7 @@ final class TensorTests: XCTestCase {
 
   func testPadWithConstant() throws {
     let paddings = [(1, 2), (3, 4), (5, 6)]
-    var x = X10Tensor.rand([5, 7, 3])
+    var x = Tensor<Float>.rand([5, 7, 3])
     let padValue = Float(3.0)
     let expected = TF(x).padded(forSizes: paddings, mode: .constant(padValue))
     for useReducedPrecision in [false, true] {
@@ -2544,9 +2552,10 @@ final class TensorTests: XCTestCase {
 
   func testPow() throws {
     let dims = [3, 2]
-    var x = X10Tensor.rand(dims)
-    var e = X10Tensor(
-      shape: TensorShape(dims), scalars: [Float](repeating: 0.25, count: dims.reduce(1, *)))
+    var x = Tensor<Float>.rand(dims)
+    var e = Tensor<Float>(
+      shape: TensorShape(dims), scalars: [Float](repeating: 0.25, count: dims.reduce(1, *)), on: x10
+    )
     let expected = pow(TF(x), TF(e))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -2568,7 +2577,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testProd() throws {
-    var x = X10Tensor(shape: [3, 2], scalars: [1, 5, 43, 24, 64, 32])
+    var x = Tensor<Float>(shape: [3, 2], scalars: [1, 5, 43, 24, 64, 32], on: x10)
     let expected = TF(x).product(squeezingAxes: [0])
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -2590,7 +2599,7 @@ final class TensorTests: XCTestCase {
     for m in dims {
       for n in dims {
         for fullMatrices in [true, false] {
-          let x = X10Tensor.rand([m, n])
+          let x = Tensor<Float>.rand([m, n])
           let actual = x.qrDecomposition(fullMatrices: fullMatrices)
           let expected = TF(x).qrDecomposition(fullMatrices: fullMatrices)
           XCTAssert(
@@ -2610,21 +2619,21 @@ final class TensorTests: XCTestCase {
       let rangeFrom = reverse ? limit : start
       let to = reverse ? start : limit
       let stride = reverse ? -delta : delta
-      let actual = TF(X10Tensor_<Int32>(rangeFrom: rangeFrom, to: to, stride: stride))
-      let expected = TFTensor_<Int32>(rangeFrom: rangeFrom, to: to, stride: stride)
+      let actual = TF(Tensor<Int32>(rangeFrom: rangeFrom, to: to, stride: stride, on: x10))
+      let expected = Tensor<Int32>(rangeFrom: rangeFrom, to: to, stride: stride, on: tf)
       XCTAssertEqual(actual, expected)
     }
   }
 
   func testRank() throws {
-    let x = X10Tensor.rand([3, 2])
+    let x = Tensor<Float>.rand([3, 2])
     let actual = TF(x.rankTensor)
     let expected = TF(x).rankTensor
     XCTAssertEqual(actual, expected)
   }
 
   func testRelu() throws {
-    var x = X10Tensor(shape: [2], scalars: [-0.5, 0.5])
+    var x = Tensor<Float>(shape: [2], scalars: [-0.5, 0.5], on: x10)
     let expected = relu(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -2641,14 +2650,14 @@ final class TensorTests: XCTestCase {
   }
 
   func testReluGrad() throws {
-    func reluX10(_ arg: X10Tensor) -> X10Tensor {
+    func reluX10(_ arg: Tensor<Float>) -> Tensor<Float> {
       return relu(arg)
     }
-    func reluTF(_ arg: TFTensor) -> TFTensor {
+    func reluTF(_ arg: Tensor<Float>) -> Tensor<Float> {
       return relu(arg)
     }
-    var x = X10Tensor(shape: [2], scalars: [-0.5, 0.5])
-    var outGrad = X10Tensor(shape: [2], scalars: [1.5, 2.5])
+    var x = Tensor<Float>(shape: [2], scalars: [-0.5, 0.5], on: x10)
+    var outGrad = Tensor<Float>(shape: [2], scalars: [1.5, 2.5], on: x10)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         x = x.toReducedPrecision
@@ -2660,7 +2669,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testRelu6() throws {
-    var x = X10Tensor(shape: [5], scalars: [-0.5, 0.5, 4, 7, 8])
+    var x = Tensor<Float>(shape: [5], scalars: [-0.5, 0.5, 4, 7, 8], on: x10)
     let expected = relu6(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -2677,14 +2686,14 @@ final class TensorTests: XCTestCase {
   }
 
   func testRelu6Grad() throws {
-    func relu6X10(_ arg: X10Tensor) -> X10Tensor {
+    func relu6X10(_ arg: Tensor<Float>) -> Tensor<Float> {
       return relu6(arg)
     }
-    func relu6TF(_ arg: TFTensor) -> TFTensor {
+    func relu6TF(_ arg: Tensor<Float>) -> Tensor<Float> {
       return relu6(arg)
     }
-    var x = X10Tensor(shape: [5], scalars: [-0.5, 0.5, 4, 7, 8])
-    var outGrad = X10Tensor(shape: [5], scalars: [1.5, 2.5, 2, 5, 3])
+    var x = Tensor<Float>(shape: [5], scalars: [-0.5, 0.5, 4, 7, 8], on: x10)
+    var outGrad = Tensor<Float>(shape: [5], scalars: [1.5, 2.5, 2, 5, 3], on: x10)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         x = x.toReducedPrecision
@@ -2697,7 +2706,7 @@ final class TensorTests: XCTestCase {
   func testReshape() throws {
     for useReducedPrecision in [false, true] {
       do {
-        var x = X10Tensor(shape: [4, 2], scalars: [1, 5, 43, 23, 24, 64, 32, 32])
+        var x = Tensor<Float>(shape: [4, 2], scalars: [1, 5, 43, 23, 24, 64, 32, 32], on: x10)
         let expected = TF(x).reshaped(to: [1, 8])
         if useReducedPrecision {
           x = x.toReducedPrecision
@@ -2711,7 +2720,7 @@ final class TensorTests: XCTestCase {
         XCTAssertEqual(TF(actual), expected)
       }
       do {
-        var x = X10Tensor(shape: [1, 1, 1], scalars: [3])
+        var x = Tensor<Float>(shape: [1, 1, 1], scalars: [3], on: x10)
         let expected = TF(x).reshaped(to: [])
         if useReducedPrecision {
           x = x.toReducedPrecision
@@ -2728,7 +2737,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testRound() throws {
-    var x = X10Tensor([-3.5, -3.4, -3.6, -0.5, 0.5, -0.45, 0.45, 2.4, 2.6])
+    var x = Tensor<Float>([-3.5, -3.4, -3.6, -0.5, 0.5, -0.45, 0.45, 2.4, 2.6], on: x10)
     let expected = round(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -2745,7 +2754,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testRsqrt() throws {
-    var x = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
     let expected = rsqrt(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -2765,8 +2774,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testRsqrtGrad() throws {
-    var x = X10Tensor.rand([3, 2])
-    var outGrad = X10Tensor.rand(x.shape.dimensions)
+    var x = Tensor<Float>.rand([3, 2])
+    var outGrad = Tensor<Float>.rand(x.shape.dimensions)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         x = x.toReducedPrecision
@@ -2782,9 +2791,9 @@ final class TensorTests: XCTestCase {
     let dims = [4, 2, 3]
     for useReducedPrecision in [false, true] {
       for broadcast in [false, true] {
-        var t = X10Tensor.rand(dims)
-        var e = X10Tensor.rand(dims)
-        let condition: X10Tensor_<Bool> = X10Tensor.randint(0, 2, broadcast ? dims : [dims[0]])
+        var t = Tensor<Float>.rand(dims)
+        var e = Tensor<Float>.rand(dims)
+        let condition: Tensor<Bool> = Tensor<Float>.randint(0, 2, broadcast ? dims : [dims[0]])
         let expected = TF(t).replacing(with: TF(e), where: TF(condition))
         if useReducedPrecision {
           t = t.toReducedPrecision
@@ -2805,8 +2814,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testSelu() throws {
-    var x = X10Tensor(shape: [6], scalars: [-1.0, -0.5, 0.5, 3.0, 4.0, 7.0])
-    var outGrad = X10Tensor.rand(x.shape.dimensions)
+    var x = Tensor<Float>(shape: [6], scalars: [-1.0, -0.5, 0.5, 3.0, 4.0, 7.0], on: x10)
+    var outGrad = Tensor<Float>.rand(x.shape.dimensions)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         x = x.toReducedPrecision
@@ -2819,7 +2828,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testSigmoid() throws {
-    var x = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
     let expected = sigmoid(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -2839,8 +2848,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testSigmoidGrad() throws {
-    var x = X10Tensor.rand([3, 2])
-    var outGrad = X10Tensor.rand(x.shape.dimensions)
+    var x = Tensor<Float>.rand([3, 2])
+    var outGrad = Tensor<Float>.rand(x.shape.dimensions)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         x = x.toReducedPrecision
@@ -2854,7 +2863,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testSign() throws {
-    var x = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
     let expected = sign(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -2866,7 +2875,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testSin() throws {
-    var x = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
     let expected = sin(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -2887,7 +2896,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testSinh() throws {
-    var x = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
     let expected = sinh(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -2907,14 +2916,14 @@ final class TensorTests: XCTestCase {
   }
 
   func testSize() throws {
-    let x = X10Tensor.rand([3, 2])
+    let x = Tensor<Float>.rand([3, 2])
     let actual = TF(x.scalarCountTensor)
     let expected = TF(x).scalarCountTensor
     XCTAssertEqual(actual, expected)
   }
 
   func testSlice() throws {
-    var x = X10Tensor.rand([5, 8])
+    var x = Tensor<Float>.rand([5, 8])
     let expected = TF(x).slice(lowerBounds: [1, 2], upperBounds: [3, 6])
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -2936,17 +2945,17 @@ final class TensorTests: XCTestCase {
   func testSliceToEnd() throws {
     let lowerBounds: [Int32] = [1, 0]
     let sizes: [Int32] = [3, -1]
-    var x = X10Tensor.rand([5, 8])
+    var x = Tensor<Float>.rand([5, 8])
     let expected = TF(x).slice(
-      lowerBounds: TFTensor_<Int32>(shape: [lowerBounds.count], scalars: lowerBounds),
-      sizes: TFTensor_<Int32>(shape: [sizes.count], scalars: sizes))
+      lowerBounds: Tensor<Int32>(shape: [lowerBounds.count], scalars: lowerBounds, on: tf),
+      sizes: Tensor<Int32>(shape: [sizes.count], scalars: sizes, on: tf))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         x = x.toReducedPrecision
       }
       var actual = x.slice(
-        lowerBounds: X10Tensor_<Int32>(shape: [lowerBounds.count], scalars: lowerBounds),
-        sizes: X10Tensor_<Int32>(shape: [sizes.count], scalars: sizes))
+        lowerBounds: Tensor<Int32>(shape: [lowerBounds.count], scalars: lowerBounds, on: x10),
+        sizes: Tensor<Int32>(shape: [sizes.count], scalars: sizes, on: x10))
       if useReducedPrecision {
         XCTAssert(actual.isReducedPrecision)
         actual = actual.toFullPrecision
@@ -2960,7 +2969,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testSoftmax() throws {
-    var x = X10Tensor(shape: [2, 2], scalars: [1, 2, 5, 3])
+    var x = Tensor<Float>(shape: [2, 2], scalars: [1, 2, 5, 3], on: x10)
     let expected = softmax(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -2978,9 +2987,9 @@ final class TensorTests: XCTestCase {
   }
 
   func testSoftmaxCrossEntropyWithLogits() throws {
-    var features = X10Tensor.rand([3, 4])
-    var labels = X10Tensor.rand([3, 4])
-    var outGrad = X10Tensor(1.0)
+    var features = Tensor<Float>.rand([3, 4])
+    var labels = Tensor<Float>.rand([3, 4])
+    var outGrad = Tensor<Float>(1.0, on: x10)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         features = features.toReducedPrecision
@@ -2996,14 +3005,14 @@ final class TensorTests: XCTestCase {
   }
 
   func testSoftplus() throws {
-    func softplusX10(_ arg: X10Tensor) -> X10Tensor {
+    func softplusX10(_ arg: Tensor<Float>) -> Tensor<Float> {
       return softplus(arg)
     }
-    func softplusTF(_ arg: TFTensor) -> TFTensor {
+    func softplusTF(_ arg: Tensor<Float>) -> Tensor<Float> {
       return softplus(arg)
     }
-    var x = X10Tensor(shape: [6], scalars: [-1.0, -0.5, 0.5, 3.0, 4.0, 7.0])
-    var outGrad = X10Tensor.rand(x.shape.dimensions)
+    var x = Tensor<Float>(shape: [6], scalars: [-1.0, -0.5, 0.5, 3.0, 4.0, 7.0], on: x10)
+    var outGrad = Tensor<Float>.rand(x.shape.dimensions)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         x = x.toReducedPrecision
@@ -3016,14 +3025,14 @@ final class TensorTests: XCTestCase {
   }
 
   func testSoftsign() throws {
-    func softsignX10(_ arg: X10Tensor) -> X10Tensor {
+    func softsignX10(_ arg: Tensor<Float>) -> Tensor<Float> {
       return softsign(arg)
     }
-    func softsignTF(_ arg: TFTensor) -> TFTensor {
+    func softsignTF(_ arg: Tensor<Float>) -> Tensor<Float> {
       return softsign(arg)
     }
-    var x = X10Tensor(shape: [6], scalars: [-1.0, -0.5, 0.5, 3.0, 4.0, 7.0])
-    var outGrad = X10Tensor.rand(x.shape.dimensions)
+    var x = Tensor<Float>(shape: [6], scalars: [-1.0, -0.5, 0.5, 3.0, 4.0, 7.0], on: x10)
+    var outGrad = Tensor<Float>.rand(x.shape.dimensions)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         x = x.toReducedPrecision
@@ -3036,9 +3045,10 @@ final class TensorTests: XCTestCase {
   }
 
   func testSparseSoftmaxCrossEntropyWithLogits() throws {
-    let labels = X10Tensor_<Int32>(shape: [2], scalars: [3, 4])
-    var logits = X10Tensor(
-      shape: [2, 5], scalars: [0.98, 0.65, 0.832, 0.324, 0.3676, 0.777, 0.244, 0.950, 0.544, 0.445])
+    let labels = Tensor<Int32>(shape: [2], scalars: [3, 4], on: x10)
+    var logits = Tensor<Float>(
+      shape: [2, 5], scalars: [0.98, 0.65, 0.832, 0.324, 0.3676, 0.777, 0.244, 0.950, 0.544, 0.445],
+      on: x10)
     let expected = _Raw.sparseSoftmaxCrossEntropyWithLogits(
       features: TF(logits), labels: TF(labels))
     for useReducedPrecision in [false, true] {
@@ -3074,14 +3084,14 @@ final class TensorTests: XCTestCase {
     let numSplit = Int64(3)
     for useReducedPrecision in [false, true] {
       for splitDim in -valueDims.count..<valueDims.count {
-        var value = X10Tensor.rand(valueDims)
+        var value = Tensor<Float>.rand(valueDims)
         let expectedList = _Raw.split(
-          splitDim: TFTensor_<Int32>(Int32(splitDim)), value: TF(value), numSplit: numSplit)
+          splitDim: Tensor<Int32>(Int32(splitDim), on: tf), value: TF(value), numSplit: numSplit)
         if useReducedPrecision {
           value = value.toReducedPrecision
         }
         var actualList = _Raw.split(
-          splitDim: X10Tensor_<Int32>(Int32(splitDim)), value: value, numSplit: numSplit)
+          splitDim: Tensor<Int32>(Int32(splitDim), on: x10), value: value, numSplit: numSplit)
         if useReducedPrecision {
           for actual in actualList {
             XCTAssert(actual.isReducedPrecision)
@@ -3110,20 +3120,20 @@ final class TensorTests: XCTestCase {
         if inferDim < originalDims.count {
           dims[inferDim] = -1
         }
-        let sizeSplits = X10Tensor_<Int32>(shape: [dims.count], scalars: dims)
+        let sizeSplits = Tensor<Int32>(shape: [dims.count], scalars: dims, on: x10)
         let valueDims = [9, 9, 9]
         for splitDim in -valueDims.count..<valueDims.count {
-          var value = X10Tensor.rand(valueDims)
+          var value = Tensor<Float>.rand(valueDims)
           let expectedList =
             _Raw.splitV(
               value: TF(value), sizeSplits: TF(sizeSplits),
-              splitDim: TFTensor_<Int32>(Int32(splitDim)),
+              splitDim: Tensor<Int32>(Int32(splitDim), on: tf),
               numSplit: Int64(sizeSplits.shape.dimensions.first!))
           if useReducedPrecision {
             value = value.toReducedPrecision
           }
           var actualList = _Raw.splitV(
-            value: value, sizeSplits: sizeSplits, splitDim: X10Tensor_<Int32>(Int32(splitDim)),
+            value: value, sizeSplits: sizeSplits, splitDim: Tensor<Int32>(Int32(splitDim), on: x10),
             numSplit: Int64(sizeSplits.shape.dimensions.first!))
           if useReducedPrecision {
             for actual in actualList {
@@ -3147,7 +3157,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testSqrt() throws {
-    var x = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
     let expected = sqrt(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -3168,7 +3178,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testSquare() throws {
-    var x = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
     let expected = TF(x).squared()
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -3188,8 +3198,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testSquaredDifference() throws {
-    var x = X10Tensor.rand([3, 2])
-    var y = X10Tensor.rand([3, 2])
+    var x = Tensor<Float>.rand([3, 2])
+    var y = Tensor<Float>.rand([3, 2])
     let expected = squaredDifference(TF(x), TF(y))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -3214,7 +3224,7 @@ final class TensorTests: XCTestCase {
   func testSqueeze() throws {
     for useReducedPrecision in [false, true] {
       for (dims, onesDims) in [([1, 3, 4, 1], [0, 3]), ([2, 1, 2, 3], [1]), ([3, 1, 1, 2], [2])] {
-        var x = X10Tensor.rand(dims)
+        var x = Tensor<Float>.rand(dims)
         let expected = TF(x).squeezingShape(at: onesDims)
         if useReducedPrecision {
           x = x.toReducedPrecision
@@ -3233,7 +3243,7 @@ final class TensorTests: XCTestCase {
 
   func testStatelessTruncatedNormal() throws {
     let seed = (graph: Int32(604_591_423), op: Int32(42_628_358))
-    let t = TF(X10Tensor(randomTruncatedNormal: [2, 2], seed: seed))
+    let t = TF(Tensor<Float>(randomTruncatedNormal: [2, 2], seed: seed, on: x10))
     for scalar in t.scalars {
       XCTAssertLessThanOrEqual(scalar, 2.0)
       XCTAssertGreaterThanOrEqual(scalar, -2.0)
@@ -3242,7 +3252,7 @@ final class TensorTests: XCTestCase {
 
   func testStatelessUniformNormal() throws {
     let seed = (graph: Int32(604_591_423), op: Int32(42_628_358))
-    let t = TF(X10Tensor(randomNormal: [2, 2], seed: seed))
+    let t = TF(Tensor<Float>(randomNormal: [2, 2], seed: seed, on: x10))
     for scalar in t.scalars {
       XCTAssertLessThanOrEqual(scalar, 6.0)
       XCTAssertGreaterThanOrEqual(scalar, -6.0)
@@ -3251,7 +3261,7 @@ final class TensorTests: XCTestCase {
 
   func testStatelessUniformRandom() throws {
     let seed = (graph: Int32(604_591_423), op: Int32(42_628_358))
-    let actual = TF(X10Tensor(randomUniform: [2, 2], seed: seed))
+    let actual = TF(Tensor<Float>(randomUniform: [2, 2], seed: seed, on: x10))
     for scalar in actual.scalars {
       XCTAssertLessThanOrEqual(scalar, 1.0)
       XCTAssertGreaterThanOrEqual(scalar, 0.0)
@@ -3260,10 +3270,10 @@ final class TensorTests: XCTestCase {
 
   func testStatelessUniformRandomInt() throws {
     let seed = (graph: Int32(604_591_423), op: Int32(42_628_358))
-    let lowerBound = X10Tensor_<Int32>(0)
-    let upperBound = X10Tensor_<Int32>(100)
-    let t = X10Tensor_<Int32>(
-      randomUniform: [2, 2], lowerBound: lowerBound, upperBound: upperBound, seed: seed)
+    let lowerBound = Tensor<Int32>(0, on: x10)
+    let upperBound = Tensor<Int32>(100, on: x10)
+    let t = Tensor<Int32>(
+      randomUniform: [2, 2], lowerBound: lowerBound, upperBound: upperBound, seed: seed, on: x10)
     for scalar in t.scalars {
       XCTAssertLessThan(scalar, 100)
       XCTAssertGreaterThanOrEqual(scalar, 0)
@@ -3271,8 +3281,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testSub() throws {
-    var x = X10Tensor(shape: [2], scalars: [1, 5])
-    var y = X10Tensor(shape: [2], scalars: [7, 19])
+    var x = Tensor<Float>(shape: [2], scalars: [1, 5], on: x10)
+    var y = Tensor<Float>(shape: [2], scalars: [7, 19], on: x10)
     let expected = TF(x) - TF(y)
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -3292,7 +3302,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testSum() throws {
-    var x = X10Tensor(shape: [4, 2], scalars: [1, 5, 43, 23, 24, 64, 32, 32])
+    var x = Tensor<Float>(shape: [4, 2], scalars: [1, 5, 43, 23, 24, 64, 32, 32], on: x10)
     let expected = TF(x).sum(squeezingAxes: [0])
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -3309,7 +3319,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testTan() throws {
-    var x = X10Tensor(shape: [2, 2], scalars: [1, 2, 5, 3])
+    var x = Tensor<Float>(shape: [2, 2], scalars: [1, 2, 5, 3], on: x10)
     let expected = tan(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -3327,7 +3337,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testTanh() throws {
-    var x = X10Tensor(shape: [2, 2], scalars: [1, 2, 5, 3])
+    var x = Tensor<Float>(shape: [2, 2], scalars: [1, 2, 5, 3], on: x10)
     let expected = tanh(TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -3345,16 +3355,16 @@ final class TensorTests: XCTestCase {
   }
 
   func testTile() throws {
-    var x = X10Tensor.rand([5, 2, 3])
+    var x = Tensor<Float>.rand([5, 2, 3])
     let multiples: [Int32] = [6, 15, 10]
     let expected = TF(x).tiled(
-      multiples: TFTensor_<Int32>(shape: [multiples.count], scalars: multiples))
+      multiples: Tensor<Int32>(shape: [multiples.count], scalars: multiples, on: tf))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         x = x.toReducedPrecision
       }
       var actual = x.tiled(
-        multiples: X10Tensor_<Int32>(shape: [multiples.count], scalars: multiples))
+        multiples: Tensor<Int32>(shape: [multiples.count], scalars: multiples, on: x10))
       if useReducedPrecision {
         XCTAssert(actual.isReducedPrecision)
         actual = actual.toFullPrecision
@@ -3366,7 +3376,7 @@ final class TensorTests: XCTestCase {
   }
 
   func testTranspose() throws {
-    var x = X10Tensor(shape: [2, 4], scalars: [0, 1, 2, 3, 4, 5, 6, 7])
+    var x = Tensor<Float>(shape: [2, 4], scalars: [0, 1, 2, 3, 4, 5, 6, 7], on: x10)
     let expected = TF(x).transposed(permutation: [0, 1])
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -3385,12 +3395,12 @@ final class TensorTests: XCTestCase {
   func testUnpack() throws {
     for useReducedPrecision in [false, true] {
       for dim in -2..<3 {
-        var xs = [[3, 2, 2], [3, 2, 2], [3, 2, 2]].map { X10Tensor.rand($0) }
+        var xs = [[3, 2, 2], [3, 2, 2], [3, 2, 2]].map { Tensor<Float>.rand($0) }
         let expected = xs
         if useReducedPrecision {
           xs = xs.toReducedPrecision
         }
-        let result = X10Tensor(stacking: xs, alongAxis: dim).unstacked(alongAxis: dim)
+        let result = Tensor(stacking: xs, alongAxis: dim).unstacked(alongAxis: dim)
         XCTAssertEqual(result.count, xs.count)
         for (x, unpacked) in zip(expected, result) {
           var actual = unpacked
@@ -3407,9 +3417,9 @@ final class TensorTests: XCTestCase {
   }
 
   func testUnsortedSegmentSum() throws {
-    var data = X10Tensor.rand([3, 4])
-    let segmentIds = X10Tensor_<Int32>(shape: [data.shape.dimensions[0]], scalars: [0, 1, 0])
-    let numSegments = X10Tensor_<Int32>(shape: [], scalars: [2])
+    var data = Tensor<Float>.rand([3, 4])
+    let segmentIds = Tensor<Int32>(shape: [data.shape.dimensions[0]], scalars: [0, 1, 0], on: x10)
+    let numSegments = Tensor<Int32>(shape: [], scalars: [2], on: x10)
     let expected = _Raw.unsortedSegmentSum(
       data: TF(data), segmentIds: TF(segmentIds), numSegments: TF(numSegments))
     for useReducedPrecision in [false, true] {
@@ -3429,8 +3439,8 @@ final class TensorTests: XCTestCase {
   }
 
   func testXdivY() throws {
-    var x = X10Tensor(shape: [2, 3], scalars: [0, 1, 0, 0, 4, 8])
-    var y = X10Tensor(shape: [3], scalars: [0, 1, 2])
+    var x = Tensor<Float>(shape: [2, 3], scalars: [0, 1, 0, 0, 4, 8], on: x10)
+    var y = Tensor<Float>(shape: [3], scalars: [0, 1, 2], on: x10)
     let expected = _Raw.xdivy(TF(x), TF(y))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
@@ -3449,13 +3459,13 @@ final class TensorTests: XCTestCase {
   }
 
   func testZerosLike() throws {
-    var x = X10Tensor.rand([3, 2, 8])
-    let expected = TFTensor(zerosLike: TF(x))
+    var x = Tensor<Float>.rand([3, 2, 8])
+    let expected = Tensor(zerosLike: TF(x))
     for useReducedPrecision in [false, true] {
       if useReducedPrecision {
         x = x.toReducedPrecision
       }
-      var actual = X10Tensor(zerosLike: x)
+      var actual = Tensor(zerosLike: x)
       if useReducedPrecision {
         XCTAssert(actual.isReducedPrecision)
         actual = actual.toFullPrecision
@@ -3629,9 +3639,6 @@ extension TensorTests {
 // export XRT_DEVICE_MAP="CPU:0;/job:localservice/replica:0/task:0/device:XLA_CPU:0"
 // export XRT_WORKERS="localservice:0;grpc://localhost:40934"
 
-// TODO(b/130689556): Remove this environment setting once the bug is fixed.
-setenv("XLA_FLAGS", "--xla_cpu_fast_math_honor_nans=true --xla_cpu_fast_math_honor_infs=true", 1)
-SetMatMulPrecision(true)
 XCTMain([
   testCase(TensorTests.allTests),
 ])


### PR DESCRIPTION
Now that runtime dispatching is supported, we can import Tensor once and use runtime dispatching to test both backends against each other.