### PR TITLE
Add `Sequential{N}` typealiases.

### DIFF
--- a/Sources/TensorFlow/Layers/Sequential.swift
+++ b/Sources/TensorFlow/Layers/Sequential.swift
@@ -73,6 +73,68 @@ extension Sequential: Layer where Layer1: Layer {
   }
 }
 
+/// A layer that sequentially composes 3 layers.
+public typealias Sequential3<L1: Module, L2: Layer, L3: Layer> = Sequential<L1, Sequential<L2, L3>>
+
+/// A layer that sequentially composes 4 layers.
+public typealias Sequential4<L1: Module, L2: Layer, L3: Layer, L4: Layer> = Sequential<
+  L1, Sequential<L2, Sequential<L3, L4>>
+>
+
+/// A layer that sequentially composes 5 layers.
+public typealias Sequential5<L1: Module, L2: Layer, L3: Layer, L4: Layer, L5: Layer> = Sequential<
+  L1, Sequential<L2, Sequential<L3, Sequential<L4, L5>>>
+>
+
+/// A layer that sequentially composes 6 layers.
+public typealias Sequential6<L1: Module, L2: Layer, L3: Layer, L4: Layer, L5: Layer, L6: Layer> =
+  Sequential<L1, Sequential<L2, Sequential<L3, Sequential<L4, Sequential<L5, L6>>>>>
+
+/// A layer that sequentially composes 7 layers.
+public typealias Sequential7<
+  L1: Module, L2: Layer, L3: Layer, L4: Layer, L5: Layer, L6: Layer, L7: Layer
+> = Sequential<
+  L1, Sequential<L2, Sequential<L3, Sequential<L4, Sequential<L5, Sequential<L6, L7>>>>>
+>
+
+/// A layer that sequentially composes 8 layers.
+public typealias Sequential8<
+  L1: Module, L2: Layer, L3: Layer, L4: Layer, L5: Layer, L6: Layer, L7: Layer, L8: Layer
+> = Sequential<
+  L1,
+  Sequential<L2, Sequential<L3, Sequential<L4, Sequential<L5, Sequential<L6, Sequential<L7, L8>>>>>>
+>
+
+/// A layer that sequentially composes 9 layers.
+public typealias Sequential9<
+  L1: Module, L2: Layer, L3: Layer, L4: Layer, L5: Layer, L6: Layer, L7: Layer, L8: Layer, L9: Layer
+> = Sequential<
+  L1,
+  Sequential<
+    L2,
+    Sequential<
+      L3, Sequential<L4, Sequential<L5, Sequential<L6, Sequential<L7, Sequential<L8, L9>>>>>
+    >
+  >
+>
+
+/// A layer that sequentially composes 10 layers.
+public typealias Sequential10<
+  L1: Module, L2: Layer, L3: Layer, L4: Layer, L5: Layer, L6: Layer, L7: Layer, L8: Layer,
+  L9: Layer, L10: Layer
+> = Sequential<
+  L1,
+  Sequential<
+    L2,
+    Sequential<
+      L3,
+      Sequential<
+        L4, Sequential<L5, Sequential<L6, Sequential<L7, Sequential<L8, Sequential<L9, L10>>>>>
+      >
+    >
+  >
+>
+
 @_functionBuilder
 public struct LayerBuilder {
   public static func buildBlock<L1: Module, L2: Layer>(_ l1: L1, _ l2: L2) -> Sequential<L1, L2>

--- a/Sources/TensorFlow/Layers/Sequential.swift
+++ b/Sources/TensorFlow/Layers/Sequential.swift
@@ -75,20 +75,43 @@ extension Sequential: Layer where Layer1: Layer {
 
 /// A layer that sequentially composes 3 layers.
 public typealias Sequential3<L1: Module, L2: Layer, L3: Layer> = Sequential<L1, Sequential<L2, L3>>
+where
+  L1.Output == L2.Input, L2.Output == L3.Input,
+  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
+  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar
 
 /// A layer that sequentially composes 4 layers.
 public typealias Sequential4<L1: Module, L2: Layer, L3: Layer, L4: Layer> = Sequential<
   L1, Sequential<L2, Sequential<L3, L4>>
 >
+where
+  L1.Output == L2.Input, L2.Output == L3.Input, L3.Output == L4.Input,
+  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
+  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
+  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar
 
 /// A layer that sequentially composes 5 layers.
 public typealias Sequential5<L1: Module, L2: Layer, L3: Layer, L4: Layer, L5: Layer> = Sequential<
   L1, Sequential<L2, Sequential<L3, Sequential<L4, L5>>>
 >
+where
+  L1.Output == L2.Input, L2.Output == L3.Input, L3.Output == L4.Input, L4.Output == L5.Input,
+  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
+  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
+  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
+  L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar
 
 /// A layer that sequentially composes 6 layers.
 public typealias Sequential6<L1: Module, L2: Layer, L3: Layer, L4: Layer, L5: Layer, L6: Layer> =
   Sequential<L1, Sequential<L2, Sequential<L3, Sequential<L4, Sequential<L5, L6>>>>>
+where
+  L1.Output == L2.Input, L2.Output == L3.Input, L3.Output == L4.Input, L4.Output == L5.Input,
+  L5.Output == L6.Input,
+  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
+  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
+  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
+  L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
+  L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar
 
 /// A layer that sequentially composes 7 layers.
 public typealias Sequential7<
@@ -96,6 +119,15 @@ public typealias Sequential7<
 > = Sequential<
   L1, Sequential<L2, Sequential<L3, Sequential<L4, Sequential<L5, Sequential<L6, L7>>>>>
 >
+where
+  L1.Output == L2.Input, L2.Output == L3.Input, L3.Output == L4.Input, L4.Output == L5.Input,
+  L5.Output == L6.Input, L6.Output == L7.Input,
+  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
+  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
+  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
+  L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
+  L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
+  L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar
 
 /// A layer that sequentially composes 8 layers.
 public typealias Sequential8<
@@ -104,6 +136,16 @@ public typealias Sequential8<
   L1,
   Sequential<L2, Sequential<L3, Sequential<L4, Sequential<L5, Sequential<L6, Sequential<L7, L8>>>>>>
 >
+where
+  L1.Output == L2.Input, L2.Output == L3.Input, L3.Output == L4.Input, L4.Output == L5.Input,
+  L5.Output == L6.Input, L6.Output == L7.Input, L7.Output == L8.Input,
+  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
+  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
+  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
+  L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
+  L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
+  L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar,
+  L7.TangentVector.VectorSpaceScalar == L8.TangentVector.VectorSpaceScalar
 
 /// A layer that sequentially composes 9 layers.
 public typealias Sequential9<
@@ -117,6 +159,17 @@ public typealias Sequential9<
     >
   >
 >
+where
+  L1.Output == L2.Input, L2.Output == L3.Input, L3.Output == L4.Input, L4.Output == L5.Input,
+  L5.Output == L6.Input, L6.Output == L7.Input, L7.Output == L8.Input, L8.Output == L9.Input,
+  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
+  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
+  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
+  L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
+  L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
+  L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar,
+  L7.TangentVector.VectorSpaceScalar == L8.TangentVector.VectorSpaceScalar,
+  L8.TangentVector.VectorSpaceScalar == L9.TangentVector.VectorSpaceScalar
 
 /// A layer that sequentially composes 10 layers.
 public typealias Sequential10<
@@ -134,6 +187,19 @@ public typealias Sequential10<
     >
   >
 >
+where
+  L1.Output == L2.Input, L2.Output == L3.Input, L3.Output == L4.Input, L4.Output == L5.Input,
+  L5.Output == L6.Input, L6.Output == L7.Input, L7.Output == L8.Input, L8.Output == L9.Input,
+  L9.Output == L10.Input,
+  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
+  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
+  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
+  L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
+  L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
+  L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar,
+  L7.TangentVector.VectorSpaceScalar == L8.TangentVector.VectorSpaceScalar,
+  L8.TangentVector.VectorSpaceScalar == L9.TangentVector.VectorSpaceScalar,
+  L9.TangentVector.VectorSpaceScalar == L10.TangentVector.VectorSpaceScalar
 
 @_functionBuilder
 public struct LayerBuilder {

--- a/Sources/TensorFlow/Layers/Sequential.swift.gyb
+++ b/Sources/TensorFlow/Layers/Sequential.swift.gyb
@@ -89,6 +89,12 @@ def sequential_type(arity):
     )
 }%
 
+%for n in SEQUENTIAL_ARITY_RANGE:
+/// A layer that sequentially composes ${n} layers.
+public typealias Sequential${n}<${generic_parameters(n, ", ")}> = ${sequential_type(n)}
+
+%end
+
 @_functionBuilder
 public struct LayerBuilder {
     public static func buildBlock<L1: Module, L2: Layer>(_ l1: L1, _ l2: L2) -> Sequential<L1, L2>

--- a/Sources/TensorFlow/Layers/Sequential.swift.gyb
+++ b/Sources/TensorFlow/Layers/Sequential.swift.gyb
@@ -92,6 +92,8 @@ def sequential_type(arity):
 %for n in SEQUENTIAL_ARITY_RANGE:
 /// A layer that sequentially composes ${n} layers.
 public typealias Sequential${n}<${generic_parameters(n, ", ")}> = ${sequential_type(n)}
+  where ${", ".join(["L{}.Output == L{}.Input".format(i, i+1) for i in range(1, n)])},
+        ${", ".join(["L{}.TangentVector.VectorSpaceScalar == L{}.TangentVector.VectorSpaceScalar".format(i, i+1) for i in range(1, n)])}
 
 %end
 


### PR DESCRIPTION
Add `Sequential{N}` generic typealiases.
These are easier to use than long nested `Sequential` types.

```swift
import TensorFlow
// Before:
typealias Model = Sequential<Dense<Float>, Sequential<Dense<Float>, Dense<Float>>>
// After:
typealias Model = Sequential3<Dense<Float>, Dense<Float>, Dense<Float>>
```