### PR TITLE
Tagging scalar zero tensors

### DIFF
--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -34,7 +34,7 @@ public struct Tensor<Scalar: TensorFlowScalar> {
   /// The underlying `TensorHandle`.
   /// - Note: `handle` is public to allow user defined ops, but should not normally be used.
   public let handle: TensorHandle<Scalar>
-  
+
   @inlinable
   public init(handle: TensorHandle<Scalar>) {
     self.handle = handle

--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -35,6 +35,10 @@ public struct Tensor<Scalar: TensorFlowScalar> {
   /// - Note: `handle` is public to allow user defined ops, but should not normally be used.
   public let handle: TensorHandle<Scalar>
 
+  // The following is a spacer intended to temporarily work around a compiler crash induced
+  // by the zero-tagging optimization residing in TensorHandle.
+  var _spacer: UInt8 = 0
+
   @inlinable
   public init(handle: TensorHandle<Scalar>) {
     self.handle = handle

--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -36,7 +36,8 @@ public struct Tensor<Scalar: TensorFlowScalar> {
   public let handle: TensorHandle<Scalar>
 
   /// An internal marker to identify scalar zero tensors, for use in optimizations.
-  public var _isScalarZero = false
+  @usableFromInline
+  internal var _isScalarZero = false
   
   @inlinable
   public init(handle: TensorHandle<Scalar>) {

--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -35,10 +35,6 @@ public struct Tensor<Scalar: TensorFlowScalar> {
   /// - Note: `handle` is public to allow user defined ops, but should not normally be used.
   public let handle: TensorHandle<Scalar>
 
-  // The following is a spacer intended to temporarily work around a compiler crash induced
-  // by the zero-tagging optimization residing in TensorHandle.
-  var _spacer: UInt8 = 0
-
   @inlinable
   public init(handle: TensorHandle<Scalar>) {
     self.handle = handle

--- a/Sources/TensorFlow/Core/TensorHandle.swift
+++ b/Sources/TensorFlow/Core/TensorHandle.swift
@@ -93,6 +93,10 @@ public struct TensorHandle<Scalar> where Scalar: _TensorFlowDataTypeCompatible {
 
   public var _cTensorHandle: CTensorHandle { handle._cTensorHandle }
 
+  // The following is a spacer intended to temporarily work around a compiler crash induced
+  // by zero-tagging optimization below.
+  var _spacer: UInt8 = 0
+
   /// An internal marker to identify scalar zero tensors, for use in optimizations.
   @usableFromInline
   internal var _isScalarZero = false

--- a/Sources/TensorFlow/Core/TensorHandle.swift
+++ b/Sources/TensorFlow/Core/TensorHandle.swift
@@ -93,6 +93,10 @@ public struct TensorHandle<Scalar> where Scalar: _TensorFlowDataTypeCompatible {
 
   public var _cTensorHandle: CTensorHandle { handle._cTensorHandle }
 
+  /// An internal marker to identify scalar zero tensors, for use in optimizations.
+  @usableFromInline
+  internal var _isScalarZero = false
+
   public init(_owning cTensorHandle: CTensorHandle) {
     self.handle = TFETensorHandle(_owning: cTensorHandle)
   }


### PR DESCRIPTION
During profiling, we noticed that a large number of scalar zero tensors were being generated in the backward pass of certain models. These zero tensors were often involved in simple arithmetic where they did not change the result. As a quick optimization, this allows for a scalar zero Tensor to be tagged as such and to avoid dispatching calculations for which it would not impact the result.

In the case of the WordSeg model, this optimization leads to almost a tripling of throughput when calculating the score and gradient in the eager mode. When using X10, the benefit is reduced due to XLA optimizations, but is still present.