### PR TITLE
reflow sources for swift-format

### DIFF
--- a/Sources/TensorFlow/Epochs/Algorithms.swift
+++ b/Sources/TensorFlow/Epochs/Algorithms.swift
@@ -16,8 +16,8 @@
 // REQUIRES: executable_test
 
 #if USE_STDLIBUNITTEST
-import Swift
-import StdlibUnittest
+  import Swift
+  import StdlibUnittest
 #endif
 
 //===--- Rotate -----------------------------------------------------------===//
@@ -31,7 +31,7 @@ import StdlibUnittest
 /// points to be used from other algorithms defined on
 /// `MutableCollectionAlgorithms`.
 public protocol MutableCollectionAlgorithms : MutableCollection
-  where SubSequence : MutableCollectionAlgorithms
+where SubSequence : MutableCollectionAlgorithms
 {
   /// Rotates the elements of the collection so that the element
   /// at `middle` ends up first.
@@ -45,10 +45,10 @@ public protocol MutableCollectionAlgorithms : MutableCollection
 
 // Conformances of common collection types to MutableCollectionAlgorithms.
 // If rotate was a requirement of MutableCollection, these would not be needed.
-extension Array : MutableCollectionAlgorithms {  }
-extension ArraySlice : MutableCollectionAlgorithms {  }
+extension Array : MutableCollectionAlgorithms {}
+extension ArraySlice : MutableCollectionAlgorithms {}
 extension Slice : MutableCollectionAlgorithms
-  where Base: MutableCollection { }
+where Base: MutableCollection {}
 
 extension MutableCollection {
   /// Swaps the elements of the two given subranges, up to the upper bound of
@@ -83,8 +83,7 @@ extension MutableCollection {
       swapAt(p, q)
       formIndex(after: &p)
       formIndex(after: &q)
-    }
-    while p != lhs.upperBound && q != rhs.upperBound
+    } while p != lhs.upperBound && q != rhs.upperBound
     return (p, q)
   }
 
