### PR TITLE
Convert device to a pointer instead of a string.

### DIFF
--- a/Sources/x10/xla_client/computation_client.cc
+++ b/Sources/x10/xla_client/computation_client.cc
@@ -195,4 +195,29 @@ ComputationClient::DataPtr ComputationClient::TransferToServer(
   TF_LOG(FATAL) << "Only supported for LocalClient";
 }
 
+std::vector<std::string> ComputationClient::GetAllDevices() const {
+  std::vector<std::string> out;
+  auto tmp = GetAllDevicePointers();
+  out.reserve(tmp.size());
+  for (Device* device : tmp) {
+    out.push_back(device->name());
+  }
+  return out;
+}
+
+void ComputationClient::AddDevice(std::unique_ptr<Device> device) {
+  devices_.push_back(device.get());
+  LOG(INFO) << "NAME: " << device->name();
+  devices_by_name_[device->name()] = device.get();
+  devices_owned_.push_back(std::move(device));
+}
+
+ComputationClient::Device* ComputationClient::GetDevice(
+    const std::string& device_name) const {
+  auto it = devices_by_name_.find(device_name);
+  XLA_CHECK(it != devices_by_name_.end())
+      << "Unable to find device: " << device_name;
+  return it->second;
+}
+
 }  // namespace xla

--- a/Sources/x10/xla_client/xrt_computation_client.cc
+++ b/Sources/x10/xla_client/xrt_computation_client.cc
@@ -273,7 +273,7 @@ bool IsLocalDevice(const XrtComputationClient::Worker& worker,
   if (mp_device.empty()) {
     return true;
   }
-  XrtComputationClient::Device device(mp_device);
+  XrtComputationClient::DeviceId device(mp_device);
   std::string task_device_key =
       BuildTaskDeviceKey(parsed_device.task, device.kind);
   auto it = dev_task_map.find(task_device_key);
@@ -288,7 +288,7 @@ std::map<std::string, int> BuildDeviceTaskMap(
   // device ordinal assigned for that task+devkind couple.
   std::map<std::string, int> dev_task_map;
   for (auto& device_xrt_device : options.global_device_map) {
-    XrtComputationClient::Device global_device(device_xrt_device.first);
+    XrtComputationClient::DeviceId global_device(device_xrt_device.first);
     tensorflow::DeviceNameUtils::ParsedName parsed_device =
         ParseXrtDevice(device_xrt_device.second);
     std::string task_device_key =
@@ -317,7 +317,7 @@ void PopulateLocalDevices(XrtComputationClient::Options* options) {
     }
     options->devices.insert(device_xrt_device.first);
 
-    XrtComputationClient::Device global_device(device_xrt_device.first);
+    XrtComputationClient::DeviceId global_device(device_xrt_device.first);
     util::InsertCombined(&min_ordinals, global_device.kind,
                          global_device.ordinal,
                          [](int a, int b) { return std::min(a, b); });
@@ -412,7 +412,7 @@ bool ParseMeshConfig(
     options->workers_map.emplace(worker, config_worker.address());
 
     for (auto& device : config_worker.devices()) {
-      XrtComputationClient::Device local_device(device.local_name());
+      XrtComputationClient::DeviceId local_device(device.local_name());
       options->global_device_map.emplace(
           device.global_name(),
           GetXrtDevicePath(worker.name, worker.task_no, local_device.kind,
@@ -521,7 +521,7 @@ std::unique_ptr<ComputationClient> ComputationClient::Create() {
 
 bool ComputationClient::IsLocal() { return false; }
 
-XrtComputationClient::Device::Device(const std::string& device_str) {
+XrtComputationClient::DeviceId::DeviceId(const std::string& device_str) {
   std::vector<std::string> parts = absl::StrSplit(device_str, ':');
   XLA_CHECK_EQ(parts.size(), 2) << device_str;
   kind = std::move(parts[0]);
@@ -572,11 +572,15 @@ XrtComputationClient::XrtComputationClient(
   MaybeCreateLocalService(options_);
   InitializeDevices(std::move(topology_proto));
   StartHandleReleaser();
+
+  for (const auto& dev_target : options_.global_device_map) {
+    AddDevice(std::make_unique<Device>(dev_target.first, this));
+  }
 }
 
 ComputationClient::DataPtr XrtComputationClient::CreateDataPlaceholder(
     std::string device, Shape shape) {
-  return std::make_shared<XrtData>(std::move(device), std::move(shape));
+  return std::make_shared<XrtData>(GetDevice(device), std::move(shape));
 }
 
 std::vector<size_t> XrtComputationClient::PartitionTransferToServer(
@@ -692,8 +696,8 @@ XrtComputationClient::TransferToServerInternal(
       for (size_t i = 0; i < outputs.size(); ++i) {
         size_t li = session_work->index_mapping[i];
         results[li] = std::make_shared<XrtData>(
-            this, GetEffectiveDevice(tensors[li].device), tensors[li].shape,
-            outputs[i].scalar<int64>()());
+            GetDevice(GetEffectiveDevice(tensors[li].device)),
+            tensors[li].shape, outputs[i].scalar<int64>()());
       }
       CreateDataHandlesCounter()->AddValue(outputs.size());
     };
@@ -723,12 +727,12 @@ std::vector<Literal> XrtComputationClient::TransferFromServer(
     current_size += shape_size;
 
     XrtSession* session = GetSessionForDevice(
-        session_cache_.get(), xrt_data.device(), &session_maps.back());
+        session_cache_.get(), xrt_data.device()->name(), &session_maps.back());
     SessionWork* session_work = &session_work_map[session];
-    tensorflow::Scope device_scope =
-        session->root()->WithDevice(SwiftDeviceToXrtDevice(xrt_data.device()));
+    tensorflow::Scope device_scope = session->root()->WithDevice(
+        SwiftDeviceToXrtDevice(xrt_data.device()->name()));
     const XrtSession::CachedNode& cached_node =
-        GetReadNode(session, device_scope, xrt_data.device());
+        GetReadNode(session, device_scope, xrt_data.device()->name());
     session_work->feed_inputs.insert(
         {cached_node.holders[0], xrt_data.get_handle()});
     session_work->outputs_handles.push_back(cached_node.outputs[0]);
@@ -1062,7 +1066,7 @@ std::vector<ComputationClient::DataPtr> XrtComputationClient::ExecuteChainedXrt(
   std::vector<DataPtr> results;
   auto handles_vec = outputs[0].vec<int64>();
   for (int64 i = 0; i < handles_vec.size(); ++i) {
-    results.push_back(std::make_shared<XrtData>(this, effective_device,
+    results.push_back(std::make_shared<XrtData>(GetDevice(effective_device),
                                                 std::move(result_shapes.at(i)),
                                                 handles_vec(i)));
   }
@@ -1152,18 +1156,18 @@ XrtComputationClient::DeconstructTuple(absl::Span<const DataPtr> tuples) {
   std::vector<int64> tuple_elements_count(tuples.size());
   for (size_t i = 0; i < tuples.size(); ++i) {
     const XrtData& xrt_data = dynamic_cast<const XrtData&>(*tuples[i]);
-    XrtSession* session = GetSessionForDevice(session_cache_.get(),
-                                              xrt_data.device(), &session_map);
+    XrtSession* session = GetSessionForDevice(
+        session_cache_.get(), xrt_data.device()->name(), &session_map);
     SessionWork* session_work = &session_work_map[session];
     session_work->index_mapping.push_back(i);
 
-    tensorflow::Scope device_scope =
-        session->root()->WithDevice(SwiftDeviceToXrtDevice(xrt_data.device()));
+    tensorflow::Scope device_scope = session->root()->WithDevice(
+        SwiftDeviceToXrtDevice(xrt_data.device()->name()));
     int64 count = ShapeUtil::TupleElementCount(xrt_data.shape());
     tuple_elements_count[i] = count;
     for (int64 j = 0; j < count; ++j) {
       const XrtSession::CachedNode& cached_node =
-          GetSubTupleNode(session, device_scope, xrt_data.device());
+          GetSubTupleNode(session, device_scope, xrt_data.device()->name());
       session_work->feed_inputs.insert(
           {cached_node.holders[0], xrt_data.get_handle()});
       tensorflow::Tensor index_tensor(tensorflow::DT_INT32,
@@ -1188,7 +1192,7 @@ XrtComputationClient::DeconstructTuple(absl::Span<const DataPtr> tuples) {
       std::vector<DataPtr> tuple_results;
       for (size_t i = 0; i < tuple_elements_count[li]; ++i, ++output_index) {
         tuple_results.push_back(std::make_shared<XrtData>(
-            this, xrt_data.device(),
+            xrt_data.device(),
             ShapeUtil::GetTupleElementShape(xrt_data.shape(), i),
             outputs[output_index].scalar<int64>()()));
       }
@@ -1254,7 +1258,7 @@ std::unique_ptr<xrt::XLAComputation> XrtComputationClient::CreateXrtComputation(
     auto device_assignment = config->mutable_device_assignment();
     auto computation_device = device_assignment->add_computation_devices();
     for (int64 i = 0; i < devices.size(); ++i) {
-      Device device(devices[i]);
+      DeviceId device(devices[i]);
       auto replica_device = computation_device->add_replica_devices();
       if (device.kind == "TPU") {
         const std::string& xrt_device = SwiftDeviceToXrtDevice(devices[i]);
@@ -1293,7 +1297,7 @@ tensorflow::Tensor XrtComputationClient::GetArgumentsInputs(
       tensorflow::TensorShape({static_cast<int64_t>(arguments.size())}));
   for (size_t i = 0; i < arguments.size(); ++i) {
     const XrtData& xrt_data = dynamic_cast<const XrtData&>(*arguments[i]);
-    XLA_CHECK_EQ(device, xrt_data.device());
+    XLA_CHECK_EQ(device, xrt_data.device()->name());
     inputs_tensor.flat<tensorflow::int64>()(i) = xrt_data.get_handle();
   }
   return inputs_tensor;
@@ -1592,7 +1596,7 @@ void XrtComputationClient::InitializeDevices(
       sys_util::GetEnvString(env::kEnvMeshService, "");
   std::string mp_device = GetMultiProcessingDevice();
   if (!mesh_service_address.empty() && !mp_device.empty()) {
-    Device device(mp_device);
+    DeviceId device(mp_device);
     if (device.ordinal == 0) {
       CreateMeshService(mesh_service_address, topology_proto.get());
     }
@@ -1647,17 +1651,18 @@ void XrtComputationClient::CreateMeshService(
 std::vector<ComputationClient::DataPtr>
 XrtComputationClient::GetComputationResults(
     const tensorflow::Tensor& xrt_result, const Shape& result_shape,
-    const std::string& device) {
+    const std::string& device_name) {
   std::vector<DataPtr> results;
+  auto* device = GetDevice(device_name);
   if (xrt_result.dims() == 1) {
     auto handles_vec = xrt_result.vec<int64>();
     for (int64 i = 0; i < handles_vec.size(); ++i) {
       results.push_back(std::make_shared<XrtData>(
-          this, device, ShapeUtil::GetTupleElementShape(result_shape, i),
+          device, ShapeUtil::GetTupleElementShape(result_shape, i),
           handles_vec(i)));
     }
   } else {
-    results.push_back(std::make_shared<XrtData>(this, device, result_shape,
+    results.push_back(std::make_shared<XrtData>(device, result_shape,
                                                 xrt_result.scalar<int64>()()));
   }
   CreateDataHandlesCounter()->AddValue(results.size());
@@ -1680,14 +1685,6 @@ size_t XrtComputationClient::GetNumDevices() const {
 std::vector<std::string> XrtComputationClient::GetLocalDevices() const {
   return std::vector<std::string>(options_.devices.begin(),
                                   options_.devices.end());
-}
-
-std::vector<std::string> XrtComputationClient::GetAllDevices() const {
-  std::vector<std::string> devices;
-  for (const auto& dev_target : options_.global_device_map) {
-    devices.push_back(dev_target.first);
-  }
-  return devices;
 }
 
 void XrtComputationClient::SetReplicationDevices(

--- a/Sources/x10/xla_tensor/tensor.cpp
+++ b/Sources/x10/xla_tensor/tensor.cpp
@@ -533,7 +533,8 @@ XLATensor::XLATensor(const at::Tensor& tensor, const Device& device)
 
 XLATensor::XLATensor(xla::ComputationClient::DataPtr xla_data,
                      c10::optional<at::ScalarType> logical_element_type)
-    : data_(std::make_shared<Data>(xla_data, Device(xla_data->device()),
+    : data_(std::make_shared<Data>(xla_data,
+                                   Device(xla_data->device()->device_id()),
                                    logical_element_type)) {}
 
 XLATensor::XLATensor(ir::Value ir_value, const Device& device,


### PR DESCRIPTION
The point of this is to allow multiple types of devices in the same
process.