### PR TITLE
Add Bazel build requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ For more models, go to [**tensorflow/swift-models**](https://github.com/tensorfl
 
 * [Swift for TensorFlow toolchain](https://github.com/tensorflow/swift/blob/master/Installation.md).
 * An environment that can run the Swift for TensorFlow toolchains: Linux 18.04 or macOS with Xcode 10.
+* Bazel. This can be installed [manually](https://docs.bazel.build/versions/master/install.html) or with
+[Baselisk](https://github.com/bazelbuild/bazelisk). You will need a version supported by TensorFlow
+(between `_TF_MIN_BAZEL_VERSION` and `_TF_MAX_BAZEL_VERSION` as specified in
+[tensorflow/configure.py](https://github.com/tensorflow/tensorflow/blob/master/configure.py)).
 
 ### Building and testing
 


### PR DESCRIPTION
Document bazel version dependency and where to find it upstream. This prevents errors like the below:

```
Traceback (most recent call last):
  File "/home/michellecasbon/repos/tensorflow/texasmichelle/out/libtensorflow-prefix/src/libtensorflow/configure.py", line 1551, in <module>
    main()
  File "/home/michellecasbon/repos/tensorflow/texasmichelle/out/libtensorflow-prefix/src/libtensorflow/configure.py", line 1368, in main
    _TF_MAX_BAZEL_VERSION)
  File "/home/michellecasbon/repos/tensorflow/texasmichelle/out/libtensorflow-prefix/src/libtensorflow/configure.py", line 483, in check_bazel_version
    ['bazel', '--batch', '--bazelrc=/dev/null', 'version'])
  File "/home/michellecasbon/repos/tensorflow/texasmichelle/out/libtensorflow-prefix/src/libtensorflow/configure.py", line 159, in run_shell
    output = subprocess.check_output(cmd, stderr=stderr)
  File "/usr/lib/python2.7/subprocess.py", line 223, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
subprocess.CalledProcessError: Command '['bazel', '--batch', '--bazelrc=/dev/null', 'version']' returned non-zero exit status 1
ninja: build stopped: subcommand failed.
```