### PR TITLE
[README] Clarify CMmake instructions for macOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ cmake --build out
 cmake --build out --target test
 ```
 
+#### macOS
+
+On macOS, passing `-D BUILD_TESTING=NO` is currently necessary to skip building
+tests. This avoids an error: `cannot load underlying module for 'XCTest'`.
+
+```shell
+cmake -B out -D USE_BUNDLED_CTENSORFLOW=YES -D USE_BUNDLED_X10=YES -D BUILD_TESTING=NO -G Ninja -S swift-apis
+cmake --build out
+```
 
 ## Bugs
 


### PR DESCRIPTION
Clarify that `-D BUILD_TESTING=NO` is currently necessary.
Building tests on macOS is not yet supported.