### PR TITLE
Fix test failures related to `Optional: KeyPathIterable` conformance

### DIFF
--- a/Sources/x10/swift_bindings/apis/CrossReplicaSum.swift
+++ b/Sources/x10/swift_bindings/apis/CrossReplicaSum.swift
@@ -49,7 +49,8 @@ extension _KeyPathIterableBase {
       let joinedkp = kp.appending(path: nkp)!
       if let valueType = type(of: joinedkp).valueType as? CrossReplicaSummable.Type {
         valueType._doCrossReplicaSum(&root, joinedkp, scale)
-      } else if let nested = self[keyPath: nkp] as? _KeyPathIterableBase {
+      } else {
+        let nested = self[keyPath: nkp]
         nested.crossReplicaSumChild(&root, joinedkp, scale)
       }
     }

--- a/Sources/x10/swift_bindings/apis/CrossReplicaSum.swift
+++ b/Sources/x10/swift_bindings/apis/CrossReplicaSum.swift
@@ -49,7 +49,7 @@ extension _KeyPathIterableBase {
       let joinedkp = kp.appending(path: nkp)!
       if let valueType = type(of: joinedkp).valueType as? CrossReplicaSummable.Type {
         valueType._doCrossReplicaSum(&root, joinedkp, scale)
-      } else if let value self[keyPath: nkp], let nested = value as? _KeyPathIterableBase {
+      } else if let value = self[keyPath: nkp], let nested = value as? _KeyPathIterableBase {
         nested.crossReplicaSumChild(&root, joinedkp, scale)
       }
     }

--- a/Sources/x10/swift_bindings/apis/CrossReplicaSum.swift
+++ b/Sources/x10/swift_bindings/apis/CrossReplicaSum.swift
@@ -49,8 +49,7 @@ extension _KeyPathIterableBase {
       let joinedkp = kp.appending(path: nkp)!
       if let valueType = type(of: joinedkp).valueType as? CrossReplicaSummable.Type {
         valueType._doCrossReplicaSum(&root, joinedkp, scale)
-      } else {
-        let nested = self[keyPath: nkp]
+      } else if let value self[keyPath: nkp], let nested = value as? _KeyPathIterableBase {
         nested.crossReplicaSumChild(&root, joinedkp, scale)
       }
     }


### PR DESCRIPTION
Uses the same fix as #1090 to resolve the warning:

```
/home/michellecasbon/repos/swift-apis/Sources/x10/swift_bindings/apis/CrossReplicaSum.swift:52:49: warning: conditional cast from 'Any?' to '_KeyPathIterableBase' always succeeds
      } else if let nested = self[keyPath: nkp] as? _KeyPathIterableBase {
                                                ^
```