### PR TITLE
Fix `ParameterlessLayer` conformance.

### DIFF
--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -17,10 +17,10 @@ import XCTest
 @testable import TensorFlow
 
 fileprivate struct Sigmoid<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
-  public init() {}
+  typealias TangentVector = EmptyTangentVector
 
   @differentiable
-  public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
+  func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
     sigmoid(input)
   }
 }


### PR DESCRIPTION
Follow-up to https://github.com/tensorflow/swift-apis/pull/1034. See that PR description for more info.
Unblocks the [2020-06-30 `master -> tensorflow` merge](https://github.com/apple/swift/pull/32623).

---

I overlooked this case in https://github.com/tensorflow/swift-apis/pull/1034 because I locally tested that PR with https://github.com/apple/swift/pull/32623 on macOS via CMake, which doesn't build tests.

This time, I confirmed that tests pass on Linux with https://github.com/apple/swift/pull/32623.