### PR TITLE
Remove use of `xla::ValidateEinsumNumericDimensions`

### DIFF
--- a/Sources/x10/xla_tensor/ops/einsum.cpp
+++ b/Sources/x10/xla_tensor/ops/einsum.cpp
@@ -75,12 +75,7 @@ bool Einsum::SupportsEquation(const std::string& equation, xla::int64 x_rank,
   if (!einsum_config_numeric_or_err.ok()) {
     return false;
   }
-  auto einsum_config_numeric = einsum_config_numeric_or_err.ConsumeValueOrDie();
-  auto validation_status = xla::ValidateEinsumNumericDimensions(
-      /*x_config=*/einsum_config_numeric[0],
-      /*y_config=*/einsum_config_numeric[1],
-      /*output_config=*/einsum_config_numeric[2]);
-  return validation_status.ok();
+  return true;
 }
 
 }  // namespace ops


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/commit/116792db459ca63398d5373bd5b139e32e67eb47
removes the function `xla::ValidateEinsumNumericDimensions` because all
expressible op configurations are valid, and thus this function effectively
always returns `true`. This change updates the S4TF usage to remove the
function call, and always return true.