### PR TITLE
build: allow building against Foundation build-tree artifacts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,9 @@ else()
   find_package(TensorFlow REQUIRED)
 endif()
 
+find_package(dispatch CONFIG QUIET)
+find_package(Foundation CONFIG QUIET)
+
 include(CTest)
 include(SwiftSupport)
 

--- a/Sources/TensorFlow/CMakeLists.txt
+++ b/Sources/TensorFlow/CMakeLists.txt
@@ -96,6 +96,8 @@ target_compile_options(TensorFlow PRIVATE
   $<$<BOOL:${BUILD_TESTING}>:-enable-testing>)
 target_link_libraries(TensorFlow PUBLIC
   CTensorFlow
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:dispatch>
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>
   Tensor)
 
 _install_target(TensorFlow)


### PR DESCRIPTION
Support building with Foundation in the build-tree.  This allows
building with a development environment with a custom local build of
Foundation.  `Epochs` was added with a dependency on `Foundation` but
the build system was not updated.