### PR TITLE
swift-format: permit non-ascii symbols in variables

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -24,7 +24,7 @@
     "FileprivateAtFileScope" : true,
     "FullyIndirectEnum" : true,
     "GroupNumericLiterals" : true,
-    "IdentifiersMustBeASCII" : true,
+    "IdentifiersMustBeASCII" : false,
     "NeverForceUnwrap" : true,
     "NeverUseForceTry" : true,
     "NeverUseImplicitlyUnwrappedOptionals" : true,


### PR DESCRIPTION
We use nabla to represent the gradient.