### PR TITLE
Add curl retry for toolchain download to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,11 @@ fi
 
 # Download and extract S4TF
 WORKDIR /swift-tensorflow-toolchain
-RUN curl -fSsL $swift_tf_url -o swift.tar.gz \
-    && mkdir usr \
+RUN if ! curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz; \
+    then sleep 30 && curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz; \
+    fi;
+
+RUN mkdir usr \
     && tar -xzf swift.tar.gz --directory=usr --strip-components=1 \
     && rm swift.tar.gz
 


### PR DESCRIPTION
In swift-models PRs [#590](https://github.com/tensorflow/swift-models/pull/590) and [#596](https://github.com/tensorflow/swift-models/pull/596), we found that adding a delayed retry to the curl download of the nightly toolchain helped with the intermittent OpenSSL errors we have been hitting. It doesn't completely solve all cases, but for our CI benchmark runs we went from ~25% failing two days ago to none failing due to network errors last night with this workaround in place.

I noticed that this repository was also experiencing these CI failures, so hopefully this helps.