### PR TITLE
TensorFlow: attempt to repair the Windows build

### DIFF
--- a/Sources/TensorFlow/Layers/Dropout.swift
+++ b/Sources/TensorFlow/Layers/Dropout.swift
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if os(Windows)
+import func MSVCRT.sqrt
+#endif
+
 extension Tensor where Scalar: TensorFlowFloatingPoint {
   /// Computes dropout given a probability.
   // TODO: Remove the underscore once `droppingOut(probability:)` has been removed.


### PR DESCRIPTION
The type generic math needs to be imported through the use of
`MSVCRT` as that is the equivalent to the `Darwin` or `Glibc` modules.
`ucrt` is the pure C library without any additions.