### PR TITLE
Making GroupNorm and LayerNorm more compatible with X10

### DIFF
--- a/Sources/TensorFlow/Layers/Normalization.swift
+++ b/Sources/TensorFlow/Layers/Normalization.swift
@@ -240,7 +240,7 @@ public struct LayerNorm<Scalar: TensorFlowFloatingPoint>: Layer {
   /// - Returns: The output.
   @differentiable
   public func callAsFunction(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-    let epsilon = Tensor(self.epsilon, on: input.device)
+    let epsilon = withoutDerivative(at: input) { Tensor(self.epsilon, deviceAndPrecisionLike: $0) }
     let positiveAxis = (input.rank + axis) % input.rank
     precondition(
       input.shape[positiveAxis] == offset.shape[0],
@@ -357,7 +357,7 @@ public struct GroupNorm<Scalar: TensorFlowFloatingPoint>: Layer {
     var normalizedAxes = Array(1..<grouped.rank)
     normalizedAxes.remove(at: positiveAxis - 1)
     let moments = grouped.moments(alongAxes: normalizedAxes)
-    let eps = Tensor(epsilon)
+    let eps = withoutDerivative(at: input) { Tensor(self.epsilon, deviceAndPrecisionLike: $0) }
     let normalized = normalize(
       grouped,
       mean: moments.mean, variance: moments.variance,


### PR DESCRIPTION
GroupNorm's local `epsilon` Tensor was being created on the default TF eager device, which led to a crash on X10 devices. This creates an appropriately placed Tensor for that value.

Additionally, wrapping the Tensor creation in `withoutDerivative(at:)` within both GroupNorm and LayerNorm prevents that value from being scalarized in the backwards pass, which would cut the X10 trace at that point. We've found that this has a significant performance impact within BatchNorm, so I've prevented that here.

This should fix issue #1031.