### PR TITLE
Remove outdated Package.resolved from fastai_dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ RUN /swift-tensorflow-toolchain/usr/bin/swift build -c release
 
 WORKDIR /fastai_dev/swift/FastaiNotebook_11_imagenette
 
+RUN rm Package.resolved
 RUN /swift-tensorflow-toolchain/usr/bin/swift build
 RUN /swift-tensorflow-toolchain/usr/bin/swift build -c release
 


### PR DESCRIPTION
An outdated Package.resolved in [fastai/fastai_dev](https://github.com/texasmichelle/fastai_dev/blob/master/swift/FastaiNotebook_11_imagenette/Package.resolved) is causing a failure in toolchain builds.

<details>
<summary>Package.resolved file is corrupted or malformed</summary>

```
Step 32/43 : WORKDIR /fastai_dev/swift/FastaiNotebook_11_imagenette
 ---> Running in 94f549eccc16
Removing intermediate container 94f549eccc16
 ---> dd4a74c26cb2
Step 33/43 : RUN /swift-tensorflow-toolchain/usr/bin/swift build
 ---> Running in 1c64bb616eca
[91merror: Package.resolved file is corrupted or malformed; fix or delete the file to continue
[0mThe command '/bin/sh -c /swift-tensorflow-toolchain/usr/bin/swift build' returned a non-zero code: 1
```

</details>

To resolve, remove this file before building FastaiNotebook_11_imagenette.

I'll create an upstream PR to address in fastai/fastai_dev.