### PR TITLE
Remove deprecated APIs.

### DIFF
--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -47,14 +47,6 @@ public protocol Layer: Module where Input: Differentiable {
   func callAsFunction(_ input: Input) -> Output
 }
 
-extension Layer {
-  @available(*, deprecated, renamed: "callAsFunction(_:)")
-  @differentiable
-  public func call(_ input: Input) -> Output {
-    callAsFunction(input)
-  }
-}
-
 /// An empty struct representing empty `TangentVector`s for parameterless layers.
 public struct EmptyTangentVector: EuclideanDifferentiable, VectorProtocol, ElementaryFunctions,
   PointwiseMultiplicative, KeyPathIterable

--- a/Sources/TensorFlow/Layers/Dropout.swift
+++ b/Sources/TensorFlow/Layers/Dropout.swift
@@ -19,29 +19,12 @@ import _Differentiation
 
 extension Tensor where Scalar: TensorFlowFloatingPoint {
   /// Computes dropout given a probability.
-  // TODO: Remove the underscore once `droppingOut(probability:)` has been removed.
   @differentiable(wrt: self where Scalar: Differentiable)
-  fileprivate func _droppingOut(probability: Double) -> Tensor {
+  fileprivate func droppingOut(probability: Double) -> Tensor {
     let noise = Tensor(randomUniform: shape, on: device)
     let keepMask = noise .>= Scalar(probability)
     let keepProbability = Scalar(1.0 - probability)
     return self * Tensor(keepMask) / Tensor(keepProbability, on: device)
-  }
-}
-
-extension Tensor where Scalar: TensorFlowFloatingPoint {
-  /// Computes dropout given a probability.
-  @available(
-    *, deprecated,
-    message:
-      """
-      This API will be removed after Swift for TensorFlow 0.6.
-      For dropout, use the `Dropout` layer.
-      """
-  )
-  @differentiable(wrt: self where Scalar: Differentiable)
-  public func droppingOut(probability: Double) -> Tensor {
-    _droppingOut(probability: probability)
   }
 }
 
@@ -72,7 +55,7 @@ public struct Dropout<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
   public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
     switch Context.local.learningPhase {
     case .training:
-      return input._droppingOut(probability: probability)
+      return input.droppingOut(probability: probability)
     case .inference:
       return input
     }


### PR DESCRIPTION
Remove `Tensor.droppingOut(probability:)`: deprecated in version 0.6.
Remove `Layer.call(_:)`: deprecated in version 0.9.