### PR TITLE
build: disable swift-numerics on Darwin targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,16 @@ option(USE_BUNDLED_CTENSORFLOW
   "Use the CTensorFlow module bundled in the active Swift toolchain" OFF)
 option(ENABLE_PYTHON_SUPPORT
   "Enable Python interop using PythonKit" ON)
+
+# FIXME: disable swift-numerics on Darwin as `-force-autoload-symbol` and
+# `-incremental` do not play well together on Darwin.
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  set(ENABLE_SWIFT_NUMERICS_default NO)
+else()
+  set(ENABLE_SWIFT_NUMERICS_default YES)
+endif()
 option(ENABLE_SWIFT_NUMERICS
-  "Enable integrating swift-numerics" YES)
+  "Enable integrating swift-numerics" ${ENABLE_SWIFT_NUMERICS_default})
 
 if(ENABLE_SWIFT_NUMERICS)
   include(ExternalProject)


### PR DESCRIPTION
Disable the bundled swift-numerics by defualt on Darwin targets.  This repairs
the build as `-force-autoload-symbol` and `-incremental` are not currently
supported on Darwin.