### PR TITLE
X10: repair the Windows build

### DIFF
--- a/Sources/x10/swift_bindings/device_wrapper.cc
+++ b/Sources/x10/swift_bindings/device_wrapper.cc
@@ -18,6 +18,12 @@
 #include "tensorflow/compiler/xla/xla_client/computation_client.h"
 #include "tensorflow/compiler/xla/xla_client/multi_wait.h"
 
+#if defined(_WIN32)
+#define XLA_API __declspec(dllexport)
+#else
+#define XLA_API __attribute__((__visbility__("defualt")))
+#endif
+
 DeviceType ConvertDeviceType(swift_xla::DeviceType device_type) {
   switch (device_type) {
     case swift_xla::DeviceType::CPU: {
@@ -95,28 +101,28 @@ std::vector<std::string> DeviceListToStrings(DeviceList* device_list) {
 
 }  // namespace
 
-void destroyDeviceList(DeviceList* device_list) { delete device_list; }
+void XLA_API destroyDeviceList(DeviceList* device_list) { delete device_list; }
 
-DeviceList* getAllDevices() {
+DeviceList* XLA_API getAllDevices() {
   return DeviceListFromStrings(xla::ComputationClient::Get()->GetAllDevices());
 }
 
-CDevice DefaultDevice() {
+CDevice XLA_API DefaultDevice() {
   auto device = swift_xla::GetDefaultDevice();
   return {ConvertDeviceType(device->hw_type), device->ordinal};
 }
 
-void setReplicationDevices(struct DeviceList* device_list) {
+void XLA_API setReplicationDevices(struct DeviceList* device_list) {
   const auto device_strings = DeviceListToStrings(device_list);
   xla::ComputationClient::Get()->SetReplicationDevices(device_strings);
 }
 
-struct DeviceList* getReplicationDevices() {
+struct DeviceList* XLA_API getReplicationDevices() {
   return DeviceListFromStrings(
       xla::ComputationClient::Get()->GetReplicationDevices());
 }
 
-void syncLiveTensorsForDevices(struct DeviceList* device_list) {
+void XLA_API syncLiveTensorsForDevices(struct DeviceList* device_list) {
   const auto device_strings = DeviceListToStrings(device_list);
   xla::util::MultiWait mwait(device_strings.size());
   for (size_t i = 0; i < device_strings.size(); ++i) {
@@ -133,8 +139,8 @@ void syncLiveTensorsForDevices(struct DeviceList* device_list) {
   mwait.Wait();
 }
 
-void XLATensor_LazyTensorBarrier(const struct CDevice* device,
-                                 struct DeviceList* device_list, bool wait) {
+void XLA_API XLATensor_LazyTensorBarrier(const struct CDevice* device,
+                                         struct DeviceList* device_list, bool wait) {
   const auto device_strings = DeviceListToStrings(device_list);
   swift_xla::Device tmp_device;
   if (device) tmp_device = ConvertDevice(*device);

--- a/Sources/x10/swift_bindings/xla_tensor_tf_ops.cc
+++ b/Sources/x10/swift_bindings/xla_tensor_tf_ops.cc
@@ -18,6 +18,12 @@
 #include "tensorflow/compiler/tf2xla/xla_tensor/tensor.h"
 #include "tensorflow/compiler/xla/client/lib/pooling.h"
 
+#if defined(_WIN32)
+#define XLA_API __declspec(dllexport)
+#else
+#define XLA_API __attribute__((__visibility__("default")))
+#endif
+
 using swift_xla::XlaHelpers;
 using swift_xla::XLATensor;
 
@@ -65,9 +71,9 @@ at::ScalarType SumAccumulationType(at::ScalarType dtype) {
 
 }  // namespace
 
-OpaqueXLATensor* tf_AvgPool(OpaqueXLATensor* value, Int64ArrayRef ksize,
-                            Int64ArrayRef strides, enum TFPadding padding,
-                            enum TFDataFormat data_format) {
+OpaqueXLATensor* XLA_API tf_AvgPool(OpaqueXLATensor* value, Int64ArrayRef ksize,
+                                    Int64ArrayRef strides, enum TFPadding padding,
+                                    enum TFDataFormat data_format) {
   const auto value_shape_ref = value->shape();
   int num_spatial_dims = (*value_shape_ref).rank() - 2;
   xla::Padding xla_padding = ToXLAPadding(padding);
@@ -91,10 +97,10 @@ OpaqueXLATensor* tf_AvgPool(OpaqueXLATensor* value, Int64ArrayRef ksize,
   return new XLATensor(XLATensor::to(avg_pool, absl::nullopt, value->dtype()));
 }
 
-OpaqueXLATensor* tf_AvgPoolGrad(Int64ArrayRef origInputShape,
-                                OpaqueXLATensor* grad, Int64ArrayRef ksize,
-                                Int64ArrayRef strides, enum TFPadding padding,
-                                enum TFDataFormat data_format) {
+OpaqueXLATensor* XLA_API tf_AvgPoolGrad(Int64ArrayRef origInputShape,
+                                        OpaqueXLATensor* grad, Int64ArrayRef ksize,
+                                        Int64ArrayRef strides, enum TFPadding padding,
+                                        enum TFDataFormat data_format) {
   xla::Padding xla_padding = ToXLAPadding(padding);
   int num_spatial_dims = ksize.size - 2;
   xla::TensorFormat xla_data_format =
@@ -118,9 +124,9 @@ OpaqueXLATensor* tf_AvgPoolGrad(Int64ArrayRef origInputShape,
       XLATensor::to(in_backprop, absl::nullopt, grad->dtype()));
 }
 
-OpaqueXLATensor* tf_MaxPool(OpaqueXLATensor* input, Int64ArrayRef ksize,
-                            Int64ArrayRef strides, enum TFPadding padding,
-                            enum TFDataFormat data_format) {
+OpaqueXLATensor* XLA_API tf_MaxPool(OpaqueXLATensor* input, Int64ArrayRef ksize,
+                                    Int64ArrayRef strides, enum TFPadding padding,
+                                    enum TFDataFormat data_format) {
   xla::Padding xla_padding = ToXLAPadding(padding);
   int num_spatial_dims = ksize.size - 2;
   xla::TensorFormat xla_data_format =
@@ -132,9 +138,9 @@ OpaqueXLATensor* tf_MaxPool(OpaqueXLATensor* input, Int64ArrayRef ksize,
       /*padding=*/xla_padding, /*data_format=*/xla_data_format));
 }
 
-OpaqueXLATensor* tf_MaxPoolGrad(OpaqueXLATensor* input, OpaqueXLATensor* grad,
-                                Int64ArrayRef ksize, Int64ArrayRef strides,
-                                enum TFPadding padding) {
+OpaqueXLATensor* XLA_API tf_MaxPoolGrad(OpaqueXLATensor* input, OpaqueXLATensor* grad,
+                                        Int64ArrayRef ksize, Int64ArrayRef strides,
+                                        enum TFPadding padding) {
   xla::Padding xla_padding = ToXLAPadding(padding);
   auto kernel_size = XlaHelpers::I64List(ksize.slice());
   auto stride = XlaHelpers::I64List(strides.slice());

--- a/Sources/x10/swift_bindings/xla_tensor_wrapper.cc
+++ b/Sources/x10/swift_bindings/xla_tensor_wrapper.cc
@@ -27,6 +27,12 @@
 #include "tensorflow/compiler/tf2xla/xla_tensor/tensor_util.h"
 #include "tensorflow/core/util/mirror_pad_mode.h"
 
+#if defined(_WIN32)
+#define XLA_API __declspec(dllexport)
+#else
+#define XLA_API __attribute__((__visibility__("default")))
+#endif
+
 using swift_xla::XlaHelpers;
 using swift_xla::XLATensor;
 
@@ -98,18 +104,19 @@ at::Scalar atScalar(XLAScalar s) {
   }
 }
 
-swift_xla::XLATensor* XLATensor_makeScalar(XLAScalar value,
-                                           enum XLATensorScalarType type,
-                                           const struct CDevice cdevice) {
+swift_xla::XLATensor* XLA_API XLATensor_makeScalar(XLAScalar value,
+                                                   enum XLATensorScalarType type,
+                                                   const struct CDevice cdevice) {
   return new swift_xla::XLATensor(swift_xla::XLATensor::Create(
       atScalar(value), ToScalarType(type), ConvertDevice(cdevice)));
 }
 
 // TODO(parkers): reduce copying here...
-swift_xla::XLATensor* copyTensor(XLATensorScalarType type,
-                                 const void* raw_value, size_t num_entries,
-                                 const size_t* shape, size_t rank,
-                                 const struct CDevice device) {
+swift_xla::XLATensor* XLA_API copyTensor(XLATensorScalarType type,
+                                         const void* raw_value,
+                                         size_t num_entries,
+                                         const size_t* shape, size_t rank,
+                                         const struct CDevice device) {
   switch (type) {
 #define DEFINE_COPY_CASE(name, aten_name, DType)                 \
   case XLATensorScalarType_##name: {                             \
@@ -127,12 +134,13 @@ swift_xla::XLATensor* copyTensor(XLATensorScalarType type,
       LOG(FATAL) << "Invalid type: " << type;
   }
 }
-OpaqueXLATensor* copyTensorAndMakeResident(enum XLATensorScalarType type,
-                                           const void* value,
-                                           size_t num_entries,
-                                           const size_t* shape, size_t rank,
-                                           const struct CDevice cdevice,
-                                           bool to_reduced_precision) {
+OpaqueXLATensor* XLA_API copyTensorAndMakeResident(enum XLATensorScalarType type,
+                                                   const void* value,
+                                                   size_t num_entries,
+                                                   const size_t* shape,
+                                                   size_t rank,
+                                                   const struct CDevice cdevice,
+                                                   bool to_reduced_precision) {
   if (to_reduced_precision && XLATensorScalarType_Float == type) {
     const float* float_buffer = reinterpret_cast<const float*>(value);
     auto non_owned_buffer =
@@ -166,11 +174,11 @@ OpaqueXLATensor* copyTensorAndMakeResident(enum XLATensorScalarType type,
   return copyTensor(type, value, num_entries, shape, rank, cdevice);
 }
 
-const void* MaterializedTensor_getData(OpaqueMaterializedTensor* t) {
+const void* XLA_API MaterializedTensor_getData(OpaqueMaterializedTensor* t) {
   return t->buffer().raw_data();
 }
 
-OpaqueMaterializedTensor* XLATensor_materialize(OpaqueXLATensor* t) {
+OpaqueMaterializedTensor* XLA_API XLATensor_materialize(OpaqueXLATensor* t) {
   // Avoid barriers for fetching trivial local tensors.
   auto current_tensor = t->CurrentTensorData();
   if (current_tensor) return new at::Tensor(std::move(*current_tensor));
@@ -178,14 +186,15 @@ OpaqueMaterializedTensor* XLATensor_materialize(OpaqueXLATensor* t) {
   return new at::Tensor(t->ToTensor(/*detached=*/false));
 }
 
-enum XLATensorScalarType MaterializedTensor_getType(
+enum XLATensorScalarType XLA_API MaterializedTensor_getType(
     OpaqueMaterializedTensor* t) {
   return FromScalarType(t->scalar_type());
 }
-enum XLATensorScalarType XLATensor_dtype(OpaqueXLATensor* a) {
+enum XLATensorScalarType XLA_API XLATensor_dtype(OpaqueXLATensor* a) {
   return FromScalarType(a->dtype());
 }
-enum XLATensorScalarType XLATensor_physical_scalar_type(OpaqueXLATensor* a) {
+enum XLATensorScalarType XLA_API
+XLATensor_physical_scalar_type(OpaqueXLATensor* a) {
   return FromScalarType(a->physical_scalar_type());
 }
 
@@ -213,20 +222,20 @@ XLATensorScalarType FromScalarType(at::ScalarType type) {
   }
 }
 
-void destroyTensor(swift_xla::XLATensor* t) { delete t; }
-void destroyMaterializedTensor(OpaqueMaterializedTensor* t) { delete t; }
-void destroyXLAShape(xla::util::MaybeRef<xla::Shape>* s) { delete s; }
+void XLA_API destroyTensor(swift_xla::XLATensor* t) { delete t; }
+void XLA_API destroyMaterializedTensor(OpaqueMaterializedTensor* t) { delete t; }
+void XLA_API destroyXLAShape(xla::util::MaybeRef<xla::Shape>* s) { delete s; }
 
-xla::util::MaybeRef<xla::Shape>* fetchTensorShape(
+xla::util::MaybeRef<xla::Shape>* XLA_API fetchTensorShape(
     swift_xla::XLATensor* tensor) {
   return new xla::util::MaybeRef<xla::Shape>(tensor->shape());
 }
 
-size_t XLAShape_getRank(xla::util::MaybeRef<xla::Shape>* shape) {
+size_t XLA_API XLAShape_getRank(xla::util::MaybeRef<xla::Shape>* shape) {
   return shape->get().dimensions().size();
 }
 
-const int64_t* XLAShape_getDimensions(OpaqueXLAShape* shape) {
+const int64_t* XLA_API XLAShape_getDimensions(OpaqueXLAShape* shape) {
   static_assert(sizeof(int64_t) == sizeof(xla::int64), "Sanity");
   return reinterpret_cast<const int64_t*>(shape->get().dimensions().data());
 }
@@ -240,10 +249,10 @@ static const CDevice& CheckedRef(const CDevice* device) {
   return *device;
 }
 
-XLAAnnotationScope* MakeAnnotationScope(const char* scope) {
+XLAAnnotationScope* XLA_API MakeAnnotationScope(const char* scope) {
   return new tensorflow::profiler::TraceMe(scope);
 }
-void DestroyAnnotationScope(XLAAnnotationScope* scope) {
+void XLA_API DestroyAnnotationScope(XLAAnnotationScope* scope) {
   if (scope) delete scope;
 }
 
@@ -265,11 +274,12 @@ tensorflow::TensorFormat ToTFFormat(TFDataFormat data_format) {
 
 }  // namespace x10
 
-void destroyOpaqueXLATensorArrayRef(OpaqueXLATensorArrayRef tensor_list) {
+void XLA_API
+destroyOpaqueXLATensorArrayRef(OpaqueXLATensorArrayRef tensor_list) {
   delete[] tensor_list.data;
 }
 
-void destroyStridedSliceSpec(StridedSliceSpec* strided_slice_spec) {
+void XLA_API destroyStridedSliceSpec(StridedSliceSpec* strided_slice_spec) {
   delete[] strided_slice_spec->begin.data;
   delete[] strided_slice_spec->end.data;
   delete[] strided_slice_spec->strides.data;
@@ -279,106 +289,111 @@ void destroyStridedSliceSpec(StridedSliceSpec* strided_slice_spec) {
 }
 
 // Ops.
-OpaqueXLATensor* XLATensor_abs(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_abs(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::abs(*a));
 }
-OpaqueXLATensor* XLATensor_acos(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_acos(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::acos(*a));
 }
-OpaqueXLATensor* XLATensor_acosh(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_acosh(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::acosh(*a));
 }
-OpaqueXLATensor* XLATensor_cumprod(OpaqueXLATensor* a, int64_t dim,
-                                   Optional_XLAScalarType dtype, bool exclusive,
-                                   bool reverse) {
+OpaqueXLATensor* XLA_API XLATensor_cumprod(OpaqueXLATensor* a, int64_t dim,
+                                           Optional_XLAScalarType dtype,
+                                           bool exclusive, bool reverse) {
   return new XLATensor(
       XLATensor::cumprod(*a, dim, dtype.value(), exclusive, reverse));
 }
-OpaqueXLATensor* XLATensor_cumsum(OpaqueXLATensor* a, int64_t dim,
-                                  Optional_XLAScalarType dtype, bool exclusive,
-                                  bool reverse) {
+OpaqueXLATensor* XLA_API XLATensor_cumsum(OpaqueXLATensor* a, int64_t dim,
+                                          Optional_XLAScalarType dtype,
+                                          bool exclusive, bool reverse) {
   return new XLATensor(
       XLATensor::cumsum(*a, dim, dtype.value(), exclusive, reverse));
 }
-OpaqueXLATensor* XLATensor_add(OpaqueXLATensor* a, OpaqueXLATensor* b) {
+OpaqueXLATensor* XLA_API XLATensor_add(OpaqueXLATensor* a, OpaqueXLATensor* b) {
   return new XLATensor(XLATensor::add(*a, *b));
 }
-OpaqueXLATensor* XLATensor_all(OpaqueXLATensor* input, Int64ArrayRef dimensions,
-                               bool keep_reduced_dimensions) {
+OpaqueXLATensor* XLA_API XLATensor_all(OpaqueXLATensor* input,
+                                       Int64ArrayRef dimensions,
+                                       bool keep_reduced_dimensions) {
   return new XLATensor(XLATensor::all(*input,
                                       XlaHelpers::I64List(dimensions.slice()),
                                       keep_reduced_dimensions));
 }
-OpaqueXLATensor* XLATensor_any(OpaqueXLATensor* input, Int64ArrayRef dimensions,
-                               bool keep_reduced_dimensions) {
+OpaqueXLATensor* XLA_API XLATensor_any(OpaqueXLATensor* input,
+                                       Int64ArrayRef dimensions,
+                                       bool keep_reduced_dimensions) {
   return new XLATensor(XLATensor::any(*input,
                                       XlaHelpers::I64List(dimensions.slice()),
                                       keep_reduced_dimensions));
 }
-OpaqueXLATensor* XLATensor_arange(XLAScalar start, XLAScalar end,
-                                  XLAScalar step, const CDevice device,
-                                  enum XLATensorScalarType type) {
+OpaqueXLATensor* XLA_API XLATensor_arange(XLAScalar start, XLAScalar end,
+                                          XLAScalar step, const CDevice device,
+                                          enum XLATensorScalarType type) {
   XLATensor out = MakeEmpty(ToScalarType(type), ConvertDevice(device));
   XLATensor::arange_out(out, atScalar(start), atScalar(end), atScalar(step),
                         ToScalarType(type));
   return new XLATensor(out);
 }
-OpaqueXLATensor* XLATensor_argmax(OpaqueXLATensor* a, int64_t dim,
-                                  bool keepdim) {
+OpaqueXLATensor* XLA_API XLATensor_argmax(OpaqueXLATensor* a, int64_t dim,
+                                          bool keepdim) {
   XLATensor out = MakeEmpty(a->dtype(), a->GetDevice());
   XLATensor indices = MakeEmpty(at::ScalarType::Long, a->GetDevice());
   XLATensor::max_out(out, indices, *a, dim, keepdim);
   return new XLATensor(indices);
 }
-OpaqueXLATensor* XLATensor_argmin(OpaqueXLATensor* a, int64_t dim,
-                                  bool keepdim) {
+OpaqueXLATensor* XLA_API XLATensor_argmin(OpaqueXLATensor* a, int64_t dim,
+                                          bool keepdim) {
   XLATensor out = MakeEmpty(a->dtype(), a->GetDevice());
   XLATensor indices = MakeEmpty(at::ScalarType::Long, a->GetDevice());
   XLATensor::min_out(out, indices, *a, dim, keepdim);
   return new XLATensor(indices);
 }
-OpaqueXLATensor* XLATensor_asin(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_asin(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::asin(*a));
 }
-OpaqueXLATensor* XLATensor_asinh(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_asinh(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::asinh(*a));
 }
-OpaqueXLATensor* XLATensor_atan(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_atan(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::atan(*a));
 }
-OpaqueXLATensor* XLATensor_atanh(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_atanh(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::atanh(*a));
 }
-OpaqueXLATensor_pair XLATensor_broadcast_tensors(OpaqueXLATensor* a,
-                                                 OpaqueXLATensor* b) {
+OpaqueXLATensor_pair XLA_API XLATensor_broadcast_tensors(OpaqueXLATensor* a,
+                                                         OpaqueXLATensor* b) {
   OpaqueXLATensor_pair result;
   auto output = XLATensor::broadcast_tensors({*a, *b});
   result.x = new XLATensor(output[0]);
   result.y = new XLATensor(output[1]);
   return result;
 }
-OpaqueXLATensor* XLATensor_cat(OpaqueXLATensorArrayRef tensors, int64_t dim) {
+OpaqueXLATensor* XLA_API XLATensor_cat(OpaqueXLATensorArrayRef tensors,
+                                       int64_t dim) {
   return new XLATensor(XLATensor::cat(tensors.array(), dim));
 }
-OpaqueXLATensor* XLATensor_ceil(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_ceil(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::ceil(*a));
 }
-OpaqueXLATensor* XLATensor_clamp(OpaqueXLATensor* input, OpaqueXLATensor* min,
-                                 OpaqueXLATensor* max) {
+OpaqueXLATensor* XLA_API XLATensor_clamp(OpaqueXLATensor* input,
+                                         OpaqueXLATensor* min,
+                                         OpaqueXLATensor* max) {
   return new XLATensor(XLATensor::clamp(*input, *min, *max));
 }
-OpaqueXLATensor* XLATensor_constant_pad_nd(OpaqueXLATensor* input,
-                                           Int64ArrayRef pad, XLAScalar value) {
+OpaqueXLATensor* XLA_API XLATensor_constant_pad_nd(OpaqueXLATensor* input,
+                                                   Int64ArrayRef pad,
+                                                   XLAScalar value) {
   return new XLATensor(
       XLATensor::constant_pad_nd(*input, pad.slice(), atScalar(value)));
 }
-OpaqueXLATensor* XLATensor_cos(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_cos(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::cos(*a));
 }
-OpaqueXLATensor* XLATensor_cosh(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_cosh(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::cosh(*a));
 }
-OpaqueXLATensorArrayRef XLATensor_cross_replica_sum(
+OpaqueXLATensorArrayRef XLA_API XLATensor_cross_replica_sum(
     OpaqueXLATensorArrayRef inputs, double scale) {
   auto token = swift_xla::ir::MakeNode<swift_xla::ir::ops::Token>();
   auto inputs_array = inputs.array();
@@ -387,48 +402,51 @@ OpaqueXLATensorArrayRef XLATensor_cross_replica_sum(
   const auto& result_tensors = reduced_and_token.first;
   return ConvertTensorList(result_tensors);
 }
-OpaqueXLATensor* XLATensor_diagonal_value(OpaqueXLATensor* a, int64_t offset,
-                                          int64_t dim1, int64_t dim2) {
+OpaqueXLATensor* XLA_API XLATensor_diagonal_value(OpaqueXLATensor* a,
+                                                  int64_t offset, int64_t dim1,
+                                                  int64_t dim2) {
   return new XLATensor(XLATensor::diagonal_value(*a, offset, dim1, dim2));
 }
-OpaqueXLATensor* XLATensor_div(OpaqueXLATensor* a, OpaqueXLATensor* b) {
+OpaqueXLATensor* XLA_API XLATensor_div(OpaqueXLATensor* a, OpaqueXLATensor* b) {
   return new XLATensor(XLATensor::div(*a, *b));
 }
-OpaqueXLATensor* XLATensor_eq(OpaqueXLATensor* a, OpaqueXLATensor* b) {
+OpaqueXLATensor* XLA_API XLATensor_eq(OpaqueXLATensor* a, OpaqueXLATensor* b) {
   return new XLATensor(XLATensor::eq(*a, *b));
 }
-OpaqueXLATensor* XLATensor_exp(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_exp(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::exp(*a));
 }
-OpaqueXLATensor* XLATensor_expand(OpaqueXLATensor* a, Int64ArrayRef dims) {
+OpaqueXLATensor* XLA_API XLATensor_expand(OpaqueXLATensor* a,
+                                          Int64ArrayRef dims) {
   return new XLATensor(
       XLATensor::expand(*a, XlaHelpers::I64List(dims.slice())));
 }
-OpaqueXLATensor* XLATensor_expm1(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_expm1(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::expm1(*a));
 }
-OpaqueXLATensor* XLATensor_flip(OpaqueXLATensor* input, Int64ArrayRef dims) {
+OpaqueXLATensor* XLA_API XLATensor_flip(OpaqueXLATensor* input,
+                                        Int64ArrayRef dims) {
   return new XLATensor(XLATensor::flip(*input, dims.slice()));
 }
-OpaqueXLATensor* XLATensor_floor(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_floor(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::floor(*a));
 }
-OpaqueXLATensor* XLATensor_full(Int64ArrayRef size, XLAScalar value,
-                                const CDevice device,
-                                enum XLATensorScalarType type) {
+OpaqueXLATensor* XLA_API XLATensor_full(Int64ArrayRef size, XLAScalar value,
+                                        const CDevice device,
+                                        enum XLATensorScalarType type) {
   return new XLATensor(XLATensor::full(size.slice(), atScalar(value),
                                        ConvertDevice(device),
                                        ToScalarType(type)));
 }
-OpaqueXLATensor* XLATensor_ge(OpaqueXLATensor* x, OpaqueXLATensor* y) {
+OpaqueXLATensor* XLA_API XLATensor_ge(OpaqueXLATensor* x, OpaqueXLATensor* y) {
   return new XLATensor(XLATensor::ge(*x, *y));
 }
-OpaqueXLATensor* XLATensor_gt(OpaqueXLATensor* x, OpaqueXLATensor* y) {
+OpaqueXLATensor* XLA_API XLATensor_gt(OpaqueXLATensor* x, OpaqueXLATensor* y) {
   return new XLATensor(XLATensor::gt(*x, *y));
 }
-OpaqueXLATensor* XLATensor_index(OpaqueXLATensor* input,
-                                 OpaqueXLATensorArrayRef indices,
-                                 int64_t start_dim) {
+OpaqueXLATensor* XLA_API XLATensor_index(OpaqueXLATensor* input,
+                                         OpaqueXLATensorArrayRef indices,
+                                         int64_t start_dim) {
   return new XLATensor(XLATensor::index(*input, indices.array(), start_dim));
 }
 OpaqueString* XLATensor_ir_text(OpaqueXLATensor* a) {
@@ -436,214 +454,227 @@ OpaqueString* XLATensor_ir_text(OpaqueXLATensor* a) {
       swift_xla::ir::DumpUtil::ToText({a->GetIrValue().node.get()});
   return new std::string(ir_dag_text);
 }
-OpaqueXLATensor* XLATensor_is_finite(OpaqueXLATensor* input) {
+OpaqueXLATensor* XLA_API XLATensor_is_finite(OpaqueXLATensor* input) {
   return new XLATensor(XLATensor::is_finite(*input));
 }
-OpaqueXLATensor* XLATensor_is_inf(OpaqueXLATensor* input) {
+OpaqueXLATensor* XLA_API XLATensor_is_inf(OpaqueXLATensor* input) {
   return new XLATensor(XLATensor::is_inf(*input));
 }
-OpaqueXLATensor* XLATensor_is_nan(OpaqueXLATensor* input) {
+OpaqueXLATensor* XLA_API XLATensor_is_nan(OpaqueXLATensor* input) {
   return new XLATensor(XLATensor::is_nan(*input));
 }
-OpaqueXLATensor* XLATensor_le(OpaqueXLATensor* x, OpaqueXLATensor* y) {
+OpaqueXLATensor* XLA_API XLATensor_le(OpaqueXLATensor* x, OpaqueXLATensor* y) {
   return new XLATensor(XLATensor::le(*x, *y));
 }
-OpaqueXLATensor* XLATensor_lt(OpaqueXLATensor* x, OpaqueXLATensor* y) {
+OpaqueXLATensor* XLA_API XLATensor_lt(OpaqueXLATensor* x, OpaqueXLATensor* y) {
   return new XLATensor(XLATensor::lt(*x, *y));
 }
-OpaqueXLATensor* XLATensor_log(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_log(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::log(*a));
 }
-OpaqueXLATensor* XLATensor_log1p(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_log1p(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::log1p(*a));
 }
-OpaqueXLATensor* XLATensor_log_softmax(OpaqueXLATensor* a, int64_t dim) {
+OpaqueXLATensor* XLA_API XLATensor_log_softmax(OpaqueXLATensor* a, int64_t dim) {
   return new XLATensor(XLATensor::log_softmax(*a, dim, absl::nullopt));
 }
-OpaqueXLATensor* XLATensor_log_softmax_backward(OpaqueXLATensor* grad_output,
-                                                OpaqueXLATensor* output,
-                                                int64_t dim) {
+OpaqueXLATensor* XLA_API
+XLATensor_log_softmax_backward(OpaqueXLATensor* grad_output,
+                               OpaqueXLATensor* output, int64_t dim) {
   return new XLATensor(
       XLATensor::log_softmax_backward(*grad_output, *output, dim));
 }
-OpaqueXLATensor* XLATensor_logical_cast(OpaqueXLATensor* input,
-                                        enum XLATensorScalarType dest_type) {
+OpaqueXLATensor* XLA_API
+XLATensor_logical_cast(OpaqueXLATensor* input,
+                       enum XLATensorScalarType dest_type) {
   return new XLATensor(
       XLATensor::logical_cast(*input, ToScalarType(dest_type)));
 }
-OpaqueXLATensor* XLATensor_logicalAnd(OpaqueXLATensor* a, OpaqueXLATensor* b) {
+OpaqueXLATensor* XLA_API XLATensor_logicalAnd(OpaqueXLATensor* a,
+                                              OpaqueXLATensor* b) {
   return new XLATensor(XLATensor::logicalAnd(*a, *b));
 }
-OpaqueXLATensor* XLATensor_logicalNot(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_logicalNot(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::logicalNot(*a));
 }
-OpaqueXLATensor* XLATensor_logicalOr(OpaqueXLATensor* a, OpaqueXLATensor* b) {
+OpaqueXLATensor* XLA_API XLATensor_logicalOr(OpaqueXLATensor* a,
+                                             OpaqueXLATensor* b) {
   return new XLATensor(XLATensor::logicalOr(*a, *b));
 }
-OpaqueXLATensor* XLATensor_matmul(OpaqueXLATensor* a, OpaqueXLATensor* b) {
+OpaqueXLATensor* XLA_API XLATensor_matmul(OpaqueXLATensor* a,
+                                          OpaqueXLATensor* b) {
   return new XLATensor(XLATensor::matmul(*a, *b));
 }
-OpaqueXLATensor* XLATensor_max(OpaqueXLATensor* input, int64_t dim,
-                               bool keepdim) {
+OpaqueXLATensor* XLA_API XLATensor_max(OpaqueXLATensor* input, int64_t dim,
+                                       bool keepdim) {
   return new XLATensor(std::get<0>(XLATensor::max(*input, dim, keepdim)));
 }
-OpaqueXLATensor* XLATensor_maximum(OpaqueXLATensor* a, OpaqueXLATensor* b) {
+OpaqueXLATensor* XLA_API XLATensor_maximum(OpaqueXLATensor* a,
+                                           OpaqueXLATensor* b) {
   return new XLATensor(XLATensor::max(*a, *b));
 }
-OpaqueXLATensor* XLATensor_mean(OpaqueXLATensor* a, Int64ArrayRef dims,
-                                bool keep_reduced_dimensions,
-                                Optional_XLAScalarType dtype) {
+OpaqueXLATensor* XLA_API XLATensor_mean(OpaqueXLATensor* a, Int64ArrayRef dims,
+                                        bool keep_reduced_dimensions,
+                                        Optional_XLAScalarType dtype) {
   return new XLATensor(XLATensor::mean(*a, XlaHelpers::I64List(dims.slice()),
                                        keep_reduced_dimensions, dtype.value()));
 }
-OpaqueXLATensor* XLATensor_min(OpaqueXLATensor* input, int64_t dim,
-                               bool keepdim) {
+OpaqueXLATensor* XLA_API
+XLATensor_min(OpaqueXLATensor* input, int64_t dim, bool keepdim) {
   return new XLATensor(std::get<0>(XLATensor::min(*input, dim, keepdim)));
 }
-OpaqueXLATensor* XLATensor_minimum(OpaqueXLATensor* a, OpaqueXLATensor* b) {
+OpaqueXLATensor* XLA_API
+XLATensor_minimum(OpaqueXLATensor* a, OpaqueXLATensor* b) {
   return new XLATensor(XLATensor::min(*a, *b));
 }
-OpaqueXLATensor* XLATensor_mul(OpaqueXLATensor* a, OpaqueXLATensor* b) {
+OpaqueXLATensor* XLA_API XLATensor_mul(OpaqueXLATensor* a, OpaqueXLATensor* b) {
   return new XLATensor(XLATensor::mul(*a, *b));
 }
-OpaqueXLATensor* XLATensor_mm(OpaqueXLATensor* a, OpaqueXLATensor* b) {
+OpaqueXLATensor* XLA_API XLATensor_mm(OpaqueXLATensor* a, OpaqueXLATensor* b) {
   return new XLATensor(XLATensor::mm(*a, *b));
 }
-OpaqueXLATensor* XLATensor_ne(OpaqueXLATensor* a, OpaqueXLATensor* b) {
+OpaqueXLATensor* XLA_API XLATensor_ne(OpaqueXLATensor* a, OpaqueXLATensor* b) {
   return new XLATensor(XLATensor::ne(*a, *b));
 }
-OpaqueXLATensor* XLATensor_neg(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_neg(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::neg(*a));
 }
-OpaqueXLATensor* XLATensor_nll_loss(OpaqueXLATensor* input,
-                                    OpaqueXLATensor* target, int ignore_index) {
+OpaqueXLATensor* XLA_API
+XLATensor_nll_loss(OpaqueXLATensor* input, OpaqueXLATensor* target,
+                   int ignore_index) {
   XLATensor weight;
   return new XLATensor(XLATensor::nll_loss(*input, *target, weight,
                                            at::Reduction::Mean, ignore_index));
 }
-OpaqueXLATensor* XLATensor_permute_value(OpaqueXLATensor* a,
-                                         Int64ArrayRef arr) {
+OpaqueXLATensor* XLA_API
+XLATensor_permute_value(OpaqueXLATensor* a, Int64ArrayRef arr) {
   return new XLATensor(XLATensor::permute_value(*a, arr.slice()));
 }
-OpaqueXLATensor* XLATensor_physical_cast(OpaqueXLATensor* input,
-                                         enum XLATensorScalarType dest_type) {
+OpaqueXLATensor* XLA_API
+XLATensor_physical_cast(OpaqueXLATensor* input,
+                        enum XLATensorScalarType dest_type) {
   return new XLATensor(
       XLATensor::physical_cast(*input, ToScalarType(dest_type)));
 }
-OpaqueXLATensor* XLATensor_pow(OpaqueXLATensor* base,
-                               OpaqueXLATensor* exponent) {
+OpaqueXLATensor* XLA_API XLATensor_pow(OpaqueXLATensor* base,
+                                       OpaqueXLATensor* exponent) {
   return new XLATensor(XLATensor::pow(*base, *exponent));
 }
-OpaqueXLATensor* XLATensor_prod(OpaqueXLATensor* a, Int64ArrayRef dims,
-                                bool keep_reduced_dimensions,
-                                Optional_XLAScalarType dtype) {
+OpaqueXLATensor* XLA_API XLATensor_prod(OpaqueXLATensor* a, Int64ArrayRef dims,
+                                        bool keep_reduced_dimensions,
+                                        Optional_XLAScalarType dtype) {
   return new XLATensor(XLATensor::prod(*a, XlaHelpers::I64List(dims.slice()),
                                        keep_reduced_dimensions, dtype.value()));
 }
-OpaqueXLATensor_pair XLATensor_qr(OpaqueXLATensor* input, bool some) {
+OpaqueXLATensor_pair XLA_API XLATensor_qr(OpaqueXLATensor* input, bool some) {
   OpaqueXLATensor_pair result;
   auto output = XLATensor::qr(*input, some);
   result.x = new XLATensor(std::get<0>(output));
   result.y = new XLATensor(std::get<1>(output));
   return result;
 }
-OpaqueXLATensor* XLATensor_relu(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_relu(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::relu(*a));
 }
-OpaqueXLATensor* XLATensor_rem(OpaqueXLATensor* a, OpaqueXLATensor* b) {
+OpaqueXLATensor* XLA_API XLATensor_rem(OpaqueXLATensor* a, OpaqueXLATensor* b) {
   return new XLATensor(XLATensor::rem(*a, *b));
 }
-OpaqueXLATensor* XLATensor_repeat(OpaqueXLATensor* input,
-                                  Int64ArrayRef repeats) {
+OpaqueXLATensor* XLA_API XLATensor_repeat(OpaqueXLATensor* input,
+                                          Int64ArrayRef repeats) {
   return new XLATensor(
       XLATensor::repeat(*input, XlaHelpers::I64List(repeats.slice())));
 }
-OpaqueXLATensor* XLATensor_resize_value(OpaqueXLATensor* a, Int64ArrayRef arr) {
+OpaqueXLATensor* XLA_API XLATensor_resize_value(OpaqueXLATensor* a,
+                                                Int64ArrayRef arr) {
   return new XLATensor(
       XLATensor::resize_value(*a, XlaHelpers::I64List(arr.slice())));
 }
-OpaqueXLATensor* XLATensor_round_to_even(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_round_to_even(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::round_to_even(*a));
 }
-OpaqueXLATensor* XLATensor_rsqrt(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_rsqrt(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::rsqrt(*a));
 }
-OpaqueXLATensor* XLATensor_select(OpaqueXLATensor* a, int64_t dim,
-                                  int64_t index) {
+OpaqueXLATensor* XLA_API XLATensor_select(OpaqueXLATensor* a, int64_t dim,
+                                          int64_t index) {
   return new XLATensor(XLATensor::select(*a, dim, index));
 }
-OpaqueXLATensor* XLATensor_sigmoid(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_sigmoid(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::sigmoid(*a));
 }
-OpaqueXLATensor* XLATensor_sign(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_sign(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::sign(*a));
 }
-OpaqueXLATensor* XLATensor_sin(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_sin(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::sin(*a));
 }
-OpaqueXLATensor* XLATensor_sinh(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_sinh(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::sinh(*a));
 }
-OpaqueXLATensor* XLATensor_slice(OpaqueXLATensor* a, int64_t dim, int64_t start,
-                                 int64_t end, int64_t step) {
+OpaqueXLATensor* XLA_API
+XLATensor_slice(OpaqueXLATensor* a, int64_t dim, int64_t start, int64_t end,
+                int64_t step) {
   return new XLATensor(XLATensor::slice(*a, dim, start, end, step));
 }
-OpaqueXLATensor* XLATensor_softmax(OpaqueXLATensor* a, int64_t dim) {
+OpaqueXLATensor* XLA_API XLATensor_softmax(OpaqueXLATensor* a, int64_t dim) {
   return new XLATensor(XLATensor::softmax(*a, dim, absl::nullopt));
 }
-OpaqueXLATensorArrayRef XLATensor_split_with_sizes(OpaqueXLATensor* input,
-                                                   Int64ArrayRef split_size,
-                                                   int64_t dim) {
+OpaqueXLATensorArrayRef XLA_API
+XLATensor_split_with_sizes(OpaqueXLATensor* input, Int64ArrayRef split_size,
+                           int64_t dim) {
   auto chunks = XLATensor::split_with_sizes(
       *input, XlaHelpers::I64List(split_size.slice()), dim);
   return ConvertTensorList(chunks);
 }
-OpaqueXLATensor* XLATensor_sqrt(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_sqrt(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::sqrt(*a));
 }
-OpaqueXLATensor* XLATensor_squeeze(OpaqueXLATensor* a, int64_t dim) {
+OpaqueXLATensor* XLA_API XLATensor_squeeze(OpaqueXLATensor* a, int64_t dim) {
   return new XLATensor(XLATensor::squeeze(*a, dim));
 }
-OpaqueXLATensor* XLATensor_stack(OpaqueXLATensorArrayRef tensors, int64_t dim) {
+OpaqueXLATensor* XLA_API
+XLATensor_stack(OpaqueXLATensorArrayRef tensors, int64_t dim) {
   return new XLATensor(XLATensor::stack(tensors.array(), dim));
 }
-OpaqueXLATensor* XLATensor_sub(OpaqueXLATensor* a, OpaqueXLATensor* b) {
+OpaqueXLATensor* XLA_API XLATensor_sub(OpaqueXLATensor* a, OpaqueXLATensor* b) {
   return new XLATensor(XLATensor::sub(*a, *b));
 }
-OpaqueXLATensor* XLATensor_sum(OpaqueXLATensor* a, Int64ArrayRef dims,
-                               bool keep_reduced_dimensions,
-                               Optional_XLAScalarType dtype) {
+OpaqueXLATensor* XLA_API XLATensor_sum(OpaqueXLATensor* a, Int64ArrayRef dims,
+                                       bool keep_reduced_dimensions,
+                                       Optional_XLAScalarType dtype) {
   return new XLATensor(XLATensor::sum(*a, XlaHelpers::I64List(dims.slice()),
                                       keep_reduced_dimensions, dtype.value()));
 }
-OpaqueXLATensor* XLATensor_tan(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_tan(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::tan(*a));
 }
-OpaqueXLATensor* XLATensor_tanh(OpaqueXLATensor* a) {
+OpaqueXLATensor* XLA_API XLATensor_tanh(OpaqueXLATensor* a) {
   return new XLATensor(XLATensor::tanh(*a));
 }
-OpaqueXLATensor* XLATensor_tf_Conv(OpaqueXLATensor* input,
-                                   OpaqueXLATensor* filter, bool depthwise,
-                                   Int64ArrayRef strides, TFPadding padding,
-                                   Int64ArrayRef explicit_paddings,
-                                   TFDataFormat data_format,
-                                   Int64ArrayRef dilations) {
+OpaqueXLATensor* XLA_API
+XLATensor_tf_Conv(OpaqueXLATensor* input, OpaqueXLATensor* filter,
+                  bool depthwise, Int64ArrayRef strides, TFPadding padding,
+                  Int64ArrayRef explicit_paddings, TFDataFormat data_format,
+                  Int64ArrayRef dilations) {
   return new XLATensor(
       XLATensor::tf_Conv(*input, *filter, depthwise, strides.slice(),
                          ToTFPadding(padding), explicit_paddings.slice(),
                          x10::ToTFFormat(data_format), dilations.slice()));
 }
-OpaqueXLATensor* XLATensor_tf_ConvBackpropFilter(
-    OpaqueXLATensor* input, Int64ArrayRef filter_sizes,
-    OpaqueXLATensor* out_backprop, bool depthwise, Int64ArrayRef strides,
-    enum TFPadding padding, Int64ArrayRef explicit_paddings,
-    enum TFDataFormat data_format, Int64ArrayRef dilations) {
+OpaqueXLATensor* XLA_API
+XLATensor_tf_ConvBackpropFilter(OpaqueXLATensor* input,
+                                Int64ArrayRef filter_sizes,
+                                OpaqueXLATensor* out_backprop, bool depthwise,
+                                Int64ArrayRef strides, enum TFPadding padding,
+                                Int64ArrayRef explicit_paddings,
+                                enum TFDataFormat data_format,
+                                Int64ArrayRef dilations) {
   return new XLATensor(XLATensor::tf_ConvBackpropFilter(
       *input, filter_sizes.slice(), *out_backprop, depthwise, strides.slice(),
       ToTFPadding(padding), explicit_paddings.slice(),
       x10::ToTFFormat(data_format), dilations.slice()));
 }
-OpaqueXLATensor* XLATensor_tf_ConvBackpropInput(
+OpaqueXLATensor* XLA_API XLATensor_tf_ConvBackpropInput(
     Int64ArrayRef input_sizes, OpaqueXLATensor* filter,
     OpaqueXLATensor* out_backprop, bool depthwise, Int64ArrayRef strides,
     enum TFPadding padding, Int64ArrayRef explicit_paddings,
@@ -653,34 +684,34 @@ OpaqueXLATensor* XLATensor_tf_ConvBackpropInput(
       ToTFPadding(padding), explicit_paddings.slice(),
       x10::ToTFFormat(data_format), dilations.slice()));
 }
-OpaqueXLATensor* XLATensor_tf_MirrorPad(OpaqueXLATensor* input,
-                                        Int64ArrayRef padding,
-                                        enum TFMirrorPadMode mode) {
+OpaqueXLATensor* XLA_API XLATensor_tf_MirrorPad(OpaqueXLATensor* input,
+                                                Int64ArrayRef padding,
+                                                enum TFMirrorPadMode mode) {
   return new XLATensor(XLATensor::tf_MirrorPad(
       *input, XlaHelpers::I64List(padding.slice()), ToTFMirrorPadMode(mode)));
 }
-OpaqueXLATensor* XLATensor_tf_MirrorPadGrad(OpaqueXLATensor* grad_output,
-                                            Int64ArrayRef input_size,
-                                            Int64ArrayRef padding,
-                                            enum TFMirrorPadMode mode) {
+OpaqueXLATensor* XLA_API
+XLATensor_tf_MirrorPadGrad(OpaqueXLATensor* grad_output,
+                           Int64ArrayRef input_size, Int64ArrayRef padding,
+                           enum TFMirrorPadMode mode) {
   return new XLATensor(XLATensor::tf_MirrorPadGrad(
       *grad_output, XlaHelpers::I64List(input_size.slice()),
       XlaHelpers::I64List(padding.slice()), ToTFMirrorPadMode(mode)));
 }
-OpaqueXLATensor* XLATensor_tf_OneHot(OpaqueXLATensor* indices,
-                                     OpaqueXLATensor* on_value,
-                                     OpaqueXLATensor* off_value, int64_t depth,
-                                     int64_t axis) {
+OpaqueXLATensor* XLA_API XLATensor_tf_OneHot(OpaqueXLATensor* indices,
+                                             OpaqueXLATensor* on_value,
+                                             OpaqueXLATensor* off_value,
+                                             int64_t depth, int64_t axis) {
   return new XLATensor(
       XLATensor::tf_OneHot(*indices, *on_value, *off_value, depth, axis));
 }
-OpaqueXLATensor* XLATensor_tf_StatelessRandomNormal(
+OpaqueXLATensor* XLA_API XLATensor_tf_StatelessRandomNormal(
     Int64ArrayRef size, OpaqueXLATensor* seeds, const struct CDevice device,
     enum XLATensorScalarType type) {
   return new XLATensor(XLATensor::tf_StatelessRandomNormal(
       size.slice(), *seeds, ConvertDevice(device), ToScalarType(type)));
 }
-OpaqueXLATensor* XLATensor_tf_StatelessRandomUniform(
+OpaqueXLATensor* XLA_API XLATensor_tf_StatelessRandomUniform(
     Int64ArrayRef size, OpaqueXLATensor* seeds, OpaqueXLATensor* minvalue,
     OpaqueXLATensor* maxvalue, const CDevice device,
     enum XLATensorScalarType type) {
@@ -688,45 +719,46 @@ OpaqueXLATensor* XLATensor_tf_StatelessRandomUniform(
       size.slice(), *seeds, *minvalue, *maxvalue, ConvertDevice(device),
       ToScalarType(type)));
 }
-OpaqueXLATensor* XLATensor_tf_UnsortedSegmentSum(OpaqueXLATensor* data,
-                                                 OpaqueXLATensor* indices,
-                                                 int64_t num_segments) {
+OpaqueXLATensor* XLA_API
+XLATensor_tf_UnsortedSegmentSum(OpaqueXLATensor* data, OpaqueXLATensor* indices,
+                                int64_t num_segments) {
   return new XLATensor(
       XLATensor::tf_UnsortedSegmentSum(*data, *indices, num_segments));
 }
-OpaqueXLATensor* XLATensor_threshold_backward(OpaqueXLATensor* grad_output,
-                                              OpaqueXLATensor* input,
-                                              float threshold) {
+OpaqueXLATensor* XLA_API
+XLATensor_threshold_backward(OpaqueXLATensor* grad_output,
+                             OpaqueXLATensor* input, float threshold) {
   return new XLATensor(
       XLATensor::threshold_backward(*grad_output, *input, threshold));
 }
-OpaqueXLATensor* XLATensor_truncated_normal(OpaqueXLATensor* input) {
+OpaqueXLATensor* XLA_API XLATensor_truncated_normal(OpaqueXLATensor* input) {
   return new XLATensor(XLATensor::xla_truncated_normal(*input));
 }
-OpaqueXLATensor* XLATensor_to(OpaqueXLATensor* a, const CDevice* device,
-                              Optional_XLAScalarType dtype) {
+OpaqueXLATensor* XLA_API XLATensor_to(OpaqueXLATensor* a, const CDevice* device,
+                                      Optional_XLAScalarType dtype) {
   return new XLATensor(XLATensor::to(*a, AsOptional(device), dtype.value()));
 }
-OpaqueXLATensor* XLATensor_update_slice(OpaqueXLATensor* input,
-                                        OpaqueXLATensor* source,
-                                        Int64ArrayRef base_indices) {
+OpaqueXLATensor* XLA_API XLATensor_update_slice(OpaqueXLATensor* input,
+                                                OpaqueXLATensor* source,
+                                                Int64ArrayRef base_indices) {
   return new XLATensor(
       XLATensor::update_slice(*input, *source, base_indices.slice()));
 }
-OpaqueXLATensor* XLATensor_where(OpaqueXLATensor* condition,
-                                 OpaqueXLATensor* input,
-                                 OpaqueXLATensor* other) {
+OpaqueXLATensor* XLA_API XLATensor_where(OpaqueXLATensor* condition,
+                                         OpaqueXLATensor* input,
+                                         OpaqueXLATensor* other) {
   return new XLATensor(XLATensor::where(*condition, *input, *other));
 }
-OpaqueXLATensor* XLATensor_xla_slice(OpaqueXLATensor* input,
-                                     Int64ArrayRef begin, Int64ArrayRef end,
-                                     Int64ArrayRef strides) {
+OpaqueXLATensor* XLA_API XLATensor_xla_slice(OpaqueXLATensor* input,
+                                             Int64ArrayRef begin,
+                                             Int64ArrayRef end,
+                                             Int64ArrayRef strides) {
   return new XLATensor(XLATensor::xla_slice(*input, begin.slice(), end.slice(),
                                             strides.slice()));
 }
-OpaqueXLATensor* XLATensor_xla_pad(OpaqueXLATensor* input,
-                                   XLAScalar padding_value,
-                                   PaddingConfig padding_config) {
+OpaqueXLATensor* XLA_API XLATensor_xla_pad(OpaqueXLATensor* input,
+                                           XLAScalar padding_value,
+                                           PaddingConfig padding_config) {
   xla::PaddingConfig xla_padding_config;
   for (size_t i = 0; i < padding_config.count; ++i) {
     xla::PaddingConfig::PaddingConfigDimension* dims =
@@ -739,10 +771,10 @@ OpaqueXLATensor* XLATensor_xla_pad(OpaqueXLATensor* input,
   return new XLATensor(
       XLATensor::xla_pad(*input, atScalar(padding_value), xla_padding_config));
 }
-struct CDevice XLATensor_device(OpaqueXLATensor* t) {
+struct CDevice XLA_API XLATensor_device(OpaqueXLATensor* t) {
   return ConvertDevice(t->GetDevice());
 }
-OpaqueXLATensor* XLATensor_rand(Int64ArrayRef size, int64_t seed) {
+OpaqueXLATensor* XLA_API XLATensor_rand(Int64ArrayRef size, int64_t seed) {
   std::vector<int64_t> size_vec(size.slice().begin(), size.slice().end());
   uint64_t numel = std::accumulate(size_vec.begin(), size_vec.end(),
                                    uint64_t(1), std::multiplies<int64_t>());
@@ -756,16 +788,16 @@ OpaqueXLATensor* XLATensor_rand(Int64ArrayRef size, int64_t seed) {
   at::Tensor t(std::move(elements), std::move(size_vec));
   return new XLATensor(XLATensor::Create(t, *swift_xla::GetDefaultDevice()));
 }
-void SeededRandomShuffle(size_t* data, size_t size, int64_t seed) {
+void XLA_API SeededRandomShuffle(size_t* data, size_t size, int64_t seed) {
   std::mt19937 gen(seed);
   std::shuffle(data, data + size, gen);
 }
-void SetMatMulPrecision(bool use_full_precision) {
+void XLA_API SetMatMulPrecision(bool use_full_precision) {
   XlaHelpers::set_mat_mul_precision(use_full_precision
                                         ? xla::PrecisionConfig::HIGHEST
                                         : xla::PrecisionConfig::DEFAULT);
 }
-StridedSliceSpec* ComputeIndexingBoundsAndStrides(
+StridedSliceSpec* XLA_API ComputeIndexingBoundsAndStrides(
     Int64ArrayRef input_sizes, Int64ArrayRef begin, Int64ArrayRef end,
     Int64ArrayRef strides, int32_t begin_mask, int32_t end_mask,
     int32_t ellipsis_mask, int32_t new_axis_mask, int32_t shrink_axis_mask) {
@@ -780,8 +812,8 @@ StridedSliceSpec* ComputeIndexingBoundsAndStrides(
       Int64ArrayRefFromCollection(bounds_and_strides.processing_sizes),
       Int64ArrayRefFromCollection(bounds_and_strides.final_sizes)};
 }
-void PrintMetrics() {
+void XLA_API PrintMetrics() {
   LOG(INFO) << "Metrics:\n" << xla::metrics::CreateMetricReport();
 }
-void DeleteString(OpaqueString* str) { delete str; }
-const char* GetStringCStr(OpaqueString* str) { return str->c_str(); }
+void XLA_API DeleteString(OpaqueString* str) { delete str; }
+const char* XLA_API GetStringCStr(OpaqueString* str) { return str->c_str(); }


### PR DESCRIPTION
It is not possible to do the same type of filtering for exports on
Windows.  This explicitly annotates the APIs that are public as such
ensuring that they are available to users (i.e. Swift).  This is needed
to enable building for Windows again.