### PR TITLE
Update swift-numerics branch to main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ if(ENABLE_SWIFT_NUMERICS)
     GIT_REPOSITORY
       git://github.com/apple/swift-numerics
     GIT_TAG
-      master
+      main
     CMAKE_ARGS
       -D BUILD_SHARED_LIBS=YES
       -D BUILD_TESTING=NO


### PR DESCRIPTION
The branch name was changed from `master` -> `main` a while ago and `master` was recently deleted.