### PR TITLE
TensorFlow: import `_Differentiation` more thoroughly

### DIFF
--- a/Sources/TensorFlow/Core/Tensor.swift
+++ b/Sources/TensorFlow/Core/Tensor.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import CTensorFlow
 import _Differentiation
+import CTensorFlow
 
 infix operator .==: ComparisonPrecedence
 infix operator .!=: ComparisonPrecedence

--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Foundation
 import _Differentiation
+import Foundation
 
 public protocol Module: EuclideanDifferentiable, KeyPathIterable
 where

--- a/Sources/TensorFlow/Optimizers/MomentumBased.swift
+++ b/Sources/TensorFlow/Optimizers/MomentumBased.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 /// A RMSProp optimizer.
 ///
 /// Implements the RMSProp optimization algorithm. RMSProp is a form of stochastic gradient descent

--- a/Sources/TensorFlow/Optimizers/Optimizer.swift
+++ b/Sources/TensorFlow/Optimizers/Optimizer.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 /// A numerical optimizer.
 ///
 /// Optimizers apply an optimization algorithm to update a differentiable model.

--- a/Sources/TensorFlow/Optimizers/SGD.swift
+++ b/Sources/TensorFlow/Optimizers/SGD.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 /// A stochastic gradient descent (SGD) optimizer.
 ///
 /// Implements the stochastic gradient descent algorithm with support for momentum, learning rate

--- a/Sources/TensorFlow/StdlibExtensions.swift
+++ b/Sources/TensorFlow/StdlibExtensions.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 // MARK: - Array extensions
 
 extension Array: ElementaryFunctions where Element: ElementaryFunctions {

--- a/Sources/x10/swift_bindings/optimizers/Optimizer.swift
+++ b/Sources/x10/swift_bindings/optimizers/Optimizer.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
 import TensorFlow
 @_exported import x10_optimizers_tensor_visitor_plan
 

--- a/Sources/x10/swift_bindings/optimizers/TensorVisitorPlan.swift
+++ b/Sources/x10/swift_bindings/optimizers/TensorVisitorPlan.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
 import TensorFlow
 
 typealias GradMapFn = (inout Tensor<Float>, Tensor<Float>, Int) -> Void


### PR DESCRIPTION
While experimenting with building with the standard toolchain, these
sites were uncovered as requiring additional importing of the
`_Differentiation` module.  When building with the tensorflow branch,
this import is implicit.  This should be an entirely invisible change to
users.