### PR TITLE
Fix non-CUDA toolchain build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,12 +42,18 @@ if(BUILD_X10)
       COMMAND
         ${CMAKE_COMMAND} -E create_symlink ${PROJECT_SOURCE_DIR}/Sources/x10/xla_tensor <SOURCE_DIR>/tensorflow/compiler/tf2xla/xla_tensor
       COMMAND
-        sh -c "yes '' | TF_NEED_CUDA=1 <SOURCE_DIR>/configure"
+        # Note that the configure script is affected by the following environment variables:
+        #   TF_CUDA_VERSION
+        #   TF_NEED_CUDA
+        #   TF_CUDNN_VERSION
+        #   CUDA_TOOLKIT_PATH
+        #   CUDNN_INSTALL_PATH
+        sh -c "yes '' | <SOURCE_DIR>/configure"
     BUILD_COMMAND
       COMMAND
         rm -rf <SOURCE_DIR>/bazel-bin # ${CMAKE_COMMAND} -E rm -Rrf <SOURCE_DIR>/bazel-bin
       COMMAND
-        bazel build -c opt --config=cuda --define framework_shared_object=false //tensorflow/compiler/tf2xla/xla_tensor:x10
+        bazel build -c opt --define framework_shared_object=false //tensorflow/compiler/tf2xla/xla_tensor:x10
       COMMAND
         bazel shutdown
     INSTALL_COMMAND

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN python3 Utilities/benchmark_compile.py /swift-tensorflow-toolchain/usr/bin/s
 RUN /swift-tensorflow-toolchain/usr/bin/swift test
 
 # Perform CMake based build
+ENV TF_NEED_CUDA=1
 RUN cmake                                                                       \
       -B /BinaryCache/tensorflow-swift-apis                                     \
       -D BUILD_SHARED_LIBS=YES                                                  \


### PR DESCRIPTION
The tensorflow build had `TF_NEED_CUDA=1` and `--config=cuda` hardcoded, which causes the build to fail when CUDA is not available. This PR removes the hardcoding so that we can build tensorflow without CUDA.

It might seem that this would prevent tensorflow from building *with* CUDA, but actually it doesn't. The scripts invoking the CUDA builds (which currently live in google's internal repo) set some environment variables (like `TF_NEED_CUDA`) that get picked up by the configure script.

Maybe we should follow up this quick fix with something that makes the CUDA options more explicit. In the meantime, I have documented the implicit behavior at the use site to reduce confusion a bit.