### PR TITLE
Add py3/numpy requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,6 @@ For more models, go to [**tensorflow/swift-models**](https://github.com/tensorfl
 (between `_TF_MIN_BAZEL_VERSION` and `_TF_MAX_BAZEL_VERSION` as specified in
 [tensorflow/configure.py](https://github.com/tensorflow/tensorflow/blob/master/configure.py)).
 * Python3 with [numpy](https://numpy.org/).
-[Pyenv](https://github.com/pyenv/pyenv) with
-[pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv)
-is recommended for managing Python installations.
 
 ### Building and testing
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ For more models, go to [**tensorflow/swift-models**](https://github.com/tensorfl
 [Baselisk](https://github.com/bazelbuild/bazelisk). You will need a version supported by TensorFlow
 (between `_TF_MIN_BAZEL_VERSION` and `_TF_MAX_BAZEL_VERSION` as specified in
 [tensorflow/configure.py](https://github.com/tensorflow/tensorflow/blob/master/configure.py)).
+* Python3 with [numpy](https://numpy.org/).
+[Pyenv](https://github.com/pyenv/pyenv) with
+[pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv)
+is recommended for managing Python installations.
 
 ### Building and testing
 


### PR DESCRIPTION
Add requirement for building swift-apis. This resolves errors like the below:

```
ERROR: Analysis of target '//tensorflow/compiler/tf2xla/xla_tensor:x10' failed; build aborted: invalid registered toolchain '@local_config_python//:py_toolchain': no such package '@local_config_python//': Traceback (most recent call last):
	File "/home/michellecasbon/repos/tensorflow/texasmichelle/out/libtensorflow-prefix/src/libtensorflow/third_party/py/python_configure.bzl", line 263
		_create_local_python_repository(<1 more arguments>)
	File "/home/michellecasbon/repos/tensorflow/texasmichelle/out/libtensorflow-prefix/src/libtensorflow/third_party/py/python_configure.bzl", line 213, in _create_local_python_repository
		_get_numpy_include(<2 more arguments>)
	File "/home/michellecasbon/repos/tensorflow/texasmichelle/out/libtensorflow-prefix/src/libtensorflow/third_party/py/python_configure.bzl", line 187, in _get_numpy_include
		execute(repository_ctx, <3 more arguments>)
	File "/home/michellecasbon/repos/tensorflow/texasmichelle/out/libtensorflow-prefix/src/libtensorflow/third_party/remote_config/common.bzl", line 208, in execute
		fail(<1 more arguments>)
Problem getting numpy include path.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'numpy'
Is numpy installed?
INFO: Elapsed time: 5.095s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (11 packages loaded, 10 target\
s configured)
```