### PR TITLE
Fix linSpace

### DIFF
--- a/Sources/CX10/xla_tensor_wrapper.cc
+++ b/Sources/CX10/xla_tensor_wrapper.cc
@@ -454,6 +454,14 @@ OpaqueXLATensor* XLATensor_is_nan(OpaqueXLATensor* input) {
 OpaqueXLATensor* XLATensor_le(OpaqueXLATensor* x, OpaqueXLATensor* y) {
   return new XLATensor(XLATensor::le(*x, *y));
 }
+OpaqueXLATensor* XLATensor_linspace(XLAScalar start, XLAScalar stop,
+                                    int64_t num, const CDevice device,
+                                    enum XLATensorScalarType type) {
+  XLATensor out = MakeEmpty(ToScalarType(type), ConvertDevice(device));
+  XLATensor::linspace_out(out, atScalar(start), atScalar(stop), num,
+                          ToScalarType(type));
+  return new XLATensor(out);
+}
 OpaqueXLATensor* XLATensor_lt(OpaqueXLATensor* x, OpaqueXLATensor* y) {
   return new XLATensor(XLATensor::lt(*x, *y));
 }

--- a/Sources/CX10/xla_tensor_wrapper.h
+++ b/Sources/CX10/xla_tensor_wrapper.h
@@ -287,6 +287,10 @@ XLA_API OpaqueXLATensor* XLATensor_is_inf(OpaqueXLATensor* input);
 XLA_API OpaqueXLATensor* XLATensor_is_nan(OpaqueXLATensor* input);
 XLA_API OpaqueXLATensor* XLATensor_le(OpaqueXLATensor* x, OpaqueXLATensor* y);
 XLA_API OpaqueXLATensor* XLATensor_lt(OpaqueXLATensor* x, OpaqueXLATensor* y);
+XLA_API OpaqueXLATensor* XLATensor_linspace(XLAScalar start, XLAScalar stop,
+                                            int64_t num,
+                                            const struct CDevice device,
+                                            enum XLATensorScalarType type);
 XLA_API OpaqueXLATensor* XLATensor_log(OpaqueXLATensor* a);
 XLA_API OpaqueXLATensor* XLATensor_log1p(OpaqueXLATensor* a);
 XLA_API OpaqueXLATensor* XLATensor_log_softmax(OpaqueXLATensor* a, int64_t dim);

--- a/Sources/x10/swift_bindings/XLATensor.swift
+++ b/Sources/x10/swift_bindings/XLATensor.swift
@@ -514,6 +514,19 @@ extension XLATensor {
         start.xlaScalar, stop.xlaScalar, step.xlaScalar, cdevice, type))
   }
 
