### PR TITLE
Return an XLA device

### DIFF
--- a/Sources/x10/swift_bindings/Device.swift
+++ b/Sources/x10/swift_bindings/Device.swift
@@ -132,8 +132,7 @@ public struct Device {
 
   /// The default XLA device.
   public static var defaultXLA: Device {
-    let cdevice = DefaultDevice()
-    return cdevice.device
+    return Device(kind: .CPU, ordinal: 0, backend: .XLA)
   }
 
   /// The current TF Eager device.


### PR DESCRIPTION
Fixes #843 

`Device.defaultXLA` is currently returning the default device, which is TF_EAGER. It should return an XLA device.