### PR TITLE
CTensorFlow: add library search path for autolinking

### DIFF
--- a/Sources/CTensorFlow/CMakeLists.txt
+++ b/Sources/CTensorFlow/CMakeLists.txt
@@ -4,9 +4,13 @@ if(NOT USE_BUNDLED_CTENSORFLOW)
     ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 if(BUILD_X10)
+  target_link_directories(CTensorFlow INTERFACE
+    $<TARGET_FILE_DIR:x10>)
   target_link_libraries(CTensorFlow INTERFACE
     x10)
 else()
+  target_link_directories(CTensorFlow INTERFACE
+    $<TARGET_FILE_DIR:tensorflow>)
   target_link_libraries(CTensorFlow INTERFACE
     tensorflow)
 endif()


### PR DESCRIPTION
Because autolinking is needed for swift-models/s-p-m, we need to
explicitly add the library search path to the interface linking.