### PR TITLE
Fix StringTensor initializer.

### DIFF
--- a/Sources/TensorFlow/Core/StringTensor.swift
+++ b/Sources/TensorFlow/Core/StringTensor.swift
@@ -66,6 +66,7 @@ extension StringTensor {
             dataAddr = dataAddr.advanced(by: 1)
           }
         })
+      self.init(handle: handle)
     #else
       let tfEncodedSizes = cStrings.map { TF_StringEncodedSize($0.count) }
 


### PR DESCRIPTION
Add missing initializer call: `self.init(handle: handle)`.

---

Fixes error with `-D TENSORFLOW_MASTER`:
```
Sources/TensorFlow/Core/StringTensor.swift:55:11: warning: initialization of immutable value 'handle' was never used; consider replacing with assignment to '_' or removing it
      let handle = TensorHandle<String>(
      ~~~~^~~~~~
      _
Sources/TensorFlow/Core/StringTensor.swift:115:3: error: return from initializer without initializing all stored properties
  }
  ^
Sources/TensorFlow/Core/StringTensor.swift:27:14: note: 'self.handle' not initialized
  public let handle: TensorHandle<String>
             ^
```