### PR TITLE
Bug fix groupnorm for x10

### DIFF
--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -357,7 +357,7 @@ public struct GroupNorm<Scalar: TensorFlowFloatingPoint>: Layer {
     var normalizedAxes = Array(1..<grouped.rank)
     normalizedAxes.remove(at: positiveAxis - 1)
     let moments = grouped.moments(alongAxes: normalizedAxes)
-    let eps = Tensor(epsilon)
+    let eps = Tensor(copying: Tensor(epsilon), to: self.offset.device)
     let normalized = normalize(
       grouped,
       mean: moments.mean, variance: moments.variance,


### PR DESCRIPTION
While using X10 (TFEager works fine) backend you can obtain this error using InstanceNorm: 

```Fatal error: Op must have the same backend type: XLA vs TF_EAGER```. 

Fix resolves the issue