### PR TITLE
Dropout fix: tensors involed in mul should be on same device

### DIFF
--- a/Sources/TensorFlow/Layers/Dropout.swift
+++ b/Sources/TensorFlow/Layers/Dropout.swift
@@ -17,10 +17,10 @@ extension Tensor where Scalar: TensorFlowFloatingPoint {
   // TODO: Remove the underscore once `droppingOut(probability:)` has been removed.
   @differentiable(wrt: self where Scalar: Differentiable)
   fileprivate func _droppingOut(probability: Double) -> Tensor {
-    let noise = Tensor(randomUniform: shape)
+    let noise = Tensor(randomUniform: shape, on: device)
     let keepMask = noise .>= Scalar(probability)
     let keepProbability = Scalar(1.0 - probability)
-    return self * Tensor(copying: Tensor(keepMask), to: device) / Tensor(keepProbability, on: device)
+    return self * Tensor(keepMask) / Tensor(keepProbability, on: device)
   }
 }
 

--- a/Sources/TensorFlow/Layers/Dropout.swift
+++ b/Sources/TensorFlow/Layers/Dropout.swift
@@ -20,7 +20,7 @@ extension Tensor where Scalar: TensorFlowFloatingPoint {
     let noise = Tensor(randomUniform: shape)
     let keepMask = noise .>= Scalar(probability)
     let keepProbability = Scalar(1.0 - probability)
-    return self * Tensor(keepMask) / Tensor(keepProbability)
+    return self * Tensor(copying: Tensor(keepMask), to: device) / Tensor(keepProbability, on: device)
   }
 }
 

--- a/Sources/TensorFlow/Layers/Dropout.swift
+++ b/Sources/TensorFlow/Layers/Dropout.swift
@@ -18,7 +18,7 @@ extension Tensor where Scalar: TensorFlowFloatingPoint {
   @differentiable(wrt: self where Scalar: Differentiable)
   fileprivate func _droppingOut(probability: Double) -> Tensor {
     let noise = Tensor(randomUniform: shape, on: device)
-    let keepMask = noise .>= Scalar(probability)
+    let keepMask = noise .>= Tensor(Scalar(probability), on: device)
     let keepProbability = Scalar(1.0 - probability)
     return self * Tensor(keepMask) / Tensor(keepProbability, on: device)
   }


### PR DESCRIPTION
It complains:
Fatal error: Op must have the same backend type: XLA vs TF_EAGER: file third_party/swift/tensorflow_apis/Sources/TensorFlow/Bindings/RawOpsDispatching.swift, line 18758
otherwise.