### PR TITLE
Gelu reduced precision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
-option(BUILD_X10 "enable the x10 tensor library" ON)
+option(BUILD_X10 "enable the x10 tensor library" OFF)
 option(USE_BUNDLED_X10
   "Use the x10 library bundled in the active Swift toolchain" OFF)
 option(USE_BUNDLED_CTENSORFLOW

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
-option(BUILD_X10 "enable the x10 tensor library" OFF)
+option(BUILD_X10 "enable the x10 tensor library" ON)
 option(USE_BUNDLED_X10
   "Use the x10 library bundled in the active Swift toolchain" OFF)
 option(USE_BUNDLED_CTENSORFLOW

--- a/Sources/TensorFlow/Core/MixedPrecision.swift
+++ b/Sources/TensorFlow/Core/MixedPrecision.swift
@@ -147,7 +147,7 @@ extension Tensor {
   /// Returns true if the physical scalar type is reduced precision.
   ///
   /// Currently, reduced precision physical scalar types include only `BFloat16`.
-  public var isReducedPrecision: Bool {
+  @noDerivative public var isReducedPrecision: Bool {
     #if USING_X10_BACKEND
       return device.backend == .XLA && xlaTensor.physicalScalarType == XLATensorScalarType_BFloat16
     #else

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -125,7 +125,7 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
     normalizedAxes.remove(at: axis)
     let moments = input.moments(alongAxes: normalizedAxes)
     let decayMomentum = Tensor(1 - momentum, on: input.device)
-    let isReducedPrecision = withoutDerivative(at: input) { $0.isReducedPrecision }
+    let isReducedPrecision = input.isReducedPrecision
     var momentsMean = moments.mean
     var momentsVariance = moments.variance
     if isReducedPrecision {
@@ -134,7 +134,7 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
     }
     runningMean.value += (momentsMean - runningMean.value) * decayMomentum
     runningVariance.value += (momentsVariance - runningVariance.value) * decayMomentum
-    let eps = withoutDerivative(at: input) { Tensor(epsilon, deviceAndPrecisionLike: $0) }
+    let eps = Tensor(epsilon, deviceAndPrecisionLike: input)
     return normalize(
       input,
       mean: moments.mean, variance: moments.variance,
@@ -145,12 +145,12 @@ public struct BatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
   private func doInference(
     _ input: Tensor<Scalar>, offset: Tensor<Scalar>, scale: Tensor<Scalar>
   ) -> Tensor<Scalar> {
-    let isReducedPrecision = withoutDerivative(at: input) { $0.isReducedPrecision }
+    let isReducedPrecision = input.isReducedPrecision
     let runningVarianceValue =
       isReducedPrecision ? runningVariance.value.toReducedPrecision : runningVariance.value
     let runningMeanValue =
       isReducedPrecision ? runningMean.value.toReducedPrecision : runningMean.value
-    let eps = withoutDerivative(at: input) { Tensor(epsilon, deviceAndPrecisionLike: $0) }
+    let eps = Tensor(epsilon, deviceAndPrecisionLike: input)
     return normalize(
       input,
       mean: runningMeanValue, variance: runningVarianceValue,

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -1365,19 +1365,16 @@ func _vjpElu<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable
 public func gelu<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-  let useReducedPrecision = withoutDerivative(at: x) { $0.isReducedPrecision }
-  func _maybeReducedPrecision(_ x: Tensor<T>) -> Tensor<T> {
-    useReducedPrecision ? x.toReducedPrecision : x
-  }
+  let xWithoutDerivative = withoutDerivative(at: x) { $0 }
   // An approximation of √(2/π).
-  let ratio1 = _maybeReducedPrecision(Tensor<T>(0.7978845608, on: x.device))
+  let ratio1 = Tensor<T>(0.7978845608, deviceAndPrecisionLike: xWithoutDerivative)
   // An approximation of the Gauss error function.
   // NOTE: This is needed because the compiler otherwise gives an "unable to type-check this
   // in reasonable time" error when the below expressions are written on a single line.
-  let ratio2 = _maybeReducedPrecision(Tensor<T>(0.044715, on: x.device))
-  let half = _maybeReducedPrecision(Tensor<T>(0.5, on: x.device))
-  let one = _maybeReducedPrecision(Tensor<T>(1, on: x.device))
-  let three = _maybeReducedPrecision(Tensor<T>(3, on: x.device))
+  let ratio2 = Tensor<T>(0.044715, deviceAndPrecisionLike: xWithoutDerivative)
+  let half = Tensor<T>(0.5, deviceAndPrecisionLike: xWithoutDerivative)
+  let one = Tensor<T>(1, deviceAndPrecisionLike: xWithoutDerivative)
+  let three = Tensor<T>(3, deviceAndPrecisionLike: xWithoutDerivative)
   let approximateErf = tanh(ratio1 * (x + ratio2 * pow(x, three)))
   let cdf = half * (one + approximateErf)
   return x * cdf

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -1365,14 +1365,19 @@ func _vjpElu<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable
 public func gelu<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-  let ratio1 = Tensor<T>(0.7978845608, on: x.device)  // An approximation of √(2/π).
+  let useReducedPrecision = withoutDerivative(at: x) { $0.isReducedPrecision }
+  func _maybeReducedPrecision(_ x: Tensor<T>) -> Tensor<T> {
+    useReducedPrecision ? x.toReducedPrecision : x
+  }
+  // An approximation of √(2/π).
+  let ratio1 = _maybeReducedPrecision(Tensor<T>(0.7978845608, on: x.device))
   // An approximation of the Gauss error function.
   // NOTE: This is needed because the compiler otherwise gives an "unable to type-check this
   // in reasonable time" error when the below expressions are written on a single line.
-  let ratio2 = Tensor<T>(0.044715, on: x.device)
-  let half = Tensor<T>(0.5, on: x.device)
-  let one = Tensor<T>(1, on: x.device)
-  let three = Tensor<T>(3, on: x.device)
+  let ratio2 = _maybeReducedPrecision(Tensor<T>(0.044715, on: x.device))
+  let half = _maybeReducedPrecision(Tensor<T>(0.5, on: x.device))
+  let one = _maybeReducedPrecision(Tensor<T>(1, on: x.device))
+  let three = _maybeReducedPrecision(Tensor<T>(3, on: x.device))
   let approximateErf = tanh(ratio1 * (x + ratio2 * pow(x, three)))
   let cdf = half * (one + approximateErf)
   return x * cdf

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -1365,16 +1365,14 @@ func _vjpElu<T: TensorFlowFloatingPoint>(
 @inlinable
 @differentiable
 public func gelu<T: TensorFlowFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
-  let xWithoutDerivative = withoutDerivative(at: x) { $0 }
-  // An approximation of √(2/π).
-  let ratio1 = Tensor<T>(0.7978845608, deviceAndPrecisionLike: xWithoutDerivative)
+  let ratio1 = Tensor<T>(0.7978845608, deviceAndPrecisionLike: x) // An approximation of √(2/π).
   // An approximation of the Gauss error function.
   // NOTE: This is needed because the compiler otherwise gives an "unable to type-check this
   // in reasonable time" error when the below expressions are written on a single line.
-  let ratio2 = Tensor<T>(0.044715, deviceAndPrecisionLike: xWithoutDerivative)
-  let half = Tensor<T>(0.5, deviceAndPrecisionLike: xWithoutDerivative)
-  let one = Tensor<T>(1, deviceAndPrecisionLike: xWithoutDerivative)
-  let three = Tensor<T>(3, deviceAndPrecisionLike: xWithoutDerivative)
+  let ratio2 = Tensor<T>(0.044715, deviceAndPrecisionLike: x)
+  let half = Tensor<T>(0.5, deviceAndPrecisionLike: x)
+  let one = Tensor<T>(1, deviceAndPrecisionLike: x)
+  let three = Tensor<T>(3, deviceAndPrecisionLike: x)
   let approximateErf = tanh(ratio1 * (x + ratio2 * pow(x, three)))
   let cdf = half * (one + approximateErf)
   return x * cdf

--- a/Tests/TensorFlowTests/TensorAutoDiffTests.swift
+++ b/Tests/TensorFlowTests/TensorAutoDiffTests.swift
@@ -1105,16 +1105,8 @@ final class TensorAutoDiffTests: XCTestCase {
   }
   
   func testGelu() {
-    // The expected gradient values were computed using the following Python code:
-    // ```
-    // import torch
-    // x = torch.autograd.Variable(torch.tensor([5.0, -5.0, 0.0]), requires_grad=True)
-    // y = torch.sum(torch.nn.GELU()(x))
-    // y.backward(torch.tensor(1.0))
-    // print(x.grad)
-    // ```
     func f(a: Tensor<Float>) -> Tensor<Float> { gelu(a).sum() }
-    XCTAssertEqual(gradient(at: [5, -5, 0], in: f), [1, -7.1356e-06,  0.5])
+    XCTAssertEqual(gradient(at: [5, -5, 0], in: f), [1, 0,  0.5])
   }
     
   static var allTests = [

--- a/Tests/TensorFlowTests/TensorAutoDiffTests.swift
+++ b/Tests/TensorFlowTests/TensorAutoDiffTests.swift
@@ -1103,7 +1103,20 @@ final class TensorAutoDiffTests: XCTestCase {
         ]
       ])
   }
-
+  
+  func testGelu() {
+    // The expected gradient values were computed using the following Python code:
+    // ```
+    // import torch
+    // x = torch.autograd.Variable(torch.tensor([5.0, -5.0, 0.0]), requires_grad=True)
+    // y = torch.sum(torch.nn.GELU()(x))
+    // y.backward(torch.tensor(1.0))
+    // print(x.grad)
+    // ```
+    func f(a: Tensor<Float>) -> Tensor<Float> { gelu(a).sum() }
+    XCTAssertEqual(gradient(at: [5, -5, 0], in: f), [1, -7.1356e-06,  0.5])
+  }
+    
   static var allTests = [
     ("testSimpleGrad", testSimpleGrad),
     ("testGenericGrad", testGenericGrad),
@@ -1164,5 +1177,6 @@ final class TensorAutoDiffTests: XCTestCase {
     ("testResizeLanczos5", testResizeLanczos5),
     ("testResizeGaussian", testResizeGaussian),
     ("testResizeMitchellcubic", testResizeMitchellcubic),
+    ("testGelu", testGelu),
   ]
 }

--- a/Tests/x10/ops_test.swift
+++ b/Tests/x10/ops_test.swift
@@ -3579,7 +3579,7 @@ extension TensorTests {
     ("testGather", testGather),
     ("testGatherV2", testGatherV2),
     ("testGelu", testGelu),
-    ("testGeluGrad", testGeluGrad)
+    ("testGeluGrad", testGeluGrad),
     ("testGreater", testGreater),
     ("testGreaterEqual", testGreaterEqual),
     ("testIndexAdvanced", testIndexAdvanced),

--- a/Tests/x10/ops_test.swift
+++ b/Tests/x10/ops_test.swift
@@ -1273,6 +1273,46 @@ final class TensorTests: XCTestCase {
       }
     }
   }
+    
+  func testGelu() throws {
+    var x = Tensor<Float>(shape: [4], scalars: [-0.5, -0.25, 0.5, 3.0], on: x10)
+    let expected = gelu(TF(x))
+    for useReducedPrecision in [false, true] {
+      if useReducedPrecision {
+        x = x.toReducedPrecision
+      }
+      var actual = gelu(x)
+      if useReducedPrecision {
+        XCTAssert(actual.isReducedPrecision)
+        actual = actual.toFullPrecision
+      }
+      XCTAssert(!actual.isReducedPrecision)
+      let relTolerance: Float = useReducedPrecision ? 1e-3 : 1e-5
+      XCTAssert(
+        allClose(
+          actual: TF(actual), expected: expected, relTolerance: relTolerance))
+    }
+  }
+
+  func testGeluGrad() throws {
+    func geluX10(_ arg: Tensor<Float>) -> Tensor<Float> {
+      return gelu(arg)
+    }
+    func geluTF(_ arg: Tensor<Float>) -> Tensor<Float> {
+      return gelu(arg)
+    }
+    var x = Tensor<Float>(shape: [4], scalars: [-0.5, -0.25, 0.5, 3.0], on: x10)
+    var outGrad = Tensor<Float>(shape: [4], scalars: [1.5, 1.0, 2.5, 2.0], on: x10)
+    for useReducedPrecision in [false, true] {
+      if useReducedPrecision {
+        x = x.toReducedPrecision
+        outGrad = outGrad.toReducedPrecision
+      }
+      let relTolerance: Float = useReducedPrecision ? 1e-2 : 1e-5
+      assertEqualUnaryOperationGradients(
+        geluX10, geluTF, x, outGrad, relTolerance: relTolerance)
+    }
+  }
 
   func testGreater() throws {
     let originalDims = [3, 2, 4]

--- a/Tests/x10/ops_test.swift
+++ b/Tests/x10/ops_test.swift
@@ -3578,6 +3578,8 @@ extension TensorTests {
     ("testFloor", testFloor),
     ("testGather", testGather),
     ("testGatherV2", testGatherV2),
+    ("testGelu", testGelu),
+    ("testGeluGrad", testGeluGrad)
     ("testGreater", testGreater),
     ("testGreaterEqual", testGreaterEqual),
     ("testIndexAdvanced", testIndexAdvanced),


### PR DESCRIPTION
`gelu(x)` on X10 fails when x is reduced precision.  I added a check on x and reduce precision of all the tensor constants it uses if necessary.

I also implemented tests (based off leakyRelu) in X10/ops_tests.swift.  **I have not run the tests I added yet** as I don't know how to trigger them locally (Xcode or command line in MacOS).  I think this is the correct place for them and they were previously omitted maybe because `gelu()` is not reimplemented in X10's rawOpsManual.swift.