### PR TITLE
Silence warning.

### DIFF
--- a/Sources/TensorFlow/Bindings/EagerExecution.swift
+++ b/Sources/TensorFlow/Bindings/EagerExecution.swift
@@ -66,7 +66,7 @@ internal struct TFE_Op: TFTensorOperation {
   @inlinable @inline(__always)
   internal func addInputList<T: TensorArrayProtocol>(_ input: T) {
     let count = input._tensorHandleCount
-    var buffer = UnsafeMutableBufferPointer<CTensorHandle>.allocate(capacity: Int(count))
+    let buffer = UnsafeMutableBufferPointer<CTensorHandle>.allocate(capacity: Int(count))
     defer { buffer.deallocate() }
     input._unpackTensorHandles(into: buffer.baseAddress)
     for i in 0..<Int(count) {

--- a/Sources/TensorFlow/Bindings/EagerExecution.swift.gyb
+++ b/Sources/TensorFlow/Bindings/EagerExecution.swift.gyb
@@ -66,7 +66,7 @@ internal struct TFE_Op: TFTensorOperation {
     @inlinable @inline(__always)
     internal func addInputList<T: TensorArrayProtocol>(_ input: T) {
         let count = input._tensorHandleCount
-        var buffer = UnsafeMutableBufferPointer<CTensorHandle>.allocate(capacity: Int(count))
+        let buffer = UnsafeMutableBufferPointer<CTensorHandle>.allocate(capacity: Int(count))
         defer { buffer.deallocate() }
         input._unpackTensorHandles(into: buffer.baseAddress)
         for i in 0..<Int(count) {


### PR DESCRIPTION
Silences:
```
swift-apis/Sources/TensorFlow/Bindings/EagerExecution.swift:69:9: warning: variable 'buffer' was never mutated; consider changing to 'let' constant
    var buffer = UnsafeMutableBufferPointer<CTensorHandle>.allocate(capacity: Int(count))
    ~~~ ^
    let
```