### PR TITLE
x10: port for Darwin

### DIFF
--- a/Sources/x10/xla_client/mesh_service.cc
+++ b/Sources/x10/xla_client/mesh_service.cc
@@ -38,6 +38,18 @@
 #include "tensorflow/compiler/xla/xla_client/util.h"
 #include "tensorflow/compiler/xla/status.h"
 
+namespace std {
+std::ostream& operator<<(std::ostream& ostrm, const ::grpc::Status& status) {
+  if (status.ok()) {
+    ostrm << "OK";
+  } else {
+    ostrm << status.error_message() << " ("
+          << static_cast<int>(status.error_code()) << ")";
+  }
+  return ostrm;
+}
+}
+
 namespace xla {
 namespace service {
 namespace {
@@ -55,16 +67,6 @@ namespace {
              ? ::grpc::Status::OK
              : ::grpc::Status(static_cast<::grpc::StatusCode>(status.code()),
                               status.error_message());
-}
-
-std::ostream& operator<<(std::ostream& ostrm, const ::grpc::Status& status) {
-  if (status.ok()) {
-    ostrm << "OK";
-  } else {
-    ostrm << status.error_message() << " ("
-          << static_cast<int>(status.error_code()) << ")";
-  }
-  return ostrm;
 }
 
 class MeshServiceImpl : public grpc::MeshService::Service {

--- a/Sources/x10/xla_client/xrt_computation_client.cc
+++ b/Sources/x10/xla_client/xrt_computation_client.cc
@@ -136,6 +136,10 @@ class TensorAllocator : public tensorflow::Allocator {
     void* ptr = _aligned_malloc(
         alloc_blocks->alloc_key.alignment,
         alloc_blocks->alloc_key.alignment + alloc_blocks->alloc_key.num_bytes);
+#elif defined(__APPLE__)
+    void* ptr = nullptr;
+    posix_memalign(&ptr, alloc_blocks->alloc_key.alignment,
+        alloc_blocks->alloc_key.alignment + alloc_blocks->alloc_key.num_bytes);
 #else
     void* ptr = ::aligned_alloc(
         alloc_blocks->alloc_key.alignment,


### PR DESCRIPTION
The Xcode 11.3 compiler does objects to the use of the extension to
provide the overload for a std::operator<< in a different namespace.
Move the definition into the `std::` namespace.  Although this is
placing something into a restricted namespace, it is adding an overload
and is permissible.  This allows the streaming of the `grpc::Status`
type to the logging.

Adjust the allocation to use `posix_malloc` for the alignment rather
than the C11 `aligned_alloc` as the latter is unavailable in C++11 mode
and C11 needs to be explicitly opted into.  It should be available as
part of C++17 on macOS, however, tensorflow is still adhering C++11.