### PR TITLE
CI: add swift-format based linting/auto-formatting

### DIFF
--- a/.github/workflows/swift-format.yml
+++ b/.github/workflows/swift-format.yml
@@ -1,0 +1,40 @@
+name: swift-format
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  swift-format:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v2.1.0
+
+      - uses: actions/checkout@v2.1.0
+        with:
+          repository: apple/swift-format
+          path: ${{ github.workspace }}/swift-format
+          ref: swift-5.2-branch
+
+      - uses: actions/cache@v1.1.2
+        with:
+          path: ${{ github.workspace }}/swift-format/.build
+          key: ${{ runner.os }}-swift-format-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-format-
+
+      - name: build swift-format
+        run: |
+          pushd ${{ github.workspace }}/swift-format
+          swift build -c release
+          echo "::add-path::${PWD}/.build/release"
+          popd
+
+      - uses: samuelmeuli/lint-action@v1.5.0
+        with:
+          auto_fix: true
+          swift_format_official: true
+          git_name: Swift for TensorFlow
+          git_email: ainu-bot@google.com
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Sources/TensorFlow/Epochs/Algorithms.swift
+++ b/Sources/TensorFlow/Epochs/Algorithms.swift
@@ -31,8 +31,7 @@
 /// points to be used from other algorithms defined on
 /// `MutableCollectionAlgorithms`.
 public protocol MutableCollectionAlgorithms: MutableCollection
-where SubSequence: MutableCollectionAlgorithms
-{
+where SubSequence: MutableCollectionAlgorithms {
   /// Rotates the elements of the collection so that the element
   /// at `middle` ends up first.
   ///

--- a/Tests/TensorFlowTests/EpochsTests.swift
+++ b/Tests/TensorFlowTests/EpochsTests.swift
@@ -185,11 +185,11 @@ final class EpochsTests: XCTestCase {
         // Elements are not accessed until we do something with `batch` so only
         // `i * batchSize` elements have been accessed yet.
         XCTAssertEqual(
-          dataset.accessed.filter() { $0 }.count, i * batchSize,
+          dataset.accessed.filter { $0 }.count, i * batchSize,
           "Should have accessed \(i * batchSize) elements.")
         let _ = Array(batch)
         XCTAssertEqual(
-          dataset.accessed.filter() { $0 }.count, (i + 1) * batchSize,
+          dataset.accessed.filter { $0 }.count, (i + 1) * batchSize,
           "Should have accessed \((i + 1) * batchSize) elements.")
       }
     }


### PR DESCRIPTION
Introduce swift-format based auto-formatting of PRs on the repository
via GitHub actions.  This will automatically perform the required style
changes and commit them to the PR.