### PR TITLE
Update `@_Freezable` after wrapped property differentiation changes.

### DIFF
--- a/Sources/TensorFlow/Freezable.swift
+++ b/Sources/TensorFlow/Freezable.swift
@@ -12,64 +12,49 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// A wrapper around a differentiable value with "freezable" derivatives.
+/// A wrapper around a value whose value can be frozen.
 ///
-/// When `isFrozen` is true, accesses to `wrappedValue` have a derivative of zero.
+/// When `isFrozen` is true, assignments to `wrappedValue` will do nothing.
 @propertyWrapper
-public struct _Freezable<Value: Differentiable> {
-  @noDerivative public var isFrozen: Bool = false
+public struct _Freezable<Value> {
   private var _value: Value
+
+  /// True iff the value is frozen.
+  public var isFrozen: Bool = false
 
   public init(wrappedValue: Value) {
     _value = wrappedValue
   }
 
   public var projectedValue: Self {
-    get { return self }
+    get { self }
     set { self = newValue }
   }
 
-  /// The wrapped differentiable value.
-  @differentiable
+  /// The wrapped value.
   public var wrappedValue: Value {
     get { _value }
-    set { _value = newValue }
-  }
-
-  @usableFromInline
-  @derivative(of: wrappedValue)
-  func _vjpValue() -> (value: Value, pullback: (Value.TangentVector) -> TangentVector) {
-    return (
-      _value,
-      { [isFrozen = self.isFrozen] v in
-        isFrozen ? .zero : v
-      }
-    )
+    set {
+      // If frozen, do not update the value.
+      if isFrozen { return }
+      // Otherwise, update the value.
+      _value = newValue
+    }
   }
 }
 
 extension _Freezable {
-  /// Freeze derivatives for `wrappedValue`. Accesses to `wrappedValue` will always have a
-  /// derivative of zero.
+  /// Freeze the value of `wrappedValue`.
+  ///
+  /// While frozen, assignments to `wrappedValue` will do nothing.
   public mutating func freeze() {
     isFrozen = true
   }
 
-  /// Unfreeze derivatives for `wrappedValue`.
+  /// Unfreeze the value of `wrappedValue`.
+  ///
+  /// Assignments to `wrappedValue` will behave as normal.
   public mutating func unfreeze() {
     isFrozen = false
-  }
-}
-
-extension _Freezable: Differentiable {
-  public typealias TangentVector = Value.TangentVector
-  public mutating func move(along direction: TangentVector) {
-    _value.move(along: direction)
-  }
-}
-
-extension _Freezable: EuclideanDifferentiable where Value: EuclideanDifferentiable {
-  public var differentiableVectorView: TangentVector {
-    return _value.differentiableVectorView
   }
 }

--- a/Tests/TensorFlowTests/FreezableTests.swift
+++ b/Tests/TensorFlowTests/FreezableTests.swift
@@ -38,40 +38,23 @@ final class FreezableTests: XCTestCase {
     }
 
     var dense = FreezableDense(weight: Tensor(2), bias: Tensor(3))
-    let x = Tensor<Float>(4)
-    do {
-      let (value, gradient) = valueWithGradient(at: dense, x) { dense, x in dense(x) }
-      XCTAssertEqual(Tensor(11), value)
-      // The gradient of `dense.weight` should be non-zero.
-      XCTAssertEqual(
-        FreezableDense.TangentVector(_weight: Tensor(4), _bias: Tensor(1)),
-        gradient.0)
-      XCTAssertEqual(Tensor(2), gradient.1)
-    }
+    let grad = FreezableDense.TangentVector(weight: Tensor(4), bias: Tensor(1))
 
-    // Freeze derivatives for `dense.weight`.
+    dense.move(along: grad)
+    XCTAssertEqual(Tensor(6), dense.weight)
+    XCTAssertEqual(Tensor(4), dense.bias)
+
+    // Freeze `dense.weight`: its value cannot be updated.
     dense.$weight.freeze()
-    do {
-      let (value, gradient) = valueWithGradient(at: dense, x) { dense, x in dense(x) }
-      // The gradient of `dense.weight` should now be zero.
-      XCTAssertEqual(Tensor(11), value)
-      XCTAssertEqual(
-        FreezableDense.TangentVector(_weight: Tensor(0), _bias: Tensor(1)),
-        gradient.0)
-      XCTAssertEqual(Tensor(2), gradient.1)
-    }
+    dense.move(along: grad)
+    XCTAssertEqual(Tensor(6), dense.weight)
+    XCTAssertEqual(Tensor(5), dense.bias)
 
-    // Unfreeze derivatives for `dense.weight`.
+    // Unfreeze `dense.weight`: its value can be updated again.
     dense.$weight.unfreeze()
-    do {
-      let (value, gradient) = valueWithGradient(at: dense, x) { dense, x in dense(x) }
-      XCTAssertEqual(Tensor(11), value)
-      // The gradient of `dense.weight` should now be non-zero.
-      XCTAssertEqual(
-        FreezableDense.TangentVector(_weight: Tensor(4), _bias: Tensor(1)),
-        gradient.0)
-      XCTAssertEqual(Tensor(2), gradient.1)
-    }
+    dense.move(along: grad)
+    XCTAssertEqual(Tensor(10), dense.weight)
+    XCTAssertEqual(Tensor(6), dense.bias)
   }
 
   static var allTests = [


### PR DESCRIPTION
Wrapped property differentiation was recently simplified:

<details>

- `Differentiable` conformance derivation now "peers through" property
  wrappers.
- Synthesized `TangentVector` structs contain wrapped properties'
  `TangentVector`s as stored properties, not wrappers' `TangentVector`s.
- It is irrelevant whether property wrapper types conform to `Differentiable`.

</details>

In light of these changes:
- `@_Freezable` no longer conforms to `Differentiable`.
- Rather than providing zero derivatives, `@_Freezable` now disables updates to
  `var wrappedValue`. This better fits the definition of "frozen".

---

This change requires and is required by https://github.com/apple/swift/pull/31731: the 2020-05-12 apple/swift `master -> tensorflow` merge.

Alternatively, we could consider deleting `@_Freezable` since it's not clear that it's useful.