### PR TITLE
Adding deprecation notice to TensorFlowCheckpointReader

### DIFF
--- a/Sources/TensorFlow/Core/Serialization.swift
+++ b/Sources/TensorFlow/Core/Serialization.swift
@@ -15,6 +15,9 @@
 import CTensorFlow
 
 /// A TensorFlow checkpoint file reader.
+@available(*, deprecated, message: """
+  TensorFlowCheckpointReader will be removed in S4TF v0.11. Please use CheckpointReader instead.
+  """)
 public class TensorFlowCheckpointReader {
   internal let status: OpaquePointer
   internal let handle: OpaquePointer


### PR DESCRIPTION
In preparation for version 0.10, this marks TensorFlowCheckpointReader as deprecated in favor of the incoming CheckpointReader.