### PR TITLE
build: bump to CMake 3.16, centralise artifacts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15.1)
+cmake_minimum_required(VERSION 3.16.0)
 project(TensorFlow
   LANGUAGES Swift)
 
@@ -18,6 +18,9 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
 option(USE_BUNDLED_X10

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ For more models, go to [**tensorflow/swift-models**][swift-models].
 (between `_TF_MIN_BAZEL_VERSION` and `_TF_MAX_BAZEL_VERSION` as specified in
 [tensorflow/configure.py][configure.py]).
 * Python3 with [numpy][numpy].
+* CMake.  CMake 3.16 or newer is required to build with CMake.
 
 ### Building and testing
 
@@ -117,11 +118,7 @@ $ swift test
 
 *Note: CMake is required for building X10 modules.*
 
-In-tree builds are not supported.  The instructions here expect CMake 3.16
-or newer, although the minimum required version is 3.15.1.  Older releases
-will not allow the use of the `-B` option to specific the build tree and
-require that you are in the location of the build tree (and the `-B` option
-and its argument are elided).
+In-tree builds are not supported.  
 
 *Note: To enable CUDA support, run `export TF_NEED_CUDA=1` before the steps below.*
 


### PR DESCRIPTION
Put all the libraries into lib, all the binaries into bin.  This bumps
up the CMake requirement to 3.16.0 to enable the co-located artifacts.
It should make it easier for people to find the artifacts in the build
tree.