### PR TITLE
Tagging zero scalar tensors.

### DIFF
--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -36,7 +36,8 @@ public struct Tensor<Scalar: TensorFlowScalar> {
   public let handle: TensorHandle<Scalar>
 
   /// An internal marker to identify scalar zero tensors, for use in optimizations.
-  public var _isScalarZero = false
+  @usableFromInline
+  internal var _isScalarZero = false
   
   @inlinable
   public init(handle: TensorHandle<Scalar>) {

--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -38,6 +38,13 @@ public struct Tensor<Scalar: TensorFlowScalar> {
   /// An internal marker to identify scalar zero tensors, for use in optimizations.
   @usableFromInline
   internal var _isScalarZero = false
+
+  /// An internal workaround for SR-13263: debug info generation crash.
+  @usableFromInline
+  class SR13263Workaround {}
+
+  /// An internal workaround for SR-13263: debug info generation crash.
+  internal var _sr13263Workaround: SR13263Workaround?
   
   @inlinable
   public init(handle: TensorHandle<Scalar>) {


### PR DESCRIPTION
A fork of https://github.com/tensorflow/swift-apis/pull/1022 with an attempt to work around SR-13263: a debug info generation crash.