### PR TITLE
X10: adjustments to support Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if(BUILD_X10)
       COMMAND
         ${CMAKE_COMMAND} -E remove_directory -Rrf <SOURCE_DIR>/bazel-bin
       COMMAND
-        bazel build -c opt --config=cuda --define framework_shared_object=false //tensorflow/compiler/tf2xla/xla_tensor:libx10.so
+        bazel build -c opt --config=cuda --define framework_shared_object=false //tensorflow/compiler/tf2xla/xla_tensor:x10
       COMMAND
         bazel shutdown
     INSTALL_COMMAND
@@ -55,7 +55,7 @@ if(BUILD_X10)
     BUILD_IN_SOURCE
       TRUE
     BUILD_BYPRODUCTS
-      <SOURCE_DIR>/bazel-bin/tensorflow/compiler/tf2xla/xla_tensor/libx10.so
+      <SOURCE_DIR>/bazel-bin/tensorflow/compiler/tf2xla/xla_tensor/${CMAKE_SHARED_LIBRARY_PREFIX}x10${CMAKE_SHARED_LIBRARY_SUFFIX}
     USES_TERMINAL_BUILD
       TRUE
     STEP_TARGETS
@@ -65,7 +65,7 @@ if(BUILD_X10)
   add_library(x10 IMPORTED UNKNOWN)
   set_target_properties(x10 PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${SOURCE_DIR};${SOURCE_DIR}/bazel-bin;${SOURCE_DIR}/bazel-tensorflow/external/com_google_absl;${SOURCE_DIR}/bazel-tensorflow/external/com_google_protobuf/src;${SOURCE_DIR}/bazel-tensorflow/external/eigen_archive"
-    IMPORTED_LOCATION ${SOURCE_DIR}/bazel-bin/tensorflow/compiler/tf2xla/xla_tensor/libx10.so)
+    IMPORTED_LOCATION ${SOURCE_DIR}/bazel-bin/tensorflow/compiler/tf2xla/xla_tensor/${CMAKE_SHARED_LIBRARY_PREFIX}x10${CMAKE_SHARED_LIBRARY_SUFFIX})
   add_dependencies(x10
     tensorflow-build)
 

--- a/Sources/x10/xla_tensor/BUILD
+++ b/Sources/x10/xla_tensor/BUILD
@@ -65,13 +65,39 @@ cc_library(
     ],
 )
 
+filegroup(
+    name = "get_x10_dll_import_lib",
+    srcs = [":x10.dll"],
+    output_group = "interface_library",
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "x10_dll_import_lib",
+    srcs = [":get_x10_dll_import_lib"],
+    outs = ["x10.lib"],
+    cmd = select({
+        "//tensorflow:windows": "cp -f $< $@",
+        "//conditions:defualt": "touch $@",  # Just a placeholder for Unix platforms
+    }),
+    visibility = ["//visibility:public"],
+)
+
 tf_cc_shared_object(
-    name = "libx10.so",
-    linkopts = [
-        "-z defs",
-        "-s",
-        "-Wl,--version-script,$(location :tf_version_script.lds)",
-    ],
+    name = "x10",
+    linkopts = select({
+        "//tensorflow:macos": [
+            # TODO
+        ],
+        "//tensorflow:windows": [
+        ],
+        "//conditions:default": [
+            "-z defs",
+            "-s",
+            "-Wl,--version-script,$(location :tf_version_script.lds)",
+        ],
+    }),
+    per_os_targets = True,
     visibility = ["//visibility:public"],
     deps = [
         ":tensor",


### PR DESCRIPTION
Use `_aligned_malloc` and `_aligned_free` on Windows rather than the
POSIX `posix_memalign` or the C11 specific `aligned_alloc`.

Adjust the build rules to create target dependent libraries, fix the
linker options to be target dependent and add support for the import
library target needed for Windows.

The biggest change here is that users will now target `x10` rather than
the library name of `libx10.so`.  This will generate `libx10.so` on
Linux, `libx10.dylib` on macOS, and `x10.dll` on Windows.