### PR TITLE
TensorFlow: `import` the `_Differentiation` module

### DIFF
--- a/Sources/TensorFlow/BackwardsCompatibility.swift
+++ b/Sources/TensorFlow/BackwardsCompatibility.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 //===------------------------------------------------------------------------------------------===//
 // Losses
 //===------------------------------------------------------------------------------------------===//

--- a/Sources/TensorFlow/Core/DataTypes.swift
+++ b/Sources/TensorFlow/Core/DataTypes.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
 import CTensorFlow
 
 /// A TensorFlow dynamic type value that can be created from types that conform to

--- a/Sources/TensorFlow/Core/DifferentialOperators.swift
+++ b/Sources/TensorFlow/Core/DifferentialOperators.swift
@@ -16,6 +16,8 @@
 // Free-function-style differential operators
 // ===------------------------------------------------------------------------------------------===//
 
+import _Differentiation
+
 // Value with gradient
 
 @inlinable

--- a/Sources/TensorFlow/Core/MixedPrecision.swift
+++ b/Sources/TensorFlow/Core/MixedPrecision.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 #if USING_X10_BACKEND
   @_implementationOnly import x10_xla_tensor_wrapper
 

--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
 import CTensorFlow
 
 infix operator .==: ComparisonPrecedence

--- a/Sources/TensorFlow/Initializers.swift
+++ b/Sources/TensorFlow/Initializers.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 #if !COMPILING_TENSORFLOW_STDLIB_MODULE
   import Tensor
 #endif

--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 public protocol Module: EuclideanDifferentiable, KeyPathIterable
 where
   TangentVector: VectorProtocol & ElementaryFunctions & PointwiseMultiplicative & KeyPathIterable

--- a/Sources/TensorFlow/Layers/Convolutional.swift
+++ b/Sources/TensorFlow/Layers/Convolutional.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 /// A 1-D convolution layer (e.g. temporal convolution over a time-series).
 ///
 /// This layer creates a convolution filter that is convolved with the layer input to produce a

--- a/Sources/TensorFlow/Layers/Core.swift
+++ b/Sources/TensorFlow/Layers/Core.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 /// A flatten layer.
 ///
 /// A flatten layer flattens the input when applied without affecting the batch size.

--- a/Sources/TensorFlow/Layers/Dense.swift
+++ b/Sources/TensorFlow/Layers/Dense.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 /// A densely-connected neural network layer.
 ///
 /// `Dense` implements the operation `activation(matmul(input, weight) + bias)`, where `weight` is

--- a/Sources/TensorFlow/Layers/Dropout.swift
+++ b/Sources/TensorFlow/Layers/Dropout.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
 #if os(Windows)
   import func MSVCRT.sqrt
 #endif

--- a/Sources/TensorFlow/Layers/Embedding.swift
+++ b/Sources/TensorFlow/Layers/Embedding.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 /// An embedding layer.
 ///
 /// `Embedding` is effectively a lookup table that maps indices from a fixed vocabulary to fixed-size

--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 /// Returns normalized `input`.
 ///
 /// - Parameters:

--- a/Sources/TensorFlow/Layers/Pooling.swift
+++ b/Sources/TensorFlow/Layers/Pooling.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 /// A max pooling layer for temporal data.
 @frozen
 public struct MaxPool1D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {

--- a/Sources/TensorFlow/Layers/Recurrent.swift
+++ b/Sources/TensorFlow/Layers/Recurrent.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
 #if !COMPILING_TENSORFLOW_STDLIB_MODULE
   import Tensor
 #endif

--- a/Sources/TensorFlow/Layers/Sequential.swift
+++ b/Sources/TensorFlow/Layers/Sequential.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 /// A layer that sequentially composes two or more other layers.
 ///
 /// ### Examples: ###

--- a/Sources/TensorFlow/Layers/Sequential.swift.gyb
+++ b/Sources/TensorFlow/Layers/Sequential.swift.gyb
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 /// A layer that sequentially composes two or more other layers.
 ///
 /// ### Examples: ###

--- a/Sources/TensorFlow/Layers/Upsampling.swift
+++ b/Sources/TensorFlow/Layers/Upsampling.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 /// An upsampling layer for 1-D inputs.
 @frozen
 public struct UpSampling1D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {

--- a/Sources/TensorFlow/Loss.swift
+++ b/Sources/TensorFlow/Loss.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 /// Computes the L1 loss between `expected` and `predicted`.
 /// `loss = reduction(abs(expected - predicted))`
 ///

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 infix operator .!=: ComparisonPrecedence
 
 /// Returns a tensor with the same shape and scalars as the specified tensor.

--- a/Sources/TensorFlow/Operators/Image.swift
+++ b/Sources/TensorFlow/Operators/Image.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 /// A resize algorithm.
 public enum ResizeMethod {
   /// Nearest neighbor interpolation.

--- a/Sources/TensorFlow/Operators/LinearAlgebra.swift
+++ b/Sources/TensorFlow/Operators/LinearAlgebra.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 // MARK: - Matrix operations
 
 extension Tensor where Scalar: TensorFlowNumeric {

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 infix operator .>: ComparisonPrecedence
 infix operator .==: ComparisonPrecedence
 

--- a/Sources/TensorFlow/Operators/NN.swift
+++ b/Sources/TensorFlow/Operators/NN.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 //===------------------------------------------------------------------------------------------===//
 // Normalization
 //===------------------------------------------------------------------------------------------===//

--- a/Sources/third_party/Experimental/Complex.swift
+++ b/Sources/third_party/Experimental/Complex.swift
@@ -43,6 +43,8 @@
 /// ("not a number"). Complex functions in different languages may return
 /// different results when working with special values.
 
+import _Differentiation
+
 struct Complex<T: FloatingPoint> {
   var real: T
   var imaginary: T

--- a/Sources/x10/swift_bindings/training_loop.swift
+++ b/Sources/x10/swift_bindings/training_loop.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
 import TensorFlow
 @_implementationOnly import x10_xla_tensor_wrapper
 


### PR DESCRIPTION
This makes no difference for people using the tensorflow branch,
however, the non-tensorflow branch builds require that the
`_Differentiation` module is included before using the `@differentiable`
attribute.  This adds the required import unconditionally.