### PR TITLE
build: add X10 to the library search path

### DIFF
--- a/Sources/CX10/CMakeLists.txt
+++ b/Sources/CX10/CMakeLists.txt
@@ -3,6 +3,8 @@ if(NOT USE_BUNDLED_CTENSORFLOW)
   target_include_directories(CTensorFlow INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
+target_link_directories(CTensorFlow INTERFACE
+  $<TARGET_FILE_DIR:x10>)
 target_link_libraries(CTensorFlow INTERFACE
   x10)
 


### PR DESCRIPTION
This is needed for the Swift autolinking to work.