### PR TITLE
Eject from LazyTensorBarrier if device is eager

### DIFF
--- a/Sources/x10/swift_bindings/Device.swift
+++ b/Sources/x10/swift_bindings/Device.swift
@@ -198,7 +198,7 @@ public struct Device {
 
 extension Device: Equatable {
   public static func == (lhs: Device, rhs: Device) -> Bool {
-    return lhs.kind == rhs.kind && lhs.ordinal == rhs.ordinal
+    return lhs.kind == rhs.kind && lhs.ordinal == rhs.ordinal && lhs.backend == rhs.backend
   }
 }
 
@@ -218,6 +218,8 @@ extension CDevice {
 /// If wait is set to true, this call blocks until the computation is complete.
 public func LazyTensorBarrier(on device: Device? = nil, devices: [Device] = [], wait: Bool = false)
 {
+  if device == Device.defaultTFEager { return }
+
   devices.withDeviceList { devices in
     if var cdevice = device?.cdevice {
       XLATensor_LazyTensorBarrier(&cdevice, &devices, wait)

--- a/Sources/x10/xla_tensor/tensor.cpp
+++ b/Sources/x10/xla_tensor/tensor.cpp
@@ -1391,6 +1391,9 @@ void XLATensor::SyncLiveTensorsGraph(const Device* device,
                                      absl::Span<const std::string> devices,
                                      bool wait) {
   auto tensors = GetLiveTensors(device);
+  if (tensors.empty()) {
+    return;
+  }
   TF_VLOG(4) << tensors.size() << " live tensors: devices=("
              << absl::StrJoin(devices, ",") << ")";
   SyncTensorsGraph(&tensors, devices, wait, /*sync_xla_data=*/true);

--- a/Tests/x10/keypathiterable_test.swift
+++ b/Tests/x10/keypathiterable_test.swift
@@ -79,13 +79,13 @@ final class KeyPathIterableTests: XCTestCase {
   func testMoveToDevice() throws {
     // Testing is possible only when there are multiple devices.
     // Skip test if only one device is available.
-    guard let otherDevice = Device.allDevices.first(where: { $0 != Device.default }) else {
+    guard let otherDevice = Device.allDevices.first(where: { $0 != Device.defaultXLA }) else {
       return
     }
 
     var example = Wrapper<Tensor<Float>>.reducedPrecisionExample
     example.assertRecursivelyAllProperties(
-      withType: Tensor<Float>.self, { $0.device == Device.default })
+      withType: Tensor<Float>.self, { $0.device == Device.defaultXLA })
     example.move(to: otherDevice)
     example.assertRecursivelyAllProperties(
       withType: Tensor<Float>.self, { $0.device == otherDevice })
@@ -94,13 +94,13 @@ final class KeyPathIterableTests: XCTestCase {
   func testCopyingToDevice() throws {
     // Testing is possible only when there are multiple devices.
     // Skip test if only one device is available.
-    guard let otherDevice = Device.allDevices.first(where: { $0 != Device.default }) else {
+    guard let otherDevice = Device.allDevices.first(where: { $0 != Device.defaultXLA }) else {
       return
     }
 
     let example = Wrapper<Tensor<Float>>.reducedPrecisionExample
     example.assertRecursivelyAllProperties(
-      withType: Tensor<Float>.self, { $0.device == Device.default })
+      withType: Tensor<Float>.self, { $0.device == Device.defaultXLA })
     let copiedExample = Wrapper<Tensor<Float>>(copying: example, to: otherDevice)
     copiedExample.assertRecursivelyAllProperties(
       withType: Tensor<Float>.self, { $0.device == otherDevice })


### PR DESCRIPTION
Return from LazyTensorBarrier if device is eager or there are no live tensors.

Add backend to Device equatable.