### PR TITLE
build: bump TensorFlow to 2.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ if(NOT X10_FOUND AND NOT USE_BUNDLED_X10)
     GIT_REPOSITORY
       git://github.com/tensorflow/tensorflow
     GIT_TAG
-      r2.2
+      r2.3
     UPDATE_DISCONNECTED
       TRUE
     CONFIGURE_COMMAND

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM gcr.io/swift-tensorflow/base-deps-cuda10.2-cudnn7-ubuntu18.04
 
 # Allows the caller to specify the toolchain to use.
 ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-notf-ubuntu18.04.tar.gz
+ARG bazel_version=3.1.0
 
 RUN if test -d /swift-apis/google-cloud-sdk; then \
   mv /swift-apis/google-cloud-sdk /opt/google-cloud-sdk; \
@@ -34,11 +35,12 @@ RUN echo 'deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.
 ARG DEBIAN_FRONTEND=noninteractive
 ARG DEBCONF_NONINTERACTIVE_SEEN=true
 RUN apt-get -yq update                                                          \
- && apt-get -yq install --no-install-recommends bazel-2.0.0 cmake ninja-build   \
+ && apt-get -yq install --no-install-recommends cmake ninja-build               \
  && apt-get -yq install --no-install-recommends python-dev python-pip           \
+ && apt-get -yq install --no-install-recommends bazel-$bazel_version            \
  && apt-get clean                                                               \
  && rm -rf /tmp/* /var/tmp/* /var/lib/apt/archive/* /var/lib/apt/lists/*
-RUN ln -s /usr/bin/bazel-2.0.0 /usr/bin/bazel
+RUN ln -s /usr/bin/bazel-$bazel_version /usr/bin/bazel
 RUN pip install -U pip six numpy wheel setuptools mock 'future>=0.17.1'         \
  && pip install -U --no-deps keras_applications keras_preprocessing
 

--- a/Sources/x10/xla_client/tf_logging.h
+++ b/Sources/x10/xla_client/tf_logging.h
@@ -71,11 +71,11 @@ class ErrorGenerator {
   TF_ERROR_STREAM() << "Check failed: " #condition " "
 
 #define TF_CHECK_OP_LOG(name, op, val1, val2)                         \
-  while (::tensorflow::internal::CheckOpString _result =              \
-             ::tensorflow::internal::name##Impl(                      \
-                 ::tensorflow::internal::GetReferenceableValue(val1), \
-                 ::tensorflow::internal::GetReferenceableValue(val2), \
-                 #val1 " " #op " " #val2))                            \
+  while (::tensorflow::internal::CheckOpString _result{               \
+      ::tensorflow::internal::name##Impl(                             \
+          ::tensorflow::internal::GetReferenceableValue(val1),        \
+          ::tensorflow::internal::GetReferenceableValue(val2),        \
+          #val1 " " #op " " #val2)})                                  \
   TF_ERROR_STREAM() << *(_result.str_)
 
 #define TF_CHECK_OP(name, op, val1, val2) TF_CHECK_OP_LOG(name, op, val1, val2)

--- a/Tests/TensorFlowTests/OperatorTests/DatasetTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/DatasetTests.swift
@@ -113,7 +113,7 @@ final class DatasetTests: XCTestCase {
     let dataset = Dataset(elements: scalars)
     let shuffled = dataset.shuffled(sampleCount: 5, randomSeed: 42,
                                     reshuffleForEachIterator: false)
-    XCTAssertEqual([2, 1, 3, 4, 2], shuffled.map { $0.scalar! })
+    XCTAssertEqual([2, 1, 3, 4, 0], shuffled.map { $0.scalar! })
     let evens = shuffled.map { Tensor($0 % 2) .== Tensor(0) }
     XCTAssertEqual(evens.map { $0.scalar! }, [true, false, false, true, true])
   }

--- a/Tests/TensorFlowTests/OperatorTests/DatasetTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/DatasetTests.swift
@@ -111,10 +111,11 @@ final class DatasetTests: XCTestCase {
   func testMapToDifferentType() {
     let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
     let dataset = Dataset(elements: scalars)
-    let shuffled = dataset.shuffled(sampleCount: 5, randomSeed: 42)
-    XCTAssertEqual([0, 4, 1, 3, 2], shuffled.map { $0.scalar! })
+    let shuffled = dataset.shuffled(sampleCount: 5, randomSeed: 42,
+                                    reshuffleForEachIterator: false)
+    XCTAssertEqual([2, 1, 3, 4, 2], shuffled.map { $0.scalar! })
     let evens = shuffled.map { Tensor($0 % 2) .== Tensor(0) }
-    XCTAssertEqual(evens.map { $0.scalar! }, [true, true, false, false, true])
+    XCTAssertEqual(evens.map { $0.scalar! }, [true, false, false, true, true])
   }
 
   func testSingleValueBatched() {


### PR DESCRIPTION
The TensorFlow 2.3.0 release is GA'ed.  Update the version that we use.