### PR TITLE
Optimize split, _vjpConcatenated, tiled and _vjpTiled

### DIFF
--- a/Sources/TensorFlow/Bindings/RawOpsAugmented.swift
+++ b/Sources/TensorFlow/Bindings/RawOpsAugmented.swift
@@ -79,6 +79,20 @@ extension _RawTFEager {
       size: Tensor<Int32>(size.map { Int32($0) }, on: .defaultTFEager))
   }
 
+  public static func splitV<
+    T: TensorFlowScalar
+  >(
+    value: Tensor<T>,
+    sizeSplits: [Int],
+    splitDim: Int
+  ) -> [Tensor<T>] {
+    splitV(
+      value: value,
+      sizeSplits: Tensor<Int32>(sizeSplits.map { Int32($0) }, on: .defaultTFEager),
+      splitDim: Tensor<Int32>(Int32(splitDim), on: .defaultTFEager),
+      numSplit: Int64(sizeSplits.count))
+  }
+
   public static func sum<
     T: TensorFlowNumeric
   >(
@@ -272,6 +286,25 @@ extension _RawTFEager {
         return _RawTFEager.slice(
           input, begin: Tensor<Int32>(begin.map { Int32($0) }, on: .defaultTFEager),
           size: Tensor<Int32>(size.map { Int32($0) }, on: .defaultTFEager))
+      }
+    }
+
+    public static func splitV<
+      T: TensorFlowScalar
+    >(
+      value: Tensor<T>,
+      sizeSplits: [Int],
+      splitDim: Int
+    ) -> [Tensor<T>] {
+      switch value.handle.backend {
+      case .XLA:
+        return _RawXLA.splitV(value: value, sizeSplits: sizeSplits, splitDim: splitDim)
+      case .TF_EAGER:
+        return _RawTFEager.splitV(
+          value: value,
+          sizeSplits: Tensor<Int32>(sizeSplits.map { Int32($0) }, on: .defaultTFEager),
+          splitDim: Tensor<Int32>(Int32(splitDim), on: .defaultTFEager),
+          numSplit: Int64(sizeSplits.count))
       }
     }
 

--- a/Sources/TensorFlow/Bindings/RawOpsAugmented.swift
+++ b/Sources/TensorFlow/Bindings/RawOpsAugmented.swift
@@ -106,6 +106,15 @@ extension _RawTFEager {
       keepDims: keepDims)
   }
 
+  public static func tile<
+    T: TensorFlowScalar
+  >(
+    _ input: Tensor<T>,
+    multiples: [Int]
+  ) -> Tensor<T> {
+    tile(input, multiples: Tensor<Int32>(multiples.map { Int32($0) }, on: .defaultTFEager))
+  }
+
   public static func transpose<
     T: TensorFlowScalar
   >(
@@ -305,6 +314,20 @@ extension _RawTFEager {
           sizeSplits: Tensor<Int32>(sizeSplits.map { Int32($0) }, on: .defaultTFEager),
           splitDim: Tensor<Int32>(Int32(splitDim), on: .defaultTFEager),
           numSplit: Int64(sizeSplits.count))
+      }
+    }
+
+    public static func tile<
+      T: TensorFlowScalar
+    >(
+      _ input: Tensor<T>,
+      multiples: [Int]
+    ) -> Tensor<T> {
+      switch input.handle.backend {
+      case .XLA:
+        return _RawXLA.tile(input, multiples: multiples)
+      case .TF_EAGER:
+        return _RawTFEager.tile(input, multiples: multiples)
       }
     }
 

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -164,8 +164,7 @@ extension Tensor {
     precondition(
       multiples.allSatisfy { $0 >= 0 },
       "All scalars in multiples must be non-negative.")
-    // TODO(TF-433): Remove workaround for differentiating `map`.
-    return tiled(multiples: Tensor<Int32>({ multiples.map(Int32.init) }(), on: device))
+    return _Raw.tile(self, multiples: multiples)
   }
 
   /// Returns a tiled tensor, constructed by tiling this tensor.
@@ -285,6 +284,19 @@ extension Tensor where Scalar: TensorFlowFloatingPoint {
         let axes = Tensor<Int32>(
           rangeFrom: 0, to: Int32(splitShape.scalarCount), stride: 2, on: device)
         return v.reshaped(toShape: splitShape).sum(squeezingAxes: axes)
+      }
+    )
+  }
+
+  @inlinable
+  @derivative(of: tiled)
+  func _vjpTiled(multiples: [Int]) -> (value: Tensor, pullback: (Tensor) -> Tensor) {
+    (
+      tiled(multiples: multiples),
+      { v in
+        let splits = zip(multiples, shape.dimensions).flatMap { [$0, $1] }
+        let axes = Array(stride(from: 0, to: splits.count, by: 2))
+        return v.reshaped(to: TensorShape(splits)).sum(squeezingAxes: axes)
       }
     )
   }

--- a/Sources/x10/swift_bindings/apis/RawOpsManual.swift
+++ b/Sources/x10/swift_bindings/apis/RawOpsManual.swift
@@ -4324,19 +4324,28 @@ public enum _RawXLA {
     guard multiples.rank == 1 else {
       fatalError("Expected multiples to be 1-D, but got shape \(multiples.shape)")
     }
-    guard input.rank == multiples.shape.contiguousSize else {
+    return tile(input, multiples: multiples.scalars.map { Int($0) })
+  }
+
+  public static func tile<
+    T: TensorFlowScalar
+  >(
+    _ input: Tensor<T>,
+    multiples: [Int]
+  ) -> Tensor<T> {
+    guard input.rank == multiples.count else {
       fatalError(
         "Expected multiples argument to be a vector of length \(input.rank) but got length "
-          + String(multiples.shape.contiguousSize)
+          + String(multiples.count)
       )
     }
-    for (index, multiply) in multiples.scalars.enumerated() {
+    for (index, multiply) in multiples.enumerated() {
       guard multiply >= 0 else {
         fatalError("Expected multiples[\(index)] >= 0, but got \(multiply)")
       }
     }
     return Tensor(
-      _xla: XLATensor.tile(input.xlaTensor, repetitions: multiples.scalars.map { Int64($0) }))
+      _xla: XLATensor.tile(input.xlaTensor, repetitions: multiples.map { Int64($0) }))
   }
 
   /// Transfer a tensor to a different device.


### PR DESCRIPTION
Avoid more temporary tensors.