### PR TITLE
Tests: remove `x10_xla_tensor_wrapper` usage (NFC)

### DIFF
--- a/Tests/x10/ops_test.swift
+++ b/Tests/x10/ops_test.swift
@@ -1,8 +1,10 @@
 import TensorFlow
 import XCTest
-import x10_xla_tensor_wrapper
 
 // TODO(b/130689556): Remove this environment setting once the bug is fixed.
+@_silgen_name("SetMatMulPrecision")
+internal func SetMatMulPrecision(_: Bool) -> Void
+
 setenv("XLA_FLAGS", "--xla_cpu_fast_math_honor_nans=true --xla_cpu_fast_math_honor_infs=true", 1)
 SetMatMulPrecision(true)
 let x10 = Device.defaultXLA


### PR DESCRIPTION
This is not used directly in the tests, and the module has been made
into an implementation only import.  This fixes the dependency issue
identified by @mikowals.

Fixes: #1001