### PR TITLE
NonuniformInferenceBatches, as a type.

### DIFF
--- a/Sources/TensorFlow/Epochs/NonuniformTrainingEpochs.swift
+++ b/Sources/TensorFlow/Epochs/NonuniformTrainingEpochs.swift
@@ -199,7 +199,8 @@ extension Slices
   /// descending, with batch size determined by sample index.
   ///
   /// This initializer doesn't read elements from `samples`, so will preserve
-  /// any underlying laziness.
+  /// any underlying laziness as long as `samplesAreInAscendingSizeOrder`
+  /// doesn't access them.
   ///
   /// - Parameter samplesAreInAscendingSizeOrder: returns `true` iff the memory
   ///   footprint of the sample at the first parameter is less than that of the

--- a/Sources/TensorFlow/Epochs/NonuniformTrainingEpochs.swift
+++ b/Sources/TensorFlow/Epochs/NonuniformTrainingEpochs.swift
@@ -160,13 +160,13 @@ where Entropy == SystemRandomNumberGenerator {
 
 /// A collection of batches suitable for inference, drawing samples from
 /// `samples` into batches of `batchSize`.
-typealias NonuniformInferenceBatches<Samples: Collection> 
+public typealias NonuniformInferenceBatches<Samples: Collection> 
   = Slices<Sampling<Samples, [Samples.Index]>>
 
 /// An implementation detail used to work around the fact that Swift can't
 /// express a generic constraint that some type must be an instance of
 /// `Sampling`.
-protocol SamplingProtocol : Collection {
+public protocol SamplingProtocol : Collection {
   associatedtype Samples: Collection
   associatedtype Selection: Collection where Selection.Element == Samples.Index
   /// Creates an instance from `base` and `selection`.
@@ -184,7 +184,7 @@ extension Slices
   ///
   /// - Parameter areInAscendingSizeOrder: returns `true` iff the memory
   ///   footprint of the first parameter is less than that of the second.
-  init(
+  public init(
     samples: Base.Samples, batchSize n: Int,
     areInAscendingSizeOrder:
       @escaping (Base.Samples.Element, Base.Samples.Element) -> Bool
@@ -206,7 +206,7 @@ extension Slices
   ///   footprint of the sample at the first parameter is less than that of the
   ///   sample at the second parameter.
   ///
-  init(
+  public init(
     samples: Base.Samples, batchSize n: Int,
     samplesAreInAscendingSizeOrder:
       @escaping (Base.Samples.Index, Base.Samples.Index) -> Bool

--- a/Tests/TensorFlowTests/EpochsTests.swift
+++ b/Tests/TensorFlowTests/EpochsTests.swift
@@ -306,7 +306,7 @@ final class EpochsTests: XCTestCase {
     let samples = (0..<sampleCount).map {
       _ in SizedSample.init(size: Int.random(in: 0..<1000, using: &rng))
     }
-    let batches = nonuniformInferenceBatches(
+    let batches = NonuniformInferenceBatches(
       samples: samples, batchSize: batchSize
     ) { $0.size < $1.size }
     


### PR DESCRIPTION
The alternative to the typealias and the protocol hack would be to write a
wrapper around the type we've defined and make it conform to Collection, etc.