### PR TITLE
x10: correct typo in build rules

### DIFF
--- a/Sources/x10/xla_tensor/BUILD
+++ b/Sources/x10/xla_tensor/BUILD
@@ -81,7 +81,7 @@ genrule(
     outs = ["x10.lib"],
     cmd = select({
         "//tensorflow:windows": "cp -f $< $@",
-        "//conditions:defualt": "touch $@",  # Just a placeholder for Unix platforms
+        "//conditions:default": "touch $@",  # Just a placeholder for Unix platforms
     }),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This allows using the bazel target:
`//tensorflow/compiler/tf2xla/xla_tensor:x10_dll_import_lib` on
non-Windows platforms.