### PR TITLE
Make derivatives of public functions be `@usableFromInline`.

### DIFF
--- a/Sources/TensorFlow/Core/MixedPrecision.swift
+++ b/Sources/TensorFlow/Core/MixedPrecision.swift
@@ -206,11 +206,13 @@ extension Tensor {
 #endif
 
 extension Tensor where Scalar: TensorFlowFloatingPoint {
+  @usableFromInline
   @derivative(of: toReducedPrecision)
   func _vjpToReducedPrecision() -> (value: Tensor, pullback: (Tensor) -> Tensor) {
     (toReducedPrecision, { $0.toFullPrecision })
   }
 
+  @usableFromInline
   @derivative(of: toFullPrecision)
   func _vjpToFullPrecision() -> (value: Tensor, pullback: (Tensor) -> Tensor) {
     (toFullPrecision, { $0.toReducedPrecision })

--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -94,8 +94,8 @@ extension Layer {
 
   // TODO(TF-433, SR-11882): Remove this custom derivative when
   // differentiation supports `rethrows` functions and currying.
-  @derivative(of: inferring(from:))
   @usableFromInline
+  @derivative(of: inferring(from:))
   internal func _vjpInferring(from input: Input)
     -> (
       value: Output,

--- a/Sources/TensorFlow/Operators/NN.swift
+++ b/Sources/TensorFlow/Operators/NN.swift
@@ -971,6 +971,7 @@ public func depthToSpace<Scalar>(_ input: Tensor<Scalar>, blockSize b: Int) -> T
   return _Raw.depthToSpace(input, blockSize: Int64(b))
 }
 
+@usableFromInline
 @derivative(of: depthToSpace)
 func _vjpDepthToSpace<Scalar: TensorFlowFloatingPoint>(
   _ input: Tensor<Scalar>,
@@ -1048,6 +1049,7 @@ public func spaceToDepth<Scalar>(_ input: Tensor<Scalar>, blockSize b: Int) -> T
   return _Raw.spaceToDepth(input, blockSize: Int64(b))
 }
 
+@usableFromInline
 @derivative(of: spaceToDepth)
 func _vjpSpaceToDepth<Scalar: TensorFlowFloatingPoint>(
   _ input: Tensor<Scalar>,


### PR DESCRIPTION
Friend PR: https://github.com/apple/swift/pull/31527

> Require `@derivative` functions and their original functions to have the same access level.
> Public original functions may also have internal `@usableFromInline` derivatives, as a special case. Diagnose access level mismatches.
> 
> This simplifies derivative registration rules, and may enable simplification of AutoDiff symbol linkage rules.