### PR TITLE
Remove Package.resolved from OpenSpiel in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,6 @@ RUN /swift-tensorflow-toolchain/usr/bin/swift build -c release
 
 WORKDIR /fastai_dev/swift/FastaiNotebook_11_imagenette
 
-RUN rm Package.resolved
 RUN /swift-tensorflow-toolchain/usr/bin/swift build
 RUN /swift-tensorflow-toolchain/usr/bin/swift build -c release
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,7 @@ RUN /swift-tensorflow-toolchain/usr/bin/swift build
 RUN /swift-tensorflow-toolchain/usr/bin/swift build -c release
 
 WORKDIR /open_spiel
+RUN rm -f Package.resolved
 RUN /swift-tensorflow-toolchain/usr/bin/swift test
 
 WORKDIR /swift-apis


### PR DESCRIPTION
Pending [deepmind/openspiel#287](https://github.com/deepmind/open_spiel/pull/287), this PR unblocks toolchain builds by removing the file if it exists and succeeding either way. 