### PR TITLE
Deprecate `Layer.call(_:)`.

### DIFF
--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -46,6 +46,7 @@ public protocol Layer: Module where Input: Differentiable {
 }
 
 extension Layer {
+  @available(*, deprecated, renamed: "callAsFunction(_:)")
   @differentiable
   public func call(_ input: Input) -> Output {
     callAsFunction(input)


### PR DESCRIPTION
`Layer.call(_:)` was added as a temporary shim while [SE-0253](https://github.com/apple/swift-evolution/blob/master/proposals/0253-callable.md) was under review.
`Layer.callAsFunction(_:)` is the permanent name.