### PR TITLE
Add explicit `wrt:` clause to `@derivative(of:)` attribute.

### DIFF
--- a/Sources/TensorFlow/Layers/Dense.swift
+++ b/Sources/TensorFlow/Layers/Dense.swift
@@ -62,7 +62,7 @@ public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
   }
 
   // TODO(TF-433): Remove custom derivative after `try_apply` differentiation is supported.
-  @derivative(of: init)
+  @derivative(of: init, wrt: weight)
   @usableFromInline
   static func vjpInit(
     weight: Tensor<Scalar>,


### PR DESCRIPTION
Add explicit `wrt:` clause to the `@derivative(of:)` attribute for `Dense.init(weight:bias:activation:)`.

This is necessary now that `Optional` conforms to `Differentiable` (https://github.com/apple/swift/pull/32948) so that `bias` is not inferred as a differentiability parameter.

---

Unblocks the `2020-07-28` `apple/swift master -> tensorflow` merge.