### PR TITLE
TensorFlow: add support for importing Numerics

### DIFF
--- a/Sources/TensorFlow/Core/DataTypes.swift
+++ b/Sources/TensorFlow/Core/DataTypes.swift
@@ -14,6 +14,9 @@
 
 import _Differentiation
 import CTensorFlow
+#if TENSORFLOW_USE_STANDARD_TOOLCHAIN
+import Numerics
+#endif
 
 /// A TensorFlow dynamic type value that can be created from types that conform to
 /// `TensorFlowScalar`.

--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -14,6 +14,9 @@
 
 import _Differentiation
 import Foundation
+#if TENSORFLOW_USE_STANDARD_TOOLCHAIN
+import Numerics
+#endif
 
 public protocol Module: EuclideanDifferentiable, KeyPathIterable
 where

--- a/Sources/TensorFlow/Operators/Math.swift
+++ b/Sources/TensorFlow/Operators/Math.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import _Differentiation
+#if TENSORFLOW_USE_STANDARD_TOOLCHAIN
+import Numerics
+#endif
 
 infix operator .>: ComparisonPrecedence
 infix operator .==: ComparisonPrecedence

--- a/Sources/TensorFlow/Optimizers/MomentumBased.swift
+++ b/Sources/TensorFlow/Optimizers/MomentumBased.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import _Differentiation
+#if TENSORFLOW_USE_STANDARD_TOOLCHAIN
+import Numerics
+#endif
 
 /// A RMSProp optimizer.
 ///

--- a/Sources/TensorFlow/Optimizers/SGD.swift
+++ b/Sources/TensorFlow/Optimizers/SGD.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import _Differentiation
+#if TENSORFLOW_USE_STANDARD_TOOLCHAIN
+import Numerics
+#endif
 
 /// A stochastic gradient descent (SGD) optimizer.
 ///

--- a/Sources/TensorFlow/StdlibExtensions.swift
+++ b/Sources/TensorFlow/StdlibExtensions.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import _Differentiation
+#if TENSORFLOW_USE_STANDARD_TOOLCHAIN
+import Numerics
+#endif
 
 // MARK: - Array extensions
 

--- a/Sources/x10/swift_bindings/optimizers/Optimizer.swift
+++ b/Sources/x10/swift_bindings/optimizers/Optimizer.swift
@@ -14,6 +14,9 @@
 
 import _Differentiation
 import TensorFlow
+#if TENSORFLOW_USE_STANDARD_TOOLCHAIN
+import Numerics
+#endif
 @_exported import x10_optimizers_tensor_visitor_plan
 
 /// State for a single step of a single weight inside an optimizer.


### PR DESCRIPTION
Allow use of the Swift Numerics package for `ElementaryFunctions`
protocol support.  This is currently guarded under a flag
`TENSORFLOW_USE_STANDARD_TOOLCHAIN` which allows the change to be merged
in an inactive state to enable further experimentation.