+  static func linspace(
+    _ start: XLAScalarType,
+    _ stop: XLAScalarType,
+    _ num: Int64,
+    _ type: XLATensorScalarType,
+    _ device: Device
+  ) -> XLATensor {
+    let cdevice = device.cdevice
+    return XLATensor(
+      _handle: XLATensor_linspace(
+        start.xlaScalar, stop.xlaScalar, num, cdevice, type))
+  }
+
   static func log(_ a: XLATensor) -> XLATensor {
     defer { _fixLifetime(a) }
     return XLATensor(_handle: XLATensor_log(a.handle))

--- a/Sources/x10/swift_bindings/apis/RawOpsManual.swift
+++ b/Sources/x10/swift_bindings/apis/RawOpsManual.swift
@@ -1889,11 +1889,9 @@ public enum _RawXLA {
     if numScalarized == 1 { return start }
     let startScalar: T = start.scalarized()
     let stopScalar: T = stop.scalarized()
-    let numScalarizedMinusOne = T(numScalarized - 1)
-    let stepScalar: T = (stopScalar - startScalar) / numScalarizedMinusOne
     var linspace = Tensor<T>(
-      _xla: XLATensor.arange(
-        startScalar, stopScalar + stepScalar, stepScalar, T.xlaTensorScalarType, device))
+      _xla: XLATensor.linspace(
+        startScalar, stopScalar, Int64(numScalarized), T.xlaTensorScalarType, device))
     if start.isReducedPrecision {
       linspace = linspace.toReducedPrecision
     }

--- a/Sources/x10/xla_client/util.h
+++ b/Sources/x10/xla_client/util.h
@@ -215,6 +215,21 @@ std::vector<T> Iota(size_t size, T init = 0, T incr = 1) {
 }
 
 template <typename T>
+std::vector<T> LinSpace(T start, T stop, xla::int64 num) {
+  std::vector<T> result(num);
+  result[0] = start;
+  if (num > 1) {
+    const T step = (stop - start) / (num - 1);
+    for (xla::int64 i = 1; i < num - 1; ++i) {
+      result[i] = start + step * i;
+    }
+    // Ensure final value == stop; float arithmetic won't guarantee this.
+    result[num - 1] = stop;
+  }
+  return result;
+}
+
+template <typename T>
 std::vector<T> Range(T start, T end, T step = 1) {
   std::vector<T> result;
   result.reserve(static_cast<size_t>((end - start) / step));

--- a/Sources/x10/xla_tensor/helpers.h
+++ b/Sources/x10/xla_tensor/helpers.h
@@ -354,6 +354,12 @@ class XlaHelpers {
     return xla::LiteralUtil::CreateR1<T>(xla::util::Range<T>(start, end, step));
   }
 
+  template <typename T>
+  static xla::Literal LinSpace(T start, T stop, xla::int64 num) {
+    return xla::LiteralUtil::CreateR1<T>(
+        xla::util::LinSpace<T>(start, stop, num));
+  }
+
   static xla::PrecisionConfig::Precision mat_mul_precision() {
     return s_mat_mul_precision;
   }

--- a/Sources/x10/xla_tensor/ops/ops.cpp
+++ b/Sources/x10/xla_tensor/ops/ops.cpp
@@ -479,6 +479,59 @@ NodePtr ARange(at::Scalar start, at::Scalar end, at::Scalar step,
   return MakeNode<Constant>(std::move(values));
 }
 
+NodePtr LinSpace(at::Scalar start, at::Scalar stop, xla::int64 num,
+                 at::ScalarType scalar_type) {
+  XLA_CHECK_GT(num, 0) << "Requires num > 0: " << num;
+  xla::PrimitiveType type = MakeXlaPrimitiveType(scalar_type,
+                                                 /*device=*/nullptr);
+  xla::Literal values;
+  switch (type) {
+    case xla::PrimitiveType::F32:
+      values =
+          XlaHelpers::LinSpace<float>(start.toFloat(), stop.toFloat(), num);
+      break;
+    case xla::PrimitiveType::F64:
+      values =
+          XlaHelpers::LinSpace<double>(start.toDouble(), stop.toDouble(), num);
+      break;
+    case xla::PrimitiveType::U8:
+      values =
+          XlaHelpers::LinSpace<xla::uint8>(start.toByte(), stop.toByte(), num);
+      break;
+    case xla::PrimitiveType::S8:
+      values =
+          XlaHelpers::LinSpace<xla::int8>(start.toChar(), stop.toChar(), num);
+      break;
+    case xla::PrimitiveType::S16:
+      values = XlaHelpers::LinSpace<xla::int16>(start.toShort(), stop.toShort(),
+                                                num);
+      break;
+    case xla::PrimitiveType::U16:
+      values =
+          XlaHelpers::LinSpace<xla::uint16>(start.toInt(), stop.toInt(), num);
+      break;
+    case xla::PrimitiveType::S32:
+      values =
+          XlaHelpers::LinSpace<xla::int32>(start.toInt(), stop.toInt(), num);
+      break;
+    case xla::PrimitiveType::U32:
+      values =
+          XlaHelpers::LinSpace<xla::uint32>(start.toLong(), stop.toLong(), num);
+      break;
+    case xla::PrimitiveType::S64:
+      values =
+          XlaHelpers::LinSpace<xla::int64>(start.toLong(), stop.toLong(), num);
+      break;
+    case xla::PrimitiveType::U64:
+      values =
+          XlaHelpers::LinSpace<xla::uint64>(start.toLong(), stop.toLong(), num);
+      break;
+    default:
+      XLA_ERROR() << "XLA type not supported: " << type;
+  }
+  return MakeNode<Constant>(std::move(values));
+}
+
 NodePtr BroadcastTensors(absl::Span<const Value> tensors) {
   auto lower_fn = [](const Node& node, LoweringContext* loctx) -> XlaOpVector {
     std::vector<xla::XlaOp> xla_operands;

--- a/Sources/x10/xla_tensor/ops/ops.h
+++ b/Sources/x10/xla_tensor/ops/ops.h
@@ -191,6 +191,9 @@ NodePtr Where(const Value& condition, const Value& input, const Value& other);
 NodePtr ARange(at::Scalar start, at::Scalar end, at::Scalar step,
                at::ScalarType scalar_type);
 
+NodePtr LinSpace(at::Scalar start, at::Scalar stop, xla::int64 num,
+                 at::ScalarType scalar_type);
+
 NodePtr BroadcastTensors(absl::Span<const Value> tensors);
 
 NodePtr Norm(const Value& input, c10::optional<at::Scalar> p,

--- a/Sources/x10/xla_tensor/tensor.h
+++ b/Sources/x10/xla_tensor/tensor.h
@@ -686,6 +686,9 @@ class XLATensor {
                                        double negative_slope);
   static void leaky_relu_(XLATensor& input, double negative_slope);
 
+  static void linspace_out(XLATensor& out, at::Scalar start, at::Scalar stop,
+                           xla::int64 num, at::ScalarType scalar_type);
+
   static XLATensor log(const XLATensor& input);
   static void log_(XLATensor& input);
 

--- a/Sources/x10/xla_tensor/tensor_methods.cpp
+++ b/Sources/x10/xla_tensor/tensor_methods.cpp
@@ -1537,6 +1537,12 @@ void XLATensor::leaky_relu_(XLATensor& input, double negative_slope) {
       ir::MakeNode<ir::ops::LeakyRelu>(input.GetIrValue(), negative_slope));
 }
 
+void XLATensor::linspace_out(XLATensor& out, at::Scalar start, at::Scalar stop,
+                             xla::int64 num, at::ScalarType scalar_type) {
+  out.SetIrValue(ir::ops::LinSpace(start, stop, num, scalar_type));
+  out.SetScalarType(scalar_type);
+}
+
 XLATensor XLATensor::log(const XLATensor& input) {
   return input.CreateFrom(ir::ops::Log(input.GetIrValue()));
 }

--- a/Tests/x10/ops_test.swift
+++ b/Tests/x10/ops_test.swift
@@ -1974,7 +1974,9 @@ final class TensorTests: XCTestCase {
   }
 
   func testLinSpace() throws {
-    func testRanges(start: Float, stop: Float, num: Int32, useReducedPrecision: Bool) {
+    func testRanges(
+      start: Float, stop: Float, num: Int32, useReducedPrecision: Bool, absTolerance: Float = 1e-5
+    ) {
       var start = Tensor(start, on: x10)
       var stop = Tensor(stop, on: x10)
       if useReducedPrecision {
@@ -1991,7 +1993,7 @@ final class TensorTests: XCTestCase {
       XCTAssert(!tx10.isReducedPrecision)
       let tf = _Raw.linSpace(
         start: TF(start), stop: TF(stop), num: TF(Tensor<Int32>(num, on: x10)))
-      XCTAssert(allClose(actual: TF(tx10), expected: tf, absTolerance: 1e-5))
+      XCTAssert(allClose(actual: TF(tx10), expected: tf, absTolerance: absTolerance))
     }
     for useReducedPrecision in [false, true] {
       testRanges(start: 0.0, stop: 5.0, num: 6, useReducedPrecision: useReducedPrecision)
@@ -1999,6 +2001,9 @@ final class TensorTests: XCTestCase {
       testRanges(start: 0.0, stop: 0.0, num: 1, useReducedPrecision: useReducedPrecision)
       testRanges(start: 2.0, stop: 0.0, num: 1, useReducedPrecision: useReducedPrecision)
       testRanges(start: 20.0, stop: 0.0, num: 1, useReducedPrecision: useReducedPrecision)
+      testRanges(
+        start: -1.0, stop: 2.0, num: 1024, useReducedPrecision: useReducedPrecision,
+        absTolerance: 4e-3)
     }
   }
 


### PR DESCRIPTION
Create the result as a constant, for now. If we want to avoid
transferring a big constant to device in the future, we can replace it
with an XLA lowering which creates it on the device instead.

Fixes #980.