@@ -96,7 +95,8 @@ extension MutableCollection {
   /// - Complexity: O(*n*)
   @discardableResult
   public mutating func rotate(shiftingToStart middle: Index) -> Index {
-    var m = middle, s = startIndex
+    var m = middle
+    var s = startIndex
     let e = endIndex
 
     // Handle the trivial cases
@@ -112,7 +112,7 @@ extension MutableCollection {
     //   ^             ^     ^        ^     ^             ^
     //   s             m     e        s     m             e
     //
-    var ret = e // start with a known incorrect result.
+    var ret = e  // start with a known incorrect result.
     while true {
       // Exchange the leading elements of each region (up to the
       // length of the shorter region).
@@ -248,8 +248,8 @@ extension MutableCollection where Self: RandomAccessCollection {
   /// - Complexity: O(*n*)
   @discardableResult
   public mutating func rotateRandomAccess(
-    shiftingToStart middle: Index) -> Index
-  {
+    shiftingToStart middle: Index
+  ) -> Index {
     if middle == startIndex { return endIndex }
     if middle == endIndex { return startIndex }
 
@@ -283,8 +283,7 @@ extension MutableCollection where Self: RandomAccessCollection {
 
 /// A concatenation of two sequences with the same element type.
 public struct Concatenation<Base1: Sequence, Base2: Sequence>: Sequence
-  where Base1.Element == Base2.Element
-{
+where Base1.Element == Base2.Element {
   let _base1: Base1
   let _base2: Base2
 
@@ -314,8 +313,8 @@ public struct Concatenation<Base1: Sequence, Base2: Sequence>: Sequence
 
 extension Concatenation: Collection where Base1: Collection, Base2: Collection {
   /// A position in a `Concatenation`.
-  public struct Index : Comparable {
-    internal enum _Representation : Equatable {
+  public struct Index: Comparable {
+    internal enum _Representation: Equatable {
       case first(Base1.Index)
       case second(Base2.Index)
     }
@@ -382,8 +381,7 @@ extension Concatenation: Collection where Base1: Collection, Base2: Collection {
 }
 
 extension Concatenation : BidirectionalCollection
-  where Base1: BidirectionalCollection, Base2: BidirectionalCollection
-{
+where Base1: BidirectionalCollection, Base2: BidirectionalCollection {
   public func index(before i: Index) -> Index {
     assert(i != startIndex, "Can't advance before startIndex")
     switch i._position {
@@ -444,16 +442,14 @@ extension Concatenation : RandomAccessCollection
 /// first collection and then the elements of the second collection.
 func concatenate<S1: Sequence, S2: Sequence>(
   _ first: S1,
-  _ second: S2)
-  -> Concatenation<S1, S2> where S1.Element == S2.Element
-{
+  _ second: S2
+) -> Concatenation<S1, S2> where S1.Element == S2.Element {
   return Concatenation(_base1: first, base2: second)
 }
 
 extension Sequence {
   func followed<S: Sequence>(by other: S) -> Concatenation<Self, S>
-    where Element == S.Element
-  {
+  where Element == S.Element {
     return concatenate(self, other)
   }
 }
@@ -462,7 +458,7 @@ extension Sequence {
 //===----------------------------------------------------------------------===//
 
 /// A rotated view onto a collection.
-public struct RotatedCollection<Base : Collection> : Collection {
+public struct RotatedCollection<Base: Collection>: Collection {
   let _base: Base
   let _indices: Concatenation<Base.Indices, Base.Indices>
 
@@ -472,9 +468,8 @@ public struct RotatedCollection<Base : Collection> : Collection {
   }
 
   /// A position in a rotated collection.
-  public struct Index : Comparable {
-    internal let _index:
-      Concatenation<Base.Indices, Base.Indices>.Index
+  public struct Index: Comparable {
+    internal let _index: Concatenation<Base.Indices, Base.Indices>.Index
 
     public static func < (lhs: Index, rhs: Index) -> Bool {
       return lhs._index < rhs._index
@@ -518,15 +513,15 @@ public struct RotatedCollection<Base : Collection> : Collection {
   }
 }
 
-extension RotatedCollection : BidirectionalCollection
-  where Base : BidirectionalCollection {
+extension RotatedCollection: BidirectionalCollection
+where Base: BidirectionalCollection {
   public func index(before i: Index) -> Index {
     return Index(_index: _indices.index(before: i._index))
   }
 }
 
 extension RotatedCollection : RandomAccessCollection
-  where Base : RandomAccessCollection {}
+where Base: RandomAccessCollection {}
 
 extension Collection {
   /// Returns a view of this collection with the elements reordered such the
@@ -572,13 +567,14 @@ extension MutableCollectionAlgorithms {
   /// - Complexity: O(n) where n is the number of elements.
   /// - Precondition: `n == self.count`
   fileprivate mutating func stablePartition(
-    count n: Int, isSuffixElement: (Element) throws-> Bool
+    count n: Int, isSuffixElement: (Element) throws -> Bool
   ) rethrows -> Index {
     if n == 0 { return startIndex }
     if n == 1 {
       return try isSuffixElement(self[startIndex]) ? startIndex : endIndex
     }
-    let h = n / 2, i = index(startIndex, offsetBy: h)
+    let h = n / 2
+    let i = index(startIndex, offsetBy: h)
     let j = try self[..<i].stablePartition(
       count: h, isSuffixElement: isSuffixElement)
     let k = try self[i...].stablePartition(

--- a/Sources/TensorFlow/Epochs/NonuniformTrainingEpochs.swift
+++ b/Sources/TensorFlow/Epochs/NonuniformTrainingEpochs.swift
@@ -160,24 +160,24 @@ where Entropy == SystemRandomNumberGenerator {
 
 /// A collection of batches suitable for inference, drawing samples from
 /// `samples` into batches of `batchSize`.
-public typealias NonuniformInferenceBatches<Samples: Collection>
-  = Slices<Sampling<Samples, [Samples.Index]>>
+public typealias NonuniformInferenceBatches<Samples: Collection> = Slices<
+  Sampling<Samples, [Samples.Index]>
+>
 
 /// An implementation detail used to work around the fact that Swift can't
 /// express a generic constraint that some type must be an instance of
 /// `Sampling`.
-public protocol SamplingProtocol : Collection {
+public protocol SamplingProtocol: Collection {
   associatedtype Samples: Collection
   associatedtype Selection: Collection where Selection.Element == Samples.Index
   /// Creates an instance from `base` and `selection`.
   init(base: Samples, selection: Selection)
 }
-extension Sampling : SamplingProtocol {}
+extension Sampling: SamplingProtocol {}
 
 extension Slices
-  // This constraint matches when Self == NonuniformInferenceBatches<T>.
-  where Base: SamplingProtocol, Base.Selection == [Base.Samples.Index]
-{
+// This constraint matches when Self == NonuniformInferenceBatches<T>.
+where Base: SamplingProtocol, Base.Selection == [Base.Samples.Index] {
   /// Creates an instance containing batches of `n` elements of `samples` where
   /// the size of the largest sample in successive batches is strictly
   /// descending.

--- a/Sources/TensorFlow/Layers/Dropout.swift
+++ b/Sources/TensorFlow/Layers/Dropout.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #if os(Windows)
-import func MSVCRT.sqrt
+  import func MSVCRT.sqrt
 #endif
 
 extension Tensor where Scalar: TensorFlowFloatingPoint {
@@ -96,8 +96,9 @@ public struct GaussianNoise<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer
   public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
     switch Context.local.learningPhase {
     case .training:
-      let noise = Tensor<Scalar>(randomNormal: input.shape, mean: Tensor<Scalar>(0),
-                                 standardDeviation: self.standardDeviation)
+      let noise = Tensor<Scalar>(
+        randomNormal: input.shape, mean: Tensor<Scalar>(0),
+        standardDeviation: self.standardDeviation)
       return input + noise
     case .inference:
       return input
@@ -130,8 +131,9 @@ public struct GaussianDropout<Scalar: TensorFlowFloatingPoint>: ParameterlessLay
   public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
     switch Context.local.learningPhase {
     case .training:
-      let noise = Tensor<Scalar>(randomNormal: input.shape, mean: Tensor<Scalar>(1.0),
-                                 standardDeviation: Tensor<Scalar>(standardDeviation))
+      let noise = Tensor<Scalar>(
+        randomNormal: input.shape, mean: Tensor<Scalar>(1.0),
+        standardDeviation: Tensor<Scalar>(standardDeviation))
       return input * noise
     case .inference:
       return input

--- a/Tests/TensorFlowTests/EpochsTests.swift
+++ b/Tests/TensorFlowTests/EpochsTests.swift
@@ -22,7 +22,7 @@ final class EpochsTests: XCTestCase {
 
   // An element that keeps track of when it was first accessed.
   class AccessTracker {
-      var accessed: Bool = false
+    var accessed: Bool = false
   }
 
   // A struct keeping track of when its elements have been first accessed. We
@@ -33,7 +33,7 @@ final class EpochsTests: XCTestCase {
   ///
   /// - Warning: distinct elements may be read concurrently, but reading
   ///   the same element from two threads is a race condition.
-  struct ReadTracker<Base: RandomAccessCollection> : RandomAccessCollection {
+  struct ReadTracker<Base: RandomAccessCollection>: RandomAccessCollection {
     let base: Base
     let accessed_: [AccessTracker]
 
@@ -71,10 +71,12 @@ final class EpochsTests: XCTestCase {
     }
     let batches = dataset.inBatches(of: batchSize).lazy.map(\.collated)
 
-    XCTAssertEqual(batches.count, dataset.count / batchSize,
-                   "Incorrect number of batches.")
+    XCTAssertEqual(
+      batches.count, dataset.count / batchSize,
+      "Incorrect number of batches.")
     for batch in batches {
-      XCTAssertEqual(batch.shape, TensorShape([64, 224, 224, 3]),
+      XCTAssertEqual(
+        batch.shape, TensorShape([64, 224, 224, 3]),
         "Wrong shape for batch: \(batch.shape), should be [64, 224, 224, 3]")
     }
   }
@@ -86,38 +88,46 @@ final class EpochsTests: XCTestCase {
     let batches = dataset.inBatches(of: batchSize)
 
     // `inBatches` is lazy so no elements were accessed.
-    XCTAssert(dataset.accessed.allSatisfy(){ !$0 },
-              "No elements should have been accessed yet.")
+    XCTAssert(
+      dataset.accessed.allSatisfy(){ !$0 },
+      "No elements should have been accessed yet.")
     for (i, batch) in batches.enumerated() {
       // Elements are not accessed until we do something with `batch` so only
       // the elements up to `i * batchSize` have been accessed yet.
-      XCTAssert(dataset.accessed[..<(i * batchSize)].allSatisfy(){ $0 },
+      XCTAssert(
+        dataset.accessed[..<(i * batchSize)].allSatisfy(){ $0 },
         "Not all elements prior to \(i * batchSize) have been accessed.")
-      XCTAssert(dataset.accessed[(i * batchSize)...].allSatisfy(){ !$0 },
+      XCTAssert(
+        dataset.accessed[(i * batchSize)...].allSatisfy(){ !$0 },
         "Some elements after \(i * batchSize) have been accessed.")
       let _ = Array(batch)
       let limit = (i + 1) * batchSize
       // We accessed elements up to `limit` but no further.
-      XCTAssert(dataset.accessed[..<limit].allSatisfy(){ $0 },
-                "Not all elements prior to \(limit) have been accessed.")
-      XCTAssert(dataset.accessed[limit...].allSatisfy(){ !$0 },
-                "Some elements after \(limit) have been accessed.")
+      XCTAssert(
+        dataset.accessed[..<limit].allSatisfy(){ $0 },
+        "Not all elements prior to \(limit) have been accessed.")
+      XCTAssert(
+        dataset.accessed[limit...].allSatisfy(){ !$0 },
+        "Some elements after \(limit) have been accessed.")
     }
   }
 
   func testTrainingEpochsShuffles() {
     let batchSize = 64
     let dataset = Array(0..<512)
-    let epochs = TrainingEpochs(samples: dataset, batchSize: batchSize,
-                                entropy: rng).prefix(10)
+    let epochs = TrainingEpochs(
+      samples: dataset, batchSize: batchSize,
+      entropy: rng
+    ).prefix(10)
     var lastEpochSampleOrder = Array(0..<512)
     for batches in epochs {
       var newEpochSampleOrder: [Int] = []
       for batch in batches {
         XCTAssertEqual(batches.count, 8, "Incorrect number of batches.")
         let samples = Array(batch)
-        XCTAssertEqual(samples.count, batchSize,
-                       "This batch doesn't have batchSize elements.")
+        XCTAssertEqual(
+          samples.count, batchSize,
+          "This batch doesn't have batchSize elements.")
 
         newEpochSampleOrder += samples
       }
@@ -136,20 +146,24 @@ final class EpochsTests: XCTestCase {
   func testTrainingEpochsDropsRemainder() {
     let batchSize = 64
     let dataset = Array(0..<500)
-    let epochs = TrainingEpochs(samples: dataset, batchSize: batchSize,
-                                entropy: rng).prefix(1)
+    let epochs = TrainingEpochs(
+      samples: dataset, batchSize: batchSize,
+      entropy: rng
+    ).prefix(1)
     let samplesCount = dataset.count - dataset.count % 64
     for batches in epochs {
       XCTAssertEqual(batches.count, 7, "Incorrect number of batches.")
       var count = 0
       for batch in batches {
         let samples = Array(batch)
-        XCTAssertEqual(samples.count, batchSize,
-                       "This batch doesn't have batchSize elements.")
+        XCTAssertEqual(
+          samples.count, batchSize,
+          "This batch doesn't have batchSize elements.")
         count += samples.count
       }
-      XCTAssertEqual(count, samplesCount,
-                     "Didn't access the right number of samples.")
+      XCTAssertEqual(
+        count, samplesCount,
+        "Didn't access the right number of samples.")
     }
   }
 
@@ -157,21 +171,25 @@ final class EpochsTests: XCTestCase {
     let batchSize = 64
     let items = Array(0..<512)
     let dataset = ReadTracker(items)
-    let epochs = TrainingEpochs(samples: dataset, batchSize: batchSize,
-                                 entropy: rng).prefix(1)
+    let epochs = TrainingEpochs(
+      samples: dataset, batchSize: batchSize,
+      entropy: rng
+    ).prefix(1)
 
     // `inBatches` is lazy so no elements were accessed.
-    XCTAssert(dataset.accessed.allSatisfy(){ !$0 },
-              "No elements should have been accessed yet.")
-    for batches in epochs{
+    XCTAssert(
+      dataset.accessed.allSatisfy(){ !$0 },
+      "No elements should have been accessed yet.")
+    for batches in epochs {
       for (i, batch) in batches.enumerated() {
         // Elements are not accessed until we do something with `batch` so only
         // `i * batchSize` elements have been accessed yet.
-        XCTAssertEqual(dataset.accessed.filter(){ $0 }.count, i * batchSize,
+        XCTAssertEqual(
+          dataset.accessed.filter() { $0 }.count, i * batchSize,
           "Should have accessed \(i * batchSize) elements.")
         let _ = Array(batch)
         XCTAssertEqual(
-          dataset.accessed.filter(){ $0 }.count, (i + 1) * batchSize,
+          dataset.accessed.filter() { $0 }.count, (i + 1) * batchSize,
           "Should have accessed \((i + 1) * batchSize) elements.")
       }
     }
@@ -198,13 +216,14 @@ final class EpochsTests: XCTestCase {
       let shapes = nonuniformDataset[(i * 64)..<((i + 1) * 64)]
         .map { Int($0.shape[0]) }
       let expectedShape = shapes.reduce(0) { max($0, $1) }
-      XCTAssertEqual(Int(b.shape[1]), expectedShape,
+      XCTAssertEqual(
+        Int(b.shape[1]), expectedShape,
         "The batch does not have the expected shape: \(expectedShape).")
 
       for k in 0..<64 {
         let currentShape = nonuniformDataset[i * 64 + k].shape[0]
-        let paddedPart = atStart ? b[k, 0..<(expectedShape-currentShape)] : (
-          b[k, currentShape..<expectedShape])
+        let paddedPart =
+          atStart ? b[k, 0..<(expectedShape-currentShape)] : (b[k, currentShape..<expectedShape])
         XCTAssertEqual(
           paddedPart,
           Tensor<Int32>(
@@ -310,8 +329,9 @@ final class EpochsTests: XCTestCase {
       samples: samples, batchSize: batchSize
     ) { $0.size < $1.size }
 
-    XCTAssertEqual(batches.count, sampleCount / batchSize + 1,
-                   "Wrong number of batches")
+    XCTAssertEqual(
+      batches.count, sampleCount / batchSize + 1,
+      "Wrong number of batches")
     var previousSize: Int? = nil
     for (i, batchSamples) in batches.enumerated() {
       let batch = Array(batchSamples)
@@ -321,8 +341,9 @@ final class EpochsTests: XCTestCase {
         "Wrong number of samples in this batch.")
       let newSize = batch.map(\.size).max()!
       if let size = previousSize {
-        XCTAssert(size >= newSize,
-                 "Batch should be sorted through size.")
+        XCTAssert(
+          size >= newSize,
+          "Batch should be sorted through size.")
       }
       previousSize = Int(newSize)
     }


### PR DESCRIPTION
When enabling `swift-format`, a number of style issues were identified.
This reflows the text to adhere to the guidance from `swift-format`.  It
will enable us to auto-format and auto-lint incoming PRs.