### PR TITLE
build: only install X10 if we built it locally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ if(BUILD_TESTING)
   add_subdirectory(Tests)
 endif()
 
-if(BUILD_X10)
+if(BUILD_X10 AND NOT X10_FOUND AND NOT USE_BUNDLED_X10)
   get_swift_host_os(host_os)
   install(FILES ${SOURCE_DIR}/bazel-bin/tensorflow/compiler/tf2xla/xla_tensor/${CMAKE_SHARED_LIBRARY_PREFIX}x10${CMAKE_SHARED_LIBRARY_SUFFIX}
     DESTINATION lib/swift/${host_os})


### PR DESCRIPTION
If x10 was built externally, the just built version will not be present.
Ensure that we guard the installation with the same condition.