### PR TITLE
Tests: add a workaround for type deduction

### DIFF
--- a/Tests/TensorFlowTests/TensorAutoDiffTests.swift
+++ b/Tests/TensorFlowTests/TensorAutoDiffTests.swift
@@ -613,7 +613,7 @@ final class TensorAutoDiffTests: XCTestCase {
 
   func testSigmoid() {
     func f(a: Tensor<Float>) -> Tensor<Float> { sigmoid(a).sum() }
-    assertEqual(gradient(at: [-1, 0, 1], in: f), [0.1966119, 0.25, 0.1966119], accuracy: 0.0001)
+    assertEqual(Tensor<Float>(gradient(at: [-1, 0, 1], in: f)), [0.1966119, 0.25, 0.1966119], accuracy: 0.0001)
   }
 
   func testRelu() {


### PR DESCRIPTION
```
/SourceCache/tensorflow-swift-apis/Tests/TensorFlowTests/TensorAutoDiffTests.swift:616:17: error: cannot convert value of type 'Tensor<Float>.TangentVector' (aka 'Tensor<Float>') to expected argument type 'Tensor<Double>'
	assertEqual(gradient(at: [-1, 0, 1], in: f), [0.1966119, 0.25, 0.1966119], accuracy: 0.0001)
        ^
```

For some reason the gradient is being deduced as `Tensor<Double>` which
does not match the expectation of a `Tensor<Float>`.  Provide an
explicit conversion to workaround the issue.