### PR TITLE
fix Tensor(shape:scalars:) derivative

### DIFF
--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -428,7 +428,7 @@ extension Tensor where Scalar: TensorFlowFloatingPoint {
     shape: TensorShape, scalars: [Scalar], on device: Device = .default
   ) -> (value: Tensor, pullback: (Tensor) -> Array<Scalar>.TangentVector) {
     (
-      value: Tensor(scalars, on: device),
+      value: Tensor(shape: shape, scalars: scalars, on: device),
       pullback: { v in
         Array<Scalar>.TangentVector(v.scalars)
       }

--- a/Tests/TensorFlowTests/TensorTests.swift
+++ b/Tests/TensorFlowTests/TensorTests.swift
@@ -90,6 +90,36 @@ final class TensorTests: XCTestCase {
     XCTAssertTrue(shape3 == (shape2 + shape2))
   }
 
+  func testInitShapeScalars() {
+    XCTAssertEqual(
+      Tensor<Float>(shape: [2, 2], scalars: [1, 2, 3, 4]),
+      Tensor<Float>([[1, 2], [3, 4]])
+    )
+  }
+
+  func testInitShapeScalarsDerivative() {
+    let (value, pullback) = valueWithPullback(at: [1, 2, 3, 4]) {
+      Tensor<Float>(shape: [2, 2], scalars: $0)
+    }
+    XCTAssertEqual(value, Tensor<Float>([[1, 2], [3, 4]]))
+    XCTAssertEqual(
+      pullback(Tensor([[1, 0], [0, 0]])),
+      Array.DifferentiableView([1, 0, 0, 0])
+    )
+    XCTAssertEqual(
+      pullback(Tensor([[0, 1], [0, 0]])),
+      Array.DifferentiableView([0, 1, 0, 0])
+    )
+    XCTAssertEqual(
+      pullback(Tensor([[0, 0], [1, 0]])),
+      Array.DifferentiableView([0, 0, 1, 0])
+    )
+    XCTAssertEqual(
+      pullback(Tensor([[0, 0], [0, 1]])),
+      Array.DifferentiableView([0, 0, 0, 1])
+    )
+  }
+
   static var allTests = [
     ("testSimpleCond", testSimpleCond),
     ("testRankGetter", testRankGetter),
@@ -97,5 +127,7 @@ final class TensorTests: XCTestCase {
     ("testTensorShapeDescription", testTensorShapeDescription),
     ("testEquality", testEquality),
     ("testTensorShapeCollectionOperations", testTensorShapeCollectionOperations),
+    ("testInitShapeScalars", testInitShapeScalars),
+    ("testInitShapeScalarsDerivative", testInitShapeScalarsDerivative)
   ]
 }


### PR DESCRIPTION
The derivative was wrong, discovered [here](https://github.com/tensorflow/swift-apis/issues/815#issuecomment-614555116).