### PR TITLE
Fix X10 C++ compilation on macOS.

### DIFF
--- a/Sources/x10/xla_client/xrt_computation_client.cc
+++ b/Sources/x10/xla_client/xrt_computation_client.cc
@@ -342,11 +342,14 @@ void AddXrtHostDevices(const std::string& worker_name, int task_no,
     int count;
   } const devices[] = {
       {"TPU", "TPU",
-       sys_util::GetEnvInt(env::kEnvNumTpu, device_counts.num_tpus)},
+       static_cast<int>(
+           sys_util::GetEnvInt(env::kEnvNumTpu, device_counts.num_tpus))},
       {"GPU", "XLA_GPU",
-       sys_util::GetEnvInt(env::kEnvNumGpu, device_counts.num_gpus)},
+       static_cast<int>(
+           sys_util::GetEnvInt(env::kEnvNumGpu, device_counts.num_gpus))},
       {"CPU", "XLA_CPU",
-       sys_util::GetEnvInt(env::kEnvNumCpu, device_counts.num_cpus)},
+       static_cast<int>(
+           sys_util::GetEnvInt(env::kEnvNumCpu, device_counts.num_cpus))},
   };
   options->workers_map.emplace(
       XrtComputationClient::Worker(worker_name, task_no),


### PR DESCRIPTION
Add `static_cast<int>(...)` to fix compilation errors.

---

Fixes [`utils/build-toolchain-tensorflow`](https://github.com/apple/swift/blob/tensorflow/utils/build-toolchain-tensorflow) on macOS:

<details>
<p>

```
ERROR: /Users/danielzheng/swift-debug/build/buildbot_osx/tensorflowswiftapis-macosx-x86_64/libtensorflow-prefix/src/libtensorflow/tensorflow/compiler/xla/xla_client/BUILD:21:1: C++ compilation of rule '//tensorflow/compiler/xla/xla_client:xrt_computation_client' failed (Exit 1)
tensorflow/compiler/xla/xla_client/xrt_computation_client.cc:345:8: error: non-constant-expression cannot be narrowed from type 'tensorflow::int64' (aka 'long long') to 'int' in initializer list [-Wc++11-narrowing]
       sys_util::GetEnvInt(env::kEnvNumTpu, device_counts.num_tpus)},
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tensorflow/compiler/xla/xla_client/xrt_computation_client.cc:345:8: note: insert an explicit cast to silence this issue
       sys_util::GetEnvInt(env::kEnvNumTpu, device_counts.num_tpus)},
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       static_cast<int>(                                           )
tensorflow/compiler/xla/xla_client/xrt_computation_client.cc:347:8: error: non-constant-expression cannot be narrowed from type 'tensorflow::int64' (aka 'long long') to 'int' in initializer list [-Wc++11-narrowing]
       sys_util::GetEnvInt(env::kEnvNumGpu, device_counts.num_gpus)},
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tensorflow/compiler/xla/xla_client/xrt_computation_client.cc:347:8: note: insert an explicit cast to silence this issue
       sys_util::GetEnvInt(env::kEnvNumGpu, device_counts.num_gpus)},
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       static_cast<int>(                                           )
tensorflow/compiler/xla/xla_client/xrt_computation_client.cc:349:8: error: non-constant-expression cannot be narrowed from type 'tensorflow::int64' (aka 'long long') to 'int' in initializer list [-Wc++11-narrowing]
       sys_util::GetEnvInt(env::kEnvNumCpu, device_counts.num_cpus)},
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tensorflow/compiler/xla/xla_client/xrt_computation_client.cc:349:8: note: insert an explicit cast to silence this issue
       sys_util::GetEnvInt(env::kEnvNumCpu, device_counts.num_cpus)},
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       static_cast<int>(                                           )
3 errors generated.
Target //tensorflow/compiler/tf2xla/xla_tensor:x10 failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 14.464s, Critical Path: 6.79s
INFO: 0 processes.
FAILED: Build did NOT complete successfully
FAILED: Build did NOT complete successfully
FAILED: libtensorflow-prefix/src/libtensorflow-stamp/libtensorflow-build libtensorflow-prefix/src/libtensorflow/bazel-bin/tensorflow/compiler/tf2xla/xla_tensor/libx10.dylib
cd /Users/danielzheng/swift-debug/build/buildbot_osx/tensorflowswiftapis-macosx-x86_64/libtensorflow-prefix/src/libtensorflow && rm -rf /Users/danielzheng/swift-debug/build/buildbot_osx/tensorflowswiftapis-macosx-x86_64/libtensorflow-prefix/src/libtensorflow/bazel-bin && bazel build -c opt --define framework_shared_object=false //tensorflow/compiler/tf2xla/xla_tensor:x10 --nocheck_visibility && bazel shutdown && /usr/local/Cellar/cmake/3.16.5/bin/cmake -E touch /Users/danielzheng/swift-debug/build/buildbot_osx/tensorflowswiftapis-macosx-x86_64/libtensorflow-prefix/src/libtensorflow-stamp/libtensorflow-build
```

</p>
</details>