### PR TITLE
Fix test failures caused by `Optional: KeyPathIterable` conformance

### DIFF
--- a/Sources/TensorFlow/Core/CopyableToDevice.swift
+++ b/Sources/TensorFlow/Core/CopyableToDevice.swift
@@ -60,7 +60,7 @@ extension _KeyPathIterableBase {
       let joinedKeyPath = rootKeyPath.appending(path: kp)!
       if let valueType = type(of: joinedKeyPath).valueType as? _CopyableToDevice.Type {
         valueType._move(&root, joinedKeyPath, to: device)
-      } else if let nested = self[keyPath: kp] as? _KeyPathIterableBase {
+      } else if let value = self[keyPath: kp], let nested = value as? _KeyPathIterableBase {
         nested._move(&root, joinedKeyPath, to: device)
       }
     }

--- a/Sources/TensorFlow/Core/MixedPrecision.swift
+++ b/Sources/TensorFlow/Core/MixedPrecision.swift
@@ -92,7 +92,7 @@ import _Differentiation
         let joinedKeyPath = rootKeyPath.appending(path: kp)!
         if let valueType = type(of: joinedKeyPath).valueType as? _ReducedPrecisionConvertible.Type {
           valueType._convertToReducedPrecision(&root, joinedKeyPath)
-        } else if let nested = self[keyPath: kp] as? _KeyPathIterableBase {
+        } else if let value = self[keyPath: kp], let nested = value as? _KeyPathIterableBase {
           nested._convertToReducedPrecision(&root, joinedKeyPath)
         }
       }
@@ -107,7 +107,7 @@ import _Differentiation
         let joinedKeyPath = rootKeyPath.appending(path: kp)!
         if let valueType = type(of: joinedKeyPath).valueType as? _ReducedPrecisionConvertible.Type {
           valueType._convertToFullPrecision(&root, joinedKeyPath)
-        } else if let nested = self[keyPath: kp] as? _KeyPathIterableBase {
+        } else if let value = self[keyPath: kp], let nested = value as? _KeyPathIterableBase {
           nested._convertToFullPrecision(&root, joinedKeyPath)
         }
       }

--- a/Sources/x10/swift_bindings/optimizers/TensorVisitorPlan.swift
+++ b/Sources/x10/swift_bindings/optimizers/TensorVisitorPlan.swift
@@ -351,7 +351,7 @@ extension _KeyPathIterableBase {
         if let child = nested._buildWrappedVisitorPlan(kp as! PartialKeyPath<Base>) {
           plan.elements.append(.node(child))
         }
-      } else if let nested = self[keyPath: kp] as? _KeyPathIterableBase {
+      } else if let value = self[keyPath: kp], let nested = value as? _KeyPathIterableBase {
         if let child = nested._buildWrappedVisitorPlan(kp as! PartialKeyPath<Base>) {
           plan.elements.append(.node(child))
         }


### PR DESCRIPTION
https://github.com/apple/swift/pull/33992 added `Optional: KeyPathIterable` conformance.

The added conformance caused code parts like `self[keyPath: kp] as? _KeyPathIterableBase` to be interpreted as casting `Optional` (return type of `self[keyPath: kp]`) to `_KeyPathIterableBase` (which always succeeds because of the added conformance).

The original intention was to cast the wrapped value of `Optional` to `_KeyPathIterableBase`. This original behavior is restored by changing
`if let nested = self[keyPath: kp] as? _KeyPathIterableBase` to 
`if let value = self[keyPath: kp], let nested = value as? _KeyPathIterableBase`,
where `value` first "unwraps" `Optional` and `nested` is the result of casting wrapped value to `_KeyPathIterableBase`.