### PR TITLE
NFC: clean up `Sequential` gyb.

### DIFF
--- a/Sources/TensorFlow/Layers/Sequential.swift
+++ b/Sources/TensorFlow/Layers/Sequential.swift
@@ -201,8 +201,7 @@ public struct LayerBuilder {
     -> Sequential<
       L1,
       Sequential<
-        L2,
-        Sequential<L3, Sequential<L4, Sequential<L5, Sequential<L6, Sequential<L7, L8>>>>>
+        L2, Sequential<L3, Sequential<L4, Sequential<L5, Sequential<L6, Sequential<L7, L8>>>>>
       >
     >
   where
@@ -224,8 +223,7 @@ public struct LayerBuilder {
     Sequential(
       l1,
       Sequential(
-        l2,
-        Sequential(l3, Sequential(l4, Sequential(l5, Sequential(l6, Sequential(l7, l8)))))))
+        l2, Sequential(l3, Sequential(l4, Sequential(l5, Sequential(l6, Sequential(l7, l8)))))))
   }
 
   public static func buildBlock<
@@ -244,10 +242,7 @@ public struct LayerBuilder {
       Sequential<
         L2,
         Sequential<
-          L3,
-          Sequential<
-            L4, Sequential<L5, Sequential<L6, Sequential<L7, Sequential<L8, L9>>>>
-          >
+          L3, Sequential<L4, Sequential<L5, Sequential<L6, Sequential<L7, Sequential<L8, L9>>>>>
         >
       >
     >
@@ -274,9 +269,7 @@ public struct LayerBuilder {
       Sequential(
         l2,
         Sequential(
-          l3,
-          Sequential(
-            l4, Sequential(l5, Sequential(l6, Sequential(l7, Sequential(l8, l9))))))))
+          l3, Sequential(l4, Sequential(l5, Sequential(l6, Sequential(l7, Sequential(l8, l9))))))))
   }
 
   public static func buildBlock<
@@ -301,10 +294,7 @@ public struct LayerBuilder {
         Sequential<
           L3,
           Sequential<
-            L4,
-            Sequential<
-              L5, Sequential<L6, Sequential<L7, Sequential<L8, Sequential<L9, L10>>>>
-            >
+            L4, Sequential<L5, Sequential<L6, Sequential<L7, Sequential<L8, Sequential<L9, L10>>>>>
           >
         >
       >
@@ -336,10 +326,8 @@ public struct LayerBuilder {
         Sequential(
           l3,
           Sequential(
-            l4,
-            Sequential(
-              l5, Sequential(l6, Sequential(l7, Sequential(l8, Sequential(l9, l10)))))
-          ))))
+            l4, Sequential(l5, Sequential(l6, Sequential(l7, Sequential(l8, Sequential(l9, l10))))))
+        )))
   }
 
 }

--- a/Sources/TensorFlow/Layers/Sequential.swift.gyb
+++ b/Sources/TensorFlow/Layers/Sequential.swift.gyb
@@ -71,6 +71,24 @@ extension Sequential: Layer where Layer1: Layer {
     }
 }
 
+%{
+SEQUENTIAL_ARITY_RANGE = range(3, 11)
+
+def generic_parameters(arity, prefix=""):
+    params = ["L1: Module"]
+    params += ["L{}: Layer".format(i) for i in range(2, arity+1)]
+    return prefix.join(params)
+
+# Returns "Sequential<L1, Sequential<L2, ...>>".
+def sequential_type(arity):
+    return (
+        "".join(["Sequential<L{}, ".format(i) for i in range(1, n)])
+        + "L"
+        + str(arity)
+        + "".join([">" for i in range(1, n)])
+    )
+}%
+
 @_functionBuilder
 public struct LayerBuilder {
     public static func buildBlock<L1: Module, L2: Layer>(_ l1: L1, _ l2: L2) -> Sequential<L1, L2>
@@ -78,12 +96,11 @@ public struct LayerBuilder {
         Sequential(l1, l2)
     }
 
-    %for n in range(3, 11):
+    %for n in SEQUENTIAL_ARITY_RANGE:
     public static func buildBlock<
-        L1: Module,
-        ${",\n        ".join(["L{}: Layer".format(i) for i in range(2, n+1)])}
+        ${generic_parameters(n, prefix=",\n        ")}
     >(${", ".join(["_ l{}: L{}".format(i, i) for i in range(1, n+1)])})
-        -> ${"".join(["Sequential<L{}, ".format(i) for i in range(1, n)])}L${n}${"".join([">" for i in range(1, n)])} where
+        -> ${sequential_type(n)} where
         ${",\n        ".join(["L{}.Output == L{}.Input".format(i, i+1)
                           for i in range(1, n)])},
         ${",\n        ".join(["L{}.TangentVector.VectorSpaceScalar == ".format(i) +


### PR DESCRIPTION
Refactor `Sequential` gyb logic into helper functions for clarity.

---

This was a step towards gyb'ing `Sequential{n}` typealiases, which actually doesn't work due to [generic typealias limitations](https://github.com/apple/swift-evolution/blob/master/proposals/0048-generic-typealias.md#detail-design).