### PR TITLE
Preventing both eager runtime and XLA from completely consuming GPU memory

### DIFF
--- a/Sources/x10/swift_bindings/Device.swift
+++ b/Sources/x10/swift_bindings/Device.swift
@@ -59,6 +59,10 @@ public struct Device {
     self.kind = kind
     self.ordinal = ordinal
     self.backend = backend
+
+    // For GPU devices, the following is necessary to set TF to not use all GPU memory for the
+    // eager runtime or XLA. This needs to be here for manually-specified XLA devices.
+    let _ = _ExecutionContext.global
   }
 
   /// Backend used to dispatch the tensor operations.
@@ -132,6 +136,10 @@ public struct Device {
 
   /// The default XLA device.
   public static var defaultXLA: Device {
+    // For GPU devices, the following is necessary to set TF to not use all GPU memory for the
+    // eager runtime or XLA. This needs to be placed before getDefaultDevice() for default devices.
+    let _ = _ExecutionContext.global
+
     let defaultDevice = getDefaultDevice()
     return Device(
       kind: defaultDevice.hw_type.kind, ordinal: Int(defaultDevice.ordinal), backend: .XLA)


### PR DESCRIPTION
Currently, if you are working with the GPU as an accelerator and you use a manually specified or default XLA device, the eager-mode runtime will consume all available GPU memory by default if the first use of an eager tensor occurs after the allocation of the XLA device. As a workaround, [a small eager Tensor calculation](https://github.com/tensorflow/swift-models/blob/master/Benchmarks/Models/ImageClassificationTraining.swift#L39) can be performed right before the allocation of the XLA device and this will prevent these memory issues. It also will set the logging to the appropriate level, preventing info-level logging from cluttering the console on every execution.

This is an attempt at resolving that issue for GPUs by guaranteeing that the eager context has been properly configured before `getDefaultDevice()` or the first use of an XLA device. `_ExecutionContext.global` is queried, which makes sure that `gpu_memory_allow_growth` is set correctly at least once before any XLA device is used.