### PR TITLE
Hides the symbols except for those that are marked as visible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ if(CMAKE_VERSION VERSION_LESS 3.17)
   if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
     set(CMAKE_EXECUTABLE_RUNTIME_Swift_FLAG "-Xlinker -rpath -Xlinker ")
     set(CMAKE_SHARED_LIBRARY_RUNTIME_Swift_FLAG "-Xlinker -rpath -Xlinker ")
+	set(VISIBILITY_FLAGS --cxxopt=-fvisibility=hidden --cxxopt=-fvisibility-inlines-hidden)
     if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
       set(CMAKE_EXECUTABLE_RUNTIME_Swift_FLAG_SEP "")
       set(CMAKE_SHARED_LIBRARY_RUNTIME_Swift_FLAG_SEP "")
@@ -13,6 +14,8 @@ if(CMAKE_VERSION VERSION_LESS 3.17)
       set(CMAKE_EXECUTABLE_RUNTIME_Swift_FLAG_SEP ":")
       set(CMAKE_SHARED_LIBRARY_RUNTIME_Swift_FLAG_SEP ":")
     endif()
+  else()
+    set(VISIBILITY_FLAGS "")
   endif()
 endif()
 
@@ -59,7 +62,7 @@ if(BUILD_X10)
         COMMAND
           rm -rf <SOURCE_DIR>/bazel-bin # ${CMAKE_COMMAND} -E rm -Rrf <SOURCE_DIR>/bazel-bin
         COMMAND
-          bazel build -c opt --define framework_shared_object=false //tensorflow/compiler/tf2xla/xla_tensor:x10 --nocheck_visibility
+          bazel build ${VISIBILITY_FLAGS} -c opt --define framework_shared_object=false //tensorflow/compiler/tf2xla/xla_tensor:x10 --nocheck_visibility
         COMMAND
           bazel shutdown
       INSTALL_COMMAND

--- a/Sources/CX10/device_wrapper.cc
+++ b/Sources/CX10/device_wrapper.cc
@@ -14,6 +14,8 @@
 
 #if defined(_WIN32)
 #define XLA_API __declspec(dllexport)
+#else
+#define XLA_API __attribute__((visibility("default")))
 #endif
 
 #include "device_wrapper.h"

--- a/Sources/CX10/device_wrapper.cc
+++ b/Sources/CX10/device_wrapper.cc
@@ -15,7 +15,7 @@
 #if defined(_WIN32)
 #define XLA_API __declspec(dllexport)
 #else
-#define XLA_API __attribute__((visibility("default")))
+#define XLA_API __attribute__((__visibility__("default")))
 #endif
 
 #include "device_wrapper.h"

--- a/Sources/CX10/xla_tensor_tf_ops.cc
+++ b/Sources/CX10/xla_tensor_tf_ops.cc
@@ -15,7 +15,7 @@
 #if defined(_WIN32)
 #define XLA_API __declspec(dllexport)
 #else
-#define XLA_API __attribute__((visibility("default"))) 
+#define XLA_API __attribute__((__visibility__("default"))) 
 #endif
 
 #include "xla_tensor_tf_ops.h"

--- a/Sources/CX10/xla_tensor_tf_ops.cc
+++ b/Sources/CX10/xla_tensor_tf_ops.cc
@@ -14,6 +14,8 @@
 
 #if defined(_WIN32)
 #define XLA_API __declspec(dllexport)
+#else
+#define XLA_API __attribute__((visibility("default"))) 
 #endif
 
 #include "xla_tensor_tf_ops.h"

--- a/Sources/CX10/xla_tensor_wrapper.cc
+++ b/Sources/CX10/xla_tensor_wrapper.cc
@@ -15,7 +15,7 @@
 #if defined(_WIN32)
 #define XLA_API __declspec(dllexport)
 #else
-#define XLA_API __attribute__((visibility("default")))
+#define XLA_API __attribute__((__visibility__("default")))
 #endif
 
 #include "xla_tensor_wrapper.h"

--- a/Sources/CX10/xla_tensor_wrapper.cc
+++ b/Sources/CX10/xla_tensor_wrapper.cc
@@ -15,7 +15,7 @@
 #if defined(_WIN32)
 #define XLA_API __declspec(dllexport)
 #else
-#define XLA_API
+#define XLA_API __attribute__((visibility("default")))
 #endif
 
 #include "xla_tensor_wrapper.h"


### PR DESCRIPTION
This fixes the immediate mode issue when the TensoFlow modules was used with swift because the symbols are not being loaded twice for llvm.

https://bugs.swift.org/projects/TF/issues/TF-1273