### PR TITLE
Make tensors be on consistent device for bandpart ops

### DIFF
--- a/Sources/TensorFlow/Bindings/RawOpsDispatching.swift
+++ b/Sources/TensorFlow/Bindings/RawOpsDispatching.swift
@@ -1977,12 +1977,13 @@ public typealias Raw = _Raw
         commonBackend(input.handle.backend, numLower.handle.backend), numUpper.handle.backend)
       {
       case .XLA:
+        let device = input.device
         let input = Tensor<T>(copying: input, to: .defaultTFEager)
         let numLower = Tensor<Int64>(copying: numLower, to: .defaultTFEager)
         let numUpper = Tensor<Int64>(copying: numUpper, to: .defaultTFEager)
         return Tensor<T>(
           copying: _RawTFEager.batchMatrixBandPart(input, numLower: numLower, numUpper: numUpper),
-          to: numUpper.device)
+          to: device)
       case .TF_EAGER:
         return _RawTFEager.batchMatrixBandPart(input, numLower: numLower, numUpper: numUpper)
       }
@@ -16735,12 +16736,13 @@ public typealias Raw = _Raw
         commonBackend(input.handle.backend, numLower.handle.backend), numUpper.handle.backend)
       {
       case .XLA:
+        let device = input.device
         let input = Tensor<T>(copying: input, to: .defaultTFEager)
         let numLower = Tensor<Tindex>(copying: numLower, to: .defaultTFEager)
         let numUpper = Tensor<Tindex>(copying: numUpper, to: .defaultTFEager)
         return Tensor<T>(
           copying: _RawTFEager.matrixBandPart(input, numLower: numLower, numUpper: numUpper),
-          to: numUpper.device)
+          to: device)
       case .TF_EAGER:
         return _RawTFEager.matrixBandPart(input, numLower: numLower, numUpper: numUpper)
       }

--- a/Sources/TensorFlow/Operators/LinearAlgebra.swift
+++ b/Sources/TensorFlow/Operators/LinearAlgebra.swift
@@ -106,8 +106,8 @@ extension Tensor where Scalar: TensorFlowNumeric {
   @differentiable( where Scalar: TensorFlowFloatingPoint)
   public func bandPart(subdiagonalCount: Int, superdiagonalCount: Int) -> Tensor {
     precondition(rank >= 2, "The tensor must have at least rank 2.")
-    let lower = Tensor<Int32>(Int32(subdiagonalCount))
-    let upper = Tensor<Int32>(Int32(superdiagonalCount))
+    let lower = Tensor<Int32>(Int32(subdiagonalCount), on: self.device)
+    let upper = Tensor<Int32>(Int32(superdiagonalCount), on: self.device)
     return _Raw.matrixBandPart(self, numLower: lower, numUpper: upper)
   }
 }


### PR DESCRIPTION
This is a bug detected while training GPT2 on TPU with x10. We saw an error complaining non-x10 tensor mixed in the model. It turns out bandPart is the cause which is used by GPT2 [here](https://github.com/tensorflow/swift-models/blob/fe419a9d4b9eda9dffdb384567b2121d83107d3e/Models/Text/GPT2/TransformerLM.swift#L120). 
The PR is to fix it.