### PR TITLE
Removing reliance on experimental TF_GetServerDef TensorFlow api

### DIFF
--- a/Sources/TensorFlow/Core/Runtime.swift
+++ b/Sources/TensorFlow/Core/Runtime.swift
@@ -285,19 +285,15 @@ public final class _ExecutionContext {
     TFE_DeleteContextOptions(opts)
     checkOk(status)
 
-    #if !os(Windows)
-      if case .remote(let serverDef) = _RuntimeConfig.session {
-        debugLog("Setting up the server def to \(serverDef)...")
-        let serverDef: UnsafeMutablePointer<TF_Buffer>! = TFE_GetServerDef(
-          serverDef, status)
-        checkOk(status)
+    if case .remote(let serverDef) = _RuntimeConfig.session {
+      debugLog("Setting up the server def to \(serverDef)...")	
+      serverDef.utf8CString.withUnsafeBufferPointer { ptr in
         TFE_ContextSetServerDef(
-          eagerContext, /*keep_alive_secs*/ 0, serverDef.pointee.data,
-          serverDef.pointee.length, status)
+          eagerContext, /*keep_alive_secs*/ 0, ptr.baseAddress,
+          serverDef.utf8CString.count, status)
         checkOk(status)
-        TF_DeleteBuffer(serverDef)
       }
-    #endif
+    }
 
     let devices = TFE_ContextListDevices(eagerContext, status)
     checkOk(status)

--- a/Sources/TensorFlow/Core/Runtime.swift
+++ b/Sources/TensorFlow/Core/Runtime.swift
@@ -285,6 +285,7 @@ public final class _ExecutionContext {
     TFE_DeleteContextOptions(opts)
     checkOk(status)
 
+    #if !os(Windows)
     if case .remote(let serverDef) = _RuntimeConfig.session {
       debugLog("Setting up the server def to \(serverDef)...")	
       serverDef.utf8CString.withUnsafeBufferPointer { ptr in
@@ -294,6 +295,7 @@ public final class _ExecutionContext {
         checkOk(status)
       }
     }
+    #endif
 
     let devices = TFE_ContextListDevices(eagerContext, status)
     checkOk(status)


### PR DESCRIPTION
Removing reliance on experimental TF_GetServerDef TensorFlow api.

This will unblock: https://github.com/tensorflow/swift-apis/pull/957
Part of: https://github.com/tensorflow/swift-apis/issues/970