### PR TITLE
Fix bugs and incorrect comments in Sampling.swift

### DIFF
--- a/Sources/TensorFlow/Epochs/Sampling.swift
+++ b/Sources/TensorFlow/Epochs/Sampling.swift
@@ -48,15 +48,15 @@ extension Sampling: Collection {
 
 extension Sampling: BidirectionalCollection
 where Selection: BidirectionalCollection {
-  /// Returns the position after `i`.
+  /// Returns the position before `i`.
   public func index(before i: Index) -> Index { selection.index(before: i) }
 }
 
 extension Sampling: RandomAccessCollection
-where Selection: BidirectionalCollection {
+where Selection: RandomAccessCollection {
   /// Returns the position `n` places from `i`.
   public func index(_ i: Index, offsetBy n: Int) -> Index {
-    selection.index(before: i)
+    selection.index(i, offsetBy: n)
   }
 
   // Needed because of https://bugs.swift.org/browse/SR-12692
@@ -66,15 +66,12 @@ where Selection: BidirectionalCollection {
   public func index(
     _ i: Index, offsetBy distance: Int, limitedBy limit: Index
   ) -> Index? {
-    // FIXME: swift-3-indexing-model: tests.
-    let l = self.distance(from: i, to: limit)
-    if distance > 0 ? l >= 0 && l < distance : l <= 0 && distance < l {
-      return nil
-    }
-    return index(i, offsetBy: distance)
+    selection.index(i, offsetBy: distance, limitedBy: limit)
   }
 
-  /// Returns the number of elements in `self[start..<end]`.
+  /// Returns the number of forward steps required to convert `start` into `end`.
+  ///
+  /// A negative result indicates that `end < start`.
   public func distance(from start: Index, to end: Index) -> Int {
     selection.distance(from: start, to: end)
   }

--- a/Sources/TensorFlow/Epochs/Sampling.swift
+++ b/Sources/TensorFlow/Epochs/Sampling.swift
@@ -44,28 +44,35 @@ extension Sampling: Collection {
 
   /// Returns the position after `i`.
   public func index(after i: Index) -> Index { selection.index(after: i) }
-}
 
-extension Sampling: BidirectionalCollection
-where Selection: BidirectionalCollection {
-  /// Returns the position before `i`.
-  public func index(before i: Index) -> Index { selection.index(before: i) }
-}
+  /// Returns the number of forward steps required to convert `start` into `end`.
+  ///
+  /// A negative result indicates that `end < start`.
+  public func distance(from start: Index, to end: Index) -> Int {
+    selection.distance(from: start, to: end)
+  }
 
-extension Sampling: RandomAccessCollection
-where Selection: RandomAccessCollection {
   /// Returns the position `n` places from `i`.
   public func index(_ i: Index, offsetBy n: Int) -> Index {
     selection.index(i, offsetBy: n)
   }
 
-  // Needed because of https://bugs.swift.org/browse/SR-12692
+  // 
   /// Returns `i` offset by `distance` unless that requires passing `limit`, in
   /// which case `nil` is returned.
   public func index(
     _ i: Index, offsetBy distance: Int, limitedBy limit: Index
   ) -> Index? {
     selection.index(i, offsetBy: distance, limitedBy: limit)
+  }
+}
+
+extension Sampling: BidirectionalCollection
+  where Selection: BidirectionalCollection
+{
+  /// Returns the position before `i`.
+  public func index(before i: Index) -> Index {
+    selection.index(before: i)
   }
 
   /// Returns the number of forward steps required to convert `start` into `end`.
@@ -74,7 +81,24 @@ where Selection: RandomAccessCollection {
   public func distance(from start: Index, to end: Index) -> Int {
     selection.distance(from: start, to: end)
   }
+
+  /// Returns the position `n` places from `i`.
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
+    selection.index(i, offsetBy: n)
+  }
+
+  // 
+  /// Returns `i` offset by `distance` unless that requires passing `limit`, in
+  /// which case `nil` is returned.
+  public func index(
+    _ i: Index, offsetBy distance: Int, limitedBy limit: Index
+  ) -> Index? {
+    selection.index(i, offsetBy: distance, limitedBy: limit)
+  }
 }
+
+extension Sampling: RandomAccessCollection
+  where Selection: RandomAccessCollection {}
 
 extension Collection {
   /// Returns a collection of elements of `self` at the positions and in the order

--- a/Sources/TensorFlow/Epochs/Sampling.swift
+++ b/Sources/TensorFlow/Epochs/Sampling.swift
@@ -62,7 +62,6 @@ where Selection: RandomAccessCollection {
   // Needed because of https://bugs.swift.org/browse/SR-12692
   /// Returns `i` offset by `distance` unless that requires passing `limit`, in
   /// which case `nil` is returned.
-  @inlinable
   public func index(
     _ i: Index, offsetBy distance: Int, limitedBy limit: Index
   ) -> Index? {

--- a/Tests/TensorFlowTests/CMakeLists.txt
+++ b/Tests/TensorFlowTests/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(TensorFlowTests
+  CollectionTesting.swift
   ContextTests.swift
   EpochsTests.swift
   FreezableTests.swift
@@ -17,6 +18,7 @@ add_library(TensorFlowTests
   LossTests.swift
   OptimizerTests.swift
   RuntimeTests.swift
+  SamplingTests.swift
   SequencedTests.swift
   SequencedTests.swift.gyb
   SequentialTests.swift

--- a/Tests/TensorFlowTests/CollectionTesting.swift
+++ b/Tests/TensorFlowTests/CollectionTesting.swift
@@ -1,0 +1,265 @@
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+// ************************************************
+// Checking the traversal properties of collections.
+
+/// A type that “generic type predicates” can conform to when their result is
+/// true.
+fileprivate protocol True {}
+
+/// A “generic type predicate” that detects whether a type is a
+/// `BidirectionalCollection`.
+fileprivate struct IsBidirectionalCollection<C> {}
+extension IsBidirectionalCollection: True where C : BidirectionalCollection {  }
+
+/// A “generic type predicate” that detects whether a type is a
+/// `RandomAccessCollection`.
+fileprivate struct IsRandomAccessCollection<C> {}
+extension IsRandomAccessCollection: True where C : RandomAccessCollection {  }
+
+extension Collection {
+  /// True iff `Self` conforms to `BidirectionalCollection`.
+  ///
+  /// Useful in asserting that a certain collection is *not* declared to conform
+  /// to `BidirectionalCollection`.
+  var isBidirectional: Bool {
+    return IsBidirectionalCollection<Self>.self is True.Type
+  }
+
+  /// True iff `Self` conforms to `RandomAccessCollection`.
+  ///
+  /// Useful in asserting that a certain collection is *not* declared to conform
+  /// to `RandomAccessCollection`.
+  var isRandomAccess: Bool {
+    return IsRandomAccessCollection<Self>.self is True.Type
+  }
+}
+
+// *********************************************************************
+// Checking collection semantics.  Note that these checks cannot see any
+// declarations that happen to shadow the protocol requirements. Those shadows
+// have to be tested separately.
+
+extension Collection where Element: Equatable {
+  /// XCTests `self`'s semantic conformance to `Collection`, expecting its
+  /// elements to match `expectedValues`.
+  ///
+  /// - Complexity: O(N²), where N is `self.count`.
+  /// - Note: the fact that a call to this method compiles verifies static
+  ///   conformance.
+  func checkCollectionConformance<
+    ExpectedValues: Collection>(expectedValues: ExpectedValues)
+  where ExpectedValues.Element == Element
+  {
+    var i = startIndex
+    var firstPassElements: [Element] = []
+    var remainingCount: Int = expectedValues.count
+    var offset: Int = 0
+    var expectedIndices = indices[...]
+    
+    while i != endIndex {
+      XCTAssertEqual(
+        i, expectedIndices.popFirst()!,
+        "elements of indices don't match index(after:) results.")
+      
+      XCTAssertLessThan(i, endIndex)
+      let j = self.index(after: i)
+      XCTAssertLessThan(i, j)
+      firstPassElements.append(self[i])
+      
+      XCTAssertEqual(index(i, offsetBy: remainingCount), endIndex)
+      if offset != 0 {
+        XCTAssertEqual(
+          index(startIndex, offsetBy: offset - 1, limitedBy: i),
+          index(startIndex, offsetBy: offset - 1))
+      }
+      
+      XCTAssertEqual(
+        index(startIndex, offsetBy: offset, limitedBy: i), i)
+      
+      if remainingCount != 0 {
+        XCTAssertEqual(
+          index(startIndex, offsetBy: offset + 1, limitedBy: i), nil)
+      }
+      
+      XCTAssertEqual(distance(from: i, to: endIndex), remainingCount)
+      i = j
+      remainingCount -= 1
+      offset += 1
+    }
+    XCTAssert(firstPassElements.elementsEqual(expectedValues))
+    
+    // Check that the second pass has the same elements.  We've verified that
+    // indices
+    XCTAssert(indices.lazy.map { self[$0] }.elementsEqual(expectedValues))
+  }
+
+  /// Returns `index(i, offsetBy: n)`, invoking the implementation that
+  /// satisfies the generic requirement, without interference from anything that
+  /// happens to shadow it.
+  func generic_index(_ i: Index, offsetBy n: Int) -> Index {
+    index(i, offsetBy: n)
+  }
+
+  /// Returns `index(i, offsetBy: n, limitedBy: limit)`, invoking the
+  /// implementation that satisfies the generic requirement, without
+  /// interference from anything that happens to shadow it.
+  func generic_index(
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
+  ) -> Index? {
+    index(i, offsetBy: n, limitedBy: limit)
+  }
+
+  /// Returns `distance(from: i, to: j)`, invoking the
+  /// implementation that satisfies the generic requirement, without
+  /// interference from anything that happens to shadow it.
+  func generic_distance(from i: Index, to j: Index) -> Int {
+    distance(from: i, to: j)
+  }
+}
+
+extension BidirectionalCollection where Element: Equatable {
+  /// XCTests `self`'s semantic conformance to `BidirectionalCollection`,
+  /// expecting its elements to match `expectedValues`.
+  ///
+  /// - Complexity: O(N²), where N is `self.count`.
+  /// - Note: the fact that a call to this method compiles verifies static
+  ///   conformance.
+  func checkBidirectionalCollectionConformance<
+    ExpectedValues: Collection>(expectedValues: ExpectedValues)
+  where ExpectedValues.Element == Element
+  {
+    checkCollectionConformance(expectedValues: expectedValues)
+    var i = startIndex
+    while i != endIndex {
+      let j = index(after: i)
+      XCTAssertEqual(index(before: j), i)
+      let offset = distance(from: i, to: startIndex)
+      XCTAssertLessThanOrEqual(offset, 0)
+      XCTAssertEqual(index(i, offsetBy: offset), startIndex)
+      i = j
+    }
+  }
+}
+
+/// Shared storage for operation counts.
+///
+/// This is a class:
+/// - so that increments aren't missed due to copies
+/// - because non-mutating operations on `RandomAccessOperationCounter` have
+///   to update it.
+class RandomAccessOperationCounts {
+  /// The number of invocations of `index(after:)`
+  var indexAfter = 0
+  /// The number of invocations of `index(before:)`
+  var indexBefore = 0
+
+  /// Reset all counts to zero.
+  func reset() { (indexAfter, indexBefore) = (0, 0) }
+}
+
+
+/// A wrapper over some `Base` collection that counts index increment/decrement
+/// operations.
+///
+/// This wrapper is useful for verifying that generic collection types that
+/// conditionally conform to `RandomAccessCollection` are actually providing the
+/// correct complexity.
+struct RandomAccessOperationCounter<Base: RandomAccessCollection> {
+  var base: Base
+  
+  typealias Index = Base.Index
+  typealias Element = Base.Element
+
+  /// The number of index incrementat/decrement operations applied to `self` and
+  /// all its copies.
+  var operationCounts = RandomAccessOperationCounts()
+}
+
+extension RandomAccessOperationCounter: RandomAccessCollection {  
+  var startIndex: Index { base.startIndex }
+  var endIndex: Index { base.endIndex }
+  subscript(i: Index) -> Base.Element { base[i] }
+  
+  func index(after i: Index) -> Index {
+    operationCounts.indexAfter += 1
+    return base.index(after: i)
+  }
+  func index(before i: Index) -> Index {
+    operationCounts.indexBefore += 1
+    return base.index(before: i)
+  }
+  func index(_ i: Index, offsetBy n: Int) -> Index {
+    base.index(i, offsetBy: n)
+  }
+
+  func index(_ i: Index, offsetBy n: Int, limitedBy limit: Index) -> Index? {
+    base.index(i, offsetBy: n, limitedBy: limit)
+  }
+
+  func distance(from i: Index, to j: Index) -> Int {
+    base.distance(from: i, to: j)
+  }
+}
+
+extension RandomAccessCollection where Element: Equatable {
+  /// XCTests `self`'s semantic conformance to `RandomAccessCollection`,
+  /// expecting its elements to match `expectedValues`.
+  ///
+  /// - Parameter operationCounts: if supplied, should be an instance that
+  ///   tracks operations in copies of `self`.
+  ///
+  /// - Complexity: O(N²), where N is `self.count`.
+  ///
+  /// - Note: the fact that a call to this method compiles verifies static
+  ///   conformance.
+  func checkRandomAccessCollectionConformance<ExpectedValues: Collection>(
+    expectedValues: ExpectedValues,
+    operationCounts: RandomAccessOperationCounts = .init()
+  )
+  where ExpectedValues.Element == Element
+  {
+    checkBidirectionalCollectionConformance(expectedValues: expectedValues)
+    operationCounts.reset()
+    
+    XCTAssertEqual(generic_distance(from: startIndex, to: endIndex), count)
+    XCTAssertEqual(operationCounts.indexAfter, 0)
+    XCTAssertEqual(operationCounts.indexBefore, 0)
+    
+    XCTAssertEqual(generic_distance(from: endIndex, to: startIndex), -count)
+    XCTAssertEqual(operationCounts.indexAfter, 0)
+    XCTAssertEqual(operationCounts.indexBefore, 0)
+
+    XCTAssertEqual(index(startIndex, offsetBy: count), endIndex)
+    XCTAssertEqual(operationCounts.indexAfter, 0)
+    XCTAssertEqual(operationCounts.indexBefore, 0)
+    
+    XCTAssertEqual(index(endIndex, offsetBy: -count), startIndex)
+    XCTAssertEqual(operationCounts.indexAfter, 0)
+    XCTAssertEqual(operationCounts.indexBefore, 0)
+
+    XCTAssertEqual(
+      index(startIndex, offsetBy: count, limitedBy: endIndex), endIndex)
+    XCTAssertEqual(operationCounts.indexAfter, 0)
+    XCTAssertEqual(operationCounts.indexBefore, 0)
+    
+    XCTAssertEqual(
+      index(endIndex, offsetBy: -count, limitedBy: startIndex), startIndex)
+    XCTAssertEqual(operationCounts.indexAfter, 0)
+    XCTAssertEqual(operationCounts.indexBefore, 0)
+  }
+}

--- a/Tests/TensorFlowTests/SamplingTests.swift
+++ b/Tests/TensorFlowTests/SamplingTests.swift
@@ -15,150 +15,6 @@
 import TensorFlow
 import XCTest
 
-extension Collection where Element: Equatable {
-  /// Tests `self`'s dynamic conformance to `Collection`, expecting its elements
-  /// to match `expectedValues`.
-  ///
-  /// - Complexity: O(N²), where N is `self.count`.
-  /// - Note: the fact that a call to this method compiles verifies static
-  ///   conformance.
-  func checkCollectionConformance<
-    ExpectedValues: Collection>(expectedValues: ExpectedValues)
-  where ExpectedValues.Element == Element
-  {
-    var i = startIndex
-    var firstPassElements: [Element] = []
-    var remainingCount: Int = expectedValues.count
-    var offset: Int = 0
-    var expectedIndices = indices[...]
-    
-    while i != endIndex {
-      XCTAssertEqual(
-        i, expectedIndices.popFirst()!,
-        "elements of indices don't match index(after:) results.")
-      
-      XCTAssertLessThan(i, endIndex)
-      let j = self.index(after: i)
-      XCTAssertLessThan(i, j)
-      firstPassElements.append(self[i])
-      
-      XCTAssertEqual(index(i, offsetBy: remainingCount), endIndex)
-      if offset != 0 {
-        XCTAssertEqual(
-          index(startIndex, offsetBy: offset - 1, limitedBy: i),
-          index(startIndex, offsetBy: offset - 1))
-      }
-      
-      XCTAssertEqual(
-        index(startIndex, offsetBy: offset, limitedBy: i), i)
-      
-      if remainingCount != 0 {
-        XCTAssertEqual(
-          index(startIndex, offsetBy: offset + 1, limitedBy: i), nil)
-      }
-      
-      XCTAssertEqual(distance(from: i, to: endIndex), remainingCount)
-      i = j
-      remainingCount -= 1
-      offset += 1
-    }
-    XCTAssert(firstPassElements.elementsEqual(expectedValues))
-    
-    // Check that the second pass has the same elements.  We've verified that
-    // indices
-    XCTAssert(indices.lazy.map { self[$0] }.elementsEqual(expectedValues))
-  }
-
-  func generic_index(_ i: Index, offsetBy n: Int) -> Index {
-    index(i, offsetBy: n)
-  }
-
-  func generic_index(
-    _ i: Index, offsetBy n: Int, limitedBy limit: Index
-  ) -> Index? {
-    index(i, offsetBy: n, limitedBy: limit)
-  }
-
-  func generic_distance(from i: Index, to j: Index) -> Int {
-    distance(from: i, to: j)
-  }
-}
-
-extension BidirectionalCollection where Element: Equatable {
-  /// Tests `self`'s dynamic conformance to `BidirectionalCollection`, expecting
-  /// its elements to match `expectedValues`.
-  ///
-  /// - Complexity: O(N²), where N is `self.count`.
-  /// - Note: the fact that a call to this method compiles verifies static
-  ///   conformance.
-  func checkBidirectionalCollectionConformance<
-    ExpectedValues: Collection>(expectedValues: ExpectedValues)
-  where ExpectedValues.Element == Element
-  {
-    checkCollectionConformance(expectedValues: expectedValues)
-    var i = startIndex
-    while i != endIndex {
-      let j = index(after: i)
-      XCTAssertEqual(index(before: j), i)
-      let offset = distance(from: i, to: startIndex)
-      XCTAssertLessThanOrEqual(offset, 0)
-      XCTAssertEqual(index(i, offsetBy: offset), startIndex)
-      i = j
-    }
-  }
-}
-
-struct RandomAccessOperationCounter<Base: RandomAccessCollection> {
-  var base: Base
-  
-  typealias Index = Base.Index
-  typealias Element = Base.Element
-
-  class OperationCounts {
-    var indexAfter = 0
-    var indexBefore = 0
-  }
-  
-  var operationCounts = OperationCounts()
-  
-  mutating func reset() {
-    operationCounts.indexAfter = 0
-    operationCounts.indexBefore = 0
-  }
-}
-
-extension RandomAccessOperationCounter: Collection {  
-  var startIndex: Index { base.startIndex }
-  var endIndex: Index { base.endIndex }
-  subscript(i: Index) -> Base.Element { base[i] }
-  
-  func index(after i: Index) -> Index {
-    operationCounts.indexAfter += 1
-    return base.index(after: i)
-  }
-}
-
-extension RandomAccessOperationCounter: BidirectionalCollection {
-  func index(before i: Index) -> Index {
-    operationCounts.indexBefore += 1
-    return base.index(before: i)
-  }
-}
-
-extension RandomAccessOperationCounter: RandomAccessCollection {
-  func index(_ i: Index, offsetBy n: Int) -> Index {
-    base.index(i, offsetBy: n)
-  }
-
-  func index(_ i: Index, offsetBy n: Int, limitedBy limit: Index) -> Index? {
-    base.index(i, offsetBy: n, limitedBy: limit)
-  }
-
-  func distance(from i: Index, to j: Index) -> Int {
-    base.distance(from: i, to: j)
-  }
-}
-
 final class SamplingTests: XCTestCase {
   func test_init() {
     let a = Sampling(base: Array(3..<100), selection: [7, 9, 8])
@@ -179,6 +35,8 @@ final class SamplingTests: XCTestCase {
     let b = 0...20
     let d = Sampling(base: b, selection: AnyCollection(b.indices))
     d.checkCollectionConformance(expectedValues: b)
+    XCTAssertFalse(d.isBidirectional)
+    XCTAssertFalse(d.isRandomAccess)
   }
 
   func test_BidirectionalCollection() {
@@ -186,48 +44,25 @@ final class SamplingTests: XCTestCase {
     let d = Sampling(
       base: b, selection: AnyBidirectionalCollection(b.indices))
     d.checkBidirectionalCollectionConformance(expectedValues: b)
+    XCTAssert(d.isBidirectional)
+    XCTAssertFalse(d.isRandomAccess)
   }
 
   func test_RandomAccessCollection() {
-    let b = 0...20
+    // Can't use 0...20 directly because of
+    // https://bugs.swift.org/browse/SR-1288.  Array's Indices seem to work
+    // properly, though.
+    let b = Array(0...20)
     let d = Sampling(base: b, selection: b.indices)
-    d.checkBidirectionalCollectionConformance(expectedValues: b)
+    print(type(of: b.indices))
+    d.checkRandomAccessCollectionConformance(expectedValues: b)
+    XCTAssert(d.isBidirectional)
+    XCTAssert(d.isRandomAccess)
     
     let instrumentedIndices = RandomAccessOperationCounter(base: b.indices)
-    let operationCounts = instrumentedIndices.operationCounts
     let d1 = Sampling(base: b, selection: instrumentedIndices)
-
-    XCTAssertEqual(
-      d1.generic_distance(from: d1.startIndex, to: d1.endIndex),
-      d1.count)
-    XCTAssertEqual(operationCounts.indexAfter, 0)
-    XCTAssertEqual(operationCounts.indexBefore, 0)
-    
-    XCTAssertEqual(
-      d1.generic_distance(from: d1.endIndex, to: d1.startIndex),
-      -d1.count)
-    XCTAssertEqual(operationCounts.indexAfter, 0)
-    XCTAssertEqual(operationCounts.indexBefore, 0)
-
-    XCTAssertEqual(d1.index(d1.startIndex, offsetBy: d1.count), d1.endIndex)
-    XCTAssertEqual(operationCounts.indexAfter, 0)
-    XCTAssertEqual(operationCounts.indexBefore, 0)
-    
-    XCTAssertEqual(d1.index(d1.endIndex, offsetBy: -d1.count), d1.startIndex)
-    XCTAssertEqual(operationCounts.indexAfter, 0)
-    XCTAssertEqual(operationCounts.indexBefore, 0)
-
-    XCTAssertEqual(
-      d1.index(d1.startIndex, offsetBy: d1.count, limitedBy: d1.endIndex),
-      d1.endIndex)
-    XCTAssertEqual(operationCounts.indexAfter, 0)
-    XCTAssertEqual(operationCounts.indexBefore, 0)
-    
-    XCTAssertEqual(
-      d1.index(d1.endIndex, offsetBy: -d1.count, limitedBy: d1.startIndex),
-      d1.startIndex)
-    XCTAssertEqual(operationCounts.indexAfter, 0)
-    XCTAssertEqual(operationCounts.indexBefore, 0)
+    d1.checkRandomAccessCollectionConformance(
+      expectedValues: b, operationCounts: instrumentedIndices.operationCounts)
 }
 
   static var allTests = [

--- a/Tests/TensorFlowTests/SamplingTests.swift
+++ b/Tests/TensorFlowTests/SamplingTests.swift
@@ -1,0 +1,239 @@
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import TensorFlow
+import XCTest
+
+extension Collection where Element: Equatable {
+  /// Tests `self`'s dynamic conformance to `Collection`, expecting its elements
+  /// to match `expectedValues`.
+  ///
+  /// - Complexity: O(N²), where N is `self.count`.
+  /// - Note: the fact that a call to this method compiles verifies static
+  ///   conformance.
+  func checkCollectionConformance<
+    ExpectedValues: Collection>(expectedValues: ExpectedValues)
+  where ExpectedValues.Element == Element
+  {
+    var i = startIndex
+    var firstPassElements: [Element] = []
+    var remainingCount: Int = expectedValues.count
+    var offset: Int = 0
+    var expectedIndices = indices[...]
+    
+    while i != endIndex {
+      XCTAssertEqual(
+        i, expectedIndices.popFirst()!,
+        "elements of indices don't match index(after:) results.")
+      
+      XCTAssertLessThan(i, endIndex)
+      let j = self.index(after: i)
+      XCTAssertLessThan(i, j)
+      firstPassElements.append(self[i])
+      
+      XCTAssertEqual(index(i, offsetBy: remainingCount), endIndex)
+      if offset != 0 {
+        XCTAssertEqual(
+          index(startIndex, offsetBy: offset - 1, limitedBy: i),
+          index(startIndex, offsetBy: offset - 1))
+      }
+      
+      XCTAssertEqual(
+        index(startIndex, offsetBy: offset, limitedBy: i), i)
+      
+      if remainingCount != 0 {
+        XCTAssertEqual(
+          index(startIndex, offsetBy: offset + 1, limitedBy: i), nil)
+      }
+      
+      XCTAssertEqual(distance(from: i, to: endIndex), remainingCount)
+      i = j
+      remainingCount -= 1
+      offset += 1
+    }
+    XCTAssert(firstPassElements.elementsEqual(expectedValues))
+    
+    // Check that the second pass has the same elements.  We've verified that
+    // indices
+    XCTAssert(indices.lazy.map { self[$0] }.elementsEqual(expectedValues))
+  }
+
+  func generic_index(_ i: Index, offsetBy n: Int) -> Index {
+    index(i, offsetBy: n)
+  }
+
+  func generic_index(
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
+  ) -> Index? {
+    index(i, offsetBy: n, limitedBy: limit)
+  }
+
+  func generic_distance(from i: Index, to j: Index) -> Int {
+    distance(from: i, to: j)
+  }
+}
+
+extension BidirectionalCollection where Element: Equatable {
+  /// Tests `self`'s dynamic conformance to `BidirectionalCollection`, expecting
+  /// its elements to match `expectedValues`.
+  ///
+  /// - Complexity: O(N²), where N is `self.count`.
+  /// - Note: the fact that a call to this method compiles verifies static
+  ///   conformance.
+  func checkBidirectionalCollectionConformance<
+    ExpectedValues: Collection>(expectedValues: ExpectedValues)
+  where ExpectedValues.Element == Element
+  {
+    checkCollectionConformance(expectedValues: expectedValues)
+    var i = startIndex
+    while i != endIndex {
+      let j = index(after: i)
+      XCTAssertEqual(index(before: j), i)
+      let offset = distance(from: i, to: startIndex)
+      XCTAssertLessThanOrEqual(offset, 0)
+      XCTAssertEqual(index(i, offsetBy: offset), startIndex)
+      i = j
+    }
+  }
+}
+
+struct RandomAccessOperationCounter<Base: RandomAccessCollection> {
+  var base: Base
+  
+  typealias Index = Base.Index
+  typealias Element = Base.Element
+
+  class OperationCounts {
+    var indexAfter = 0
+    var indexBefore = 0
+  }
+  
+  var operationCounts = OperationCounts()
+  
+  mutating func reset() {
+    operationCounts.indexAfter = 0
+    operationCounts.indexBefore = 0
+  }
+}
+
+extension RandomAccessOperationCounter: Collection {  
+  var startIndex: Index { base.startIndex }
+  var endIndex: Index { base.endIndex }
+  subscript(i: Index) -> Base.Element { base[i] }
+  
+  func index(after i: Index) -> Index {
+    operationCounts.indexAfter += 1
+    return base.index(after: i)
+  }
+}
+
+extension RandomAccessOperationCounter: BidirectionalCollection {
+  func index(before i: Index) -> Index {
+    operationCounts.indexBefore += 1
+    return base.index(before: i)
+  }
+}
+
+extension RandomAccessOperationCounter: RandomAccessCollection {
+  func index(_ i: Index, offsetBy n: Int) -> Index {
+    base.index(i, offsetBy: n)
+  }
+
+  func index(_ i: Index, offsetBy n: Int, limitedBy limit: Index) -> Index? {
+    base.index(i, offsetBy: n, limitedBy: limit)
+  }
+
+  func distance(from i: Index, to j: Index) -> Int {
+    base.distance(from: i, to: j)
+  }
+}
+
+final class SamplingTests: XCTestCase {
+  func test_init() {
+    let a = Sampling(base: Array(3..<100), selection: [7, 9, 8])
+    XCTAssert(a.elementsEqual([10, 12, 11]))
+
+    let b = Set(0...20)
+    let c = Sampling(base: b, selection: b.indices)
+    XCTAssert(b.elementsEqual(c))
+
+    let d = Sampling(
+      base: b,
+      selection: (0...20).lazy.map { b.firstIndex(of: $0)! })
+    
+    XCTAssert(d.elementsEqual(0...20))
+  }
+
+  func test_Collection() {
+    let b = 0...20
+    let d = Sampling(base: b, selection: AnyCollection(b.indices))
+    d.checkCollectionConformance(expectedValues: b)
+  }
+
+  func test_BidirectionalCollection() {
+    let b = 0...20
+    let d = Sampling(
+      base: b, selection: AnyBidirectionalCollection(b.indices))
+    d.checkBidirectionalCollectionConformance(expectedValues: b)
+  }
+
+  func test_RandomAccessCollection() {
+    let b = 0...20
+    let d = Sampling(base: b, selection: b.indices)
+    d.checkBidirectionalCollectionConformance(expectedValues: b)
+    
+    let instrumentedIndices = RandomAccessOperationCounter(base: b.indices)
+    let operationCounts = instrumentedIndices.operationCounts
+    let d1 = Sampling(base: b, selection: instrumentedIndices)
+
+    XCTAssertEqual(
+      d1.generic_distance(from: d1.startIndex, to: d1.endIndex),
+      d1.count)
+    XCTAssertEqual(operationCounts.indexAfter, 0)
+    XCTAssertEqual(operationCounts.indexBefore, 0)
+    
+    XCTAssertEqual(
+      d1.generic_distance(from: d1.endIndex, to: d1.startIndex),
+      -d1.count)
+    XCTAssertEqual(operationCounts.indexAfter, 0)
+    XCTAssertEqual(operationCounts.indexBefore, 0)
+
+    XCTAssertEqual(d1.index(d1.startIndex, offsetBy: d1.count), d1.endIndex)
+    XCTAssertEqual(operationCounts.indexAfter, 0)
+    XCTAssertEqual(operationCounts.indexBefore, 0)
+    
+    XCTAssertEqual(d1.index(d1.endIndex, offsetBy: -d1.count), d1.startIndex)
+    XCTAssertEqual(operationCounts.indexAfter, 0)
+    XCTAssertEqual(operationCounts.indexBefore, 0)
+
+    XCTAssertEqual(
+      d1.index(d1.startIndex, offsetBy: d1.count, limitedBy: d1.endIndex),
+      d1.endIndex)
+    XCTAssertEqual(operationCounts.indexAfter, 0)
+    XCTAssertEqual(operationCounts.indexBefore, 0)
+    
+    XCTAssertEqual(
+      d1.index(d1.endIndex, offsetBy: -d1.count, limitedBy: d1.startIndex),
+      d1.startIndex)
+    XCTAssertEqual(operationCounts.indexAfter, 0)
+    XCTAssertEqual(operationCounts.indexBefore, 0)
+}
+
+  static var allTests = [
+    ("test_init", test_init),
+    ("test_Collection", test_Collection),
+    ("test_BidirectionalCollection", test_BidirectionalCollection),
+    ("test_RandomAccessCollection", test_RandomAccessCollection),
+  ]
+}

--- a/Tests/TensorFlowTests/XCTestManifests.swift
+++ b/Tests/TensorFlowTests/XCTestManifests.swift
@@ -40,6 +40,7 @@ import XCTest
       testCase(NNTests.allTests),
       testCase(OptimizerTests.allTests),
       testCase(RuntimeTests.allTests),
+      testCase(SamplingTests.allTests),
       testCase(SequencedTests.allTests),
       testCase(SequentialTests.allTests),
       testCase(TensorAutoDiffTests.allTests),


### PR DESCRIPTION
@sgugger I was a little shocked at the brokenness of `index(_:offsetBy:)` and not pointing any fingers 'cause I might have written it that way, but do you think you could come up with tests for all these APIs that verify them?