### PR TITLE
build: repair the X10 build

### DIFF
--- a/Sources/x10/xla_tensor/BUILD
+++ b/Sources/x10/xla_tensor/BUILD
@@ -59,6 +59,7 @@ cc_library(
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/container:node_hash_map",
+        "@com_google_absl//absl/container:node_hash_set",
         "@com_google_absl//absl/debugging:stacktrace",
         "@com_google_absl//absl/debugging:symbolize",
         "@com_google_absl//absl/memory",


### PR DESCRIPTION
XLATensor seems to have grown a dependency on node_hash_set.  Update the
bazel rules accordingly.