### PR TITLE
Revert SR-10697 workaround for in swift-apis TF-507

### DIFF
--- a/Sources/TensorFlow/Layers/Recurrent.swift
+++ b/Sources/TensorFlow/Layers/Recurrent.swift
@@ -94,14 +94,7 @@ public struct BasicRNNCell<Scalar: TensorFlowFloatingPoint>: RecurrentLayerCell 
   public var weight: Tensor<Scalar>
   public var bias: Tensor<Scalar>
 
-  // TODO(TF-507): Revert to `typealias State = Tensor<Scalar>` after SR-10697 is fixed.
-  public struct State: Equatable, Differentiable, VectorProtocol, KeyPathIterable {
-    public var value: Tensor<Scalar>
-    public init(_ value: Tensor<Scalar>) {
-      self.value = value
-    }
-  }
-
+  public typealias State = Tensor<Scalar>
   public typealias TimeStepInput = Tensor<Scalar>
   public typealias TimeStepOutput = State
   public typealias Input = RNNCellInput<TimeStepInput, State>
@@ -121,7 +114,7 @@ public struct BasicRNNCell<Scalar: TensorFlowFloatingPoint>: RecurrentLayerCell 
 
   /// Returns a zero-valued state with shape compatible with the provided input.
   public func zeroState(for input: Tensor<Scalar>) -> State {
-    State(Tensor(zeros: [input.shape[0], weight.shape[1]], on: input.device))
+    Tensor(zeros: [input.shape[0], weight.shape[1]], on: input.device)
   }
 
   /// Returns the output obtained from applying the layer to the given input.
@@ -130,8 +123,8 @@ public struct BasicRNNCell<Scalar: TensorFlowFloatingPoint>: RecurrentLayerCell 
   /// - Returns: The hidden state.
   @differentiable
   public func callAsFunction(_ input: Input) -> Output {
-    let concatenatedInput = input.input.concatenated(with: input.state.value, alongAxis: 1)
-    let newState = State(tanh(matmul(concatenatedInput, weight) + bias))
+    let concatenatedInput = input.input.concatenated(with: input.state, alongAxis: 1)
+    let newState = tanh(matmul(concatenatedInput, weight) + bias)
     return Output(output: newState, state: newState)
   }
 }
@@ -234,28 +227,11 @@ public struct LSTMCell<Scalar: TensorFlowFloatingPoint>: RecurrentLayerCell {
     let fused = matmul(gateInput, fusedWeight) + fusedBias
     let batchSize = fused.shape[0]
     let hiddenSize = fused.shape[1] / 4
-    let inputGate = sigmoid(
-      fused.slice(
-        lowerBounds: [0, 0],
-        upperBounds: [batchSize, hiddenSize]))
-    let updateGate = tanh(
-      fused.slice(
-        lowerBounds: [0, hiddenSize],
-        upperBounds: [batchSize, 2 * hiddenSize]))
-    let forgetGate = sigmoid(
-      fused.slice(
-        lowerBounds: [0, 2 * hiddenSize],
-        upperBounds: [batchSize, 3 * hiddenSize]))
-    let outputGate = sigmoid(
-      fused.slice(
-        lowerBounds: [0, 3 * hiddenSize],
-        upperBounds: [batchSize, 4 * hiddenSize]))
-    // TODO(SR-10697/TF-507): Replace with the following once it does not crash the compiler.
-    // let fusedParts = fused.split(count: 4, alongAxis: 1)
-    // let inputGate = sigmoid(fusedParts[0])
-    // let updateGate = tanh(fusedParts[1])
-    // let forgetGate = sigmoid(fusedParts[2])
-    // let outputGate = sigmoid(fusedParts[3])
+    let fusedParts = fused.split(count: 4, alongAxis: 1)
+    let inputGate = sigmoid(fusedParts[0])
+    let updateGate = tanh(fusedParts[1])
+    let forgetGate = sigmoid(fusedParts[2])
+    let outputGate = sigmoid(fusedParts[3])
 
     let newCellState = input.state.cell * forgetGate + inputGate * updateGate
     let newHiddenState = tanh(newCellState) * outputGate
@@ -280,9 +256,10 @@ public struct GRUCell<Scalar: TensorFlowFloatingPoint>: RecurrentLayerCell {
   }
 
   public func zeroState(for input: Tensor<Scalar>) -> State {
-    return State(hidden: Tensor(zeros: stateShape, on: input.device))
+    return Tensor(zeros: stateShape, on: input.device)
   }
 
+  public typealias State = Tensor<Scalar>
   public typealias TimeStepInput = Tensor<Scalar>
   public typealias TimeStepOutput = State
   public typealias Input = RNNCellInput<TimeStepInput, State>
@@ -316,17 +293,6 @@ public struct GRUCell<Scalar: TensorFlowFloatingPoint>: RecurrentLayerCell {
     self.outputRecurrentBias = biasInitializer(gateBiasShape)
   }
 
-  // TODO(TF-507): Revert to `typealias State = Tensor<Scalar>` after
-  // SR-10697 is fixed.
-  public struct State: Equatable, Differentiable, VectorProtocol, KeyPathIterable {
-    public var hidden: Tensor<Scalar>
-
-    @differentiable
-    public init(hidden: Tensor<Scalar>) {
-      self.hidden = hidden
-    }
-  }
-
   /// Returns the output obtained from applying the layer to the given input.
   ///
   /// - Parameter input: The input to the layer.
@@ -335,20 +301,20 @@ public struct GRUCell<Scalar: TensorFlowFloatingPoint>: RecurrentLayerCell {
   public func callAsFunction(_ input: Input) -> Output {
     let updateGate = sigmoid(
       (matmul(input.input, updateKernel) + updateBias)
-      + (matmul(input.state.hidden, updateRecurrentKernel) + updateRecurrentBias)
+      + (matmul(input.state, updateRecurrentKernel) + updateRecurrentBias)
     )
     let resetGate = sigmoid(
       (matmul(input.input, resetKernel) + resetBias)
-      + (matmul(input.state.hidden, resetRecurrentKernel) + resetRecurrentBias)
+      + (matmul(input.state, resetRecurrentKernel) + resetRecurrentBias)
     )
     let outputGate = tanh(
       (matmul(input.input, outputKernel) + outputBias)
-      + resetGate * (matmul(input.state.hidden, outputRecurrentKernel) + outputRecurrentBias)
+      + resetGate * (matmul(input.state, outputRecurrentKernel) + outputRecurrentBias)
     )
 
-    let updateHidden = updateGate * input.state.hidden
+    let updateHidden = updateGate * input.state
     let updateOutput = (1 - updateGate) * outputGate
-    let newState = State(hidden: updateHidden + updateOutput)
+    let newState = State(updateHidden + updateOutput)
 
     return Output(output: newState, state: newState)
   }

--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -1373,14 +1373,10 @@ final class LayerTests: XCTestCase {
     var cell = BasicRNNCell<Float>(inputSize: 2, hiddenSize: 5)
     cell.weight = weight
     cell.bias = bias
-    let state = BasicRNNCell.State(
-      Tensor<Float>(ones: [1, 5]) * Tensor<Float>([1, 0.2, 0.5, 2, 0.6])
-    )
+    let state = Tensor<Float>(ones: [1, 5]) * Tensor<Float>([1, 0.2, 0.5, 2, 0.6])
     let input = Tensor<Float>(ones: [1, 2]) * Tensor<Float>([0.3, 0.7])
     let output = cell(input: input, state: state).state
-    let expected = BasicRNNCell.State(
-      Tensor<Float>([[0.9921227, 0.9999934, 0.9921227, 0.9999934, 0.9921227]])
-    )
+    let expected = Tensor<Float>([[0.9921227, 0.9999934, 0.9921227, 0.9999934, 0.9921227]])
     XCTAssertEqual(output, expected)
   }
 
@@ -1566,11 +1562,11 @@ final class LayerTests: XCTestCase {
         initialState: initialState
       )
       assertEqual(
-        Tensor(concatenating: outputs.map { $0.value }),
+        Tensor(concatenating: outputs.map { $0 }),
         expectedStates,
         accuracy: 1e-6)
       assertEqual(
-        outputs.last!.value,
+        outputs.last!,
         expectedFinalState,
         accuracy: 1e-6)
 
@@ -1579,7 +1575,7 @@ final class LayerTests: XCTestCase {
           rnn.lastOutput(
             from: inputs, 
             initialState: initialState
-          ).value.sum()
+          ).sum()
         }
       assertEqual(
         outputSum,
@@ -1598,7 +1594,7 @@ final class LayerTests: XCTestCase {
         expectedGradX,
         accuracy: 1e-6)
       assertEqual(
-        gradInitialState.value,
+        gradInitialState,
         expectedGradInitialState,
         accuracy: 1e-6)
     }
@@ -1991,15 +1987,15 @@ final class LayerTests: XCTestCase {
       gru.cell.outputRecurrentBias = outputRecurrentBias
       
       let inputs = x.squeezingShape(at: 0).unstacked().map { $0.rankLifted() }
-      let initialState = GRUCell<Float>.State(hidden: initialState)
+      let initialState = GRUCell<Float>.State(initialState)
 
       let outputs = gru(inputs, initialState: initialState)
       assertEqual(
-        Tensor(concatenating: outputs.map { $0.hidden }),
+        Tensor(concatenating: outputs.map { $0 }),
         expectedStates,
         accuracy: 1e-6)
       assertEqual(
-        outputs.last!.hidden,
+        outputs.last!,
         expectedFinalState,
         accuracy: 1e-6)
 
@@ -2008,7 +2004,7 @@ final class LayerTests: XCTestCase {
           gru.lastOutput(
             from: inputs, 
             initialState: initialState
-          ).hidden.sum()
+          ).sum()
         }
       assertEqual(
         outputSum,
@@ -2019,7 +2015,7 @@ final class LayerTests: XCTestCase {
         expectedGradX,
         accuracy: 1e-6)
       assertEqual(
-        gradInitialState.hidden,
+        gradInitialState,
         expectedGradInitialState,
         accuracy: 1e-6)
       assertEqual(


### PR DESCRIPTION
This implements https://bugs.swift.org/browse/TF-507

Trying again since it was reverted lastime due to Google internal issues.