### PR TITLE
X10: use `CTensorFlow`

### DIFF
--- a/Sources/CX10/x10/device_wrapper.h
+++ b/Sources/CX10/x10/device_wrapper.h
@@ -1,0 +1,1 @@
+../../x10/swift_bindings/device_wrapper.h

--- a/Sources/CX10/x10/xla_tensor_tf_ops.h
+++ b/Sources/CX10/x10/xla_tensor_tf_ops.h
@@ -1,0 +1,1 @@
+../../x10/swift_bindings/xla_tensor_tf_ops.h

--- a/Sources/CX10/x10/xla_tensor_wrapper.h
+++ b/Sources/CX10/x10/xla_tensor_wrapper.h
@@ -1,0 +1,1 @@
+../../x10/swift_bindings/xla_tensor_wrapper.h

--- a/Sources/x10/CMakeLists.txt
+++ b/Sources/x10/CMakeLists.txt
@@ -3,6 +3,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 add_library(x10_device SHARED
   swift_bindings/Device.swift)
 target_link_libraries(x10_device PRIVATE
+  CTensorFlow
   x10)
 
 add_library(x10_tensor SHARED
@@ -84,6 +85,7 @@ set_target_properties(x10_tensor PROPERTIES
 target_compile_definitions(x10_tensor PRIVATE
   USING_X10_BACKEND)
 target_link_libraries(x10_tensor PUBLIC
+  CTensorFlow
   x10_device
   Tensor)
 target_link_libraries(x10_tensor PRIVATE

--- a/Tests/TensorFlowTests/CMakeLists.txt
+++ b/Tests/TensorFlowTests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(TensorFlowTests
   OperatorTests/MatrixTests.swift
   OperatorTests/NNTests.swift)
 target_link_libraries(TensorFlowTests PUBLIC
+  CTensorFlow
   TensorFlow
   Tensor
   XCTest)


### PR DESCRIPTION
Add the `CTensorFlow` dependency as the X10 module map is merged into
`CTensorFlow`.  Until they are split up, this allows building
`x10_device` again with non-bundled toolchains.