### PR TITLE
TensorFlow: migrate to `CRT` module on Windows

### DIFF
--- a/Sources/TensorFlow/Core/Utilities.swift
+++ b/Sources/TensorFlow/Core/Utilities.swift
@@ -17,7 +17,7 @@ import CTensorFlow
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
   import Darwin
 #elseif os(Windows)
-  import MSVCRT
+  import CRT
 #else
   import Glibc
 #endif

--- a/Sources/TensorFlow/Layers/Dropout.swift
+++ b/Sources/TensorFlow/Layers/Dropout.swift
@@ -15,7 +15,7 @@
 import _Differentiation
 
 #if os(Windows)
-  import func MSVCRT.sqrt
+  import func CRT.sqrt
 #endif
 
 extension Tensor where Scalar: TensorFlowFloatingPoint {


### PR DESCRIPTION
The `MSVCRT` module was replaced with the `CRT` module as the `visualc`
module was removed.