### PR TITLE
Fix log message in xla_tensor/helpers.cpp

### DIFF
--- a/Sources/x10/xla_tensor/helpers.cpp
+++ b/Sources/x10/xla_tensor/helpers.cpp
@@ -561,7 +561,7 @@ std::vector<xla::int64> XlaHelpers::GetPromotedShape(
     xla::int64 dim2 = shape2_dims[shape2_dims.size() - min_size + i];
     XLA_CHECK(dim1 == dim2 || dim1 == 1 || dim2 == 1)
         << "(" << absl::StrJoin(shape1_dims, ", ") << ") and ("
-        << absl::StrJoin(shape1_dims, ", ") << ")";
+        << absl::StrJoin(shape2_dims, ", ") << ")";
     if (dim1 == 0 || dim2 == 0) {
       dimensions.push_back(0);
     } else {


### PR DESCRIPTION
There is a typo in log message that causes confusion. This PR is a quick fix.