### PR TITLE
Adjusting or adding tolerances on tests

### DIFF
--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -1377,7 +1377,7 @@ final class LayerTests: XCTestCase {
     let input = Tensor<Float>(ones: [1, 2]) * Tensor<Float>([0.3, 0.7])
     let output = cell(input: input, state: state).state
     let expected = Tensor<Float>([[0.9921227, 0.9999934, 0.9921227, 0.9999934, 0.9921227]])
-    XCTAssertEqual(output, expected)
+    assertEqual(output, expected, accuracy: 1e-6)
   }
 
   func testDense() {
@@ -6769,7 +6769,7 @@ final class LayerTests: XCTestCase {
     let input = Tensor(shape: [5, 1], scalars: (0..<5).map(Float.init))
     let output = tanhLayer.inferring(from: input)
     let expected = Tensor<Float>([[0.0], [0.7615942], [0.9640276], [0.9950547], [0.9993292]])
-    XCTAssertEqual(output, expected)
+    assertEqual(output, expected, accuracy: 1e-6)
   }
 
   func testBatchNorm() {

--- a/Tests/TensorFlowTests/LossTests.swift
+++ b/Tests/TensorFlowTests/LossTests.swift
@@ -40,8 +40,8 @@ final class LossTests: XCTestCase {
       scalars: [0.1, 0.2, 0.3, 0.4, 0.4, 0.3, 0.2, 0.1])
 
     let loss = meanSquaredError(predicted: predicted, expected: expected)
-    let expectedLoss: Float = 23.324999
-    assertEqual(loss, Tensor(expectedLoss), accuracy: 1e-6)
+    let expectedLoss: Float = 23.325
+    assertEqual(loss, Tensor(expectedLoss), accuracy: 2e-6)
   }
 
   func testMeanSquaredLogarithmicError() {

--- a/Tests/TensorFlowTests/OperatorTests/LinearAlgebraTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/LinearAlgebraTests.swift
@@ -136,7 +136,7 @@ final class LinearAlgebraTests: XCTestCase {
     matrix = Tensor<Float>(shape: [2, 2, 2, 2], scalars: (0..<16).map(Float.init))
     computedDet = det(matrix)
     expectedDet = Tensor<Float>([[-2.0, -2.0], [-2.0, -2.0]])
-    assertEqual(computedDet, expectedDet, accuracy: 1e-5)
+    assertEqual(computedDet, expectedDet, accuracy: 2e-5)
   }
 
   func testSlogdet() {
@@ -151,8 +151,8 @@ final class LinearAlgebraTests: XCTestCase {
     expectedSigns = Tensor<Float>([[-1.0, -1.0], [-1.0, -1.0]])
     expectedLogs = Tensor<Float>([[0.6931472, 0.6931462], [0.6931462, 0.6931435]])
     (computedSigns, computedLogs) = slogdet(input)
-    XCTAssertEqual(computedSigns, expectedSigns)
-    XCTAssertEqual(computedLogs, expectedLogs)
+    assertEqual(computedSigns, expectedSigns, accuracy: 1e-5)
+    assertEqual(computedLogs, expectedLogs, accuracy: 1e-5)
   }
 
   func testLogdet() {

--- a/Tests/TensorFlowTests/OperatorTests/MathTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/MathTests.swift
@@ -226,7 +226,7 @@ final class MathOperatorTests: XCTestCase {
     let x = Tensor<Float>([-1.0, 2.0, 3.0])
     let y = elu(x)
     let expectedY = Tensor<Float>([-0.63212055, 2, 3])
-    XCTAssertEqual(y, expectedY)
+    assertEqual(y, expectedY, accuracy: 1e-6)
   }
 
   func testGelu() {

--- a/Tests/TensorFlowTests/TensorAutoDiffTests.swift
+++ b/Tests/TensorFlowTests/TensorAutoDiffTests.swift
@@ -178,7 +178,7 @@ final class TensorAutoDiffTests: XCTestCase {
     let grad = gradient(at: Tensor<Float>([3.0, 4.0])) { x in
       logSoftmax(x).mean().scalarized()
     }
-    XCTAssertEqual(grad, Tensor([0.23105857, -0.2310586]))
+    assertEqual(grad, Tensor([0.23105857, -0.2310586]), accuracy: 1e-6)
   }
 
   func testScalars() {


### PR DESCRIPTION
These tests were failing on a test platform due to slight numerical differences. Several of the tests just checked for floating point equality, so tolerances were added to those. Others had results that were just outside of the allowed tolerance, so the tolerances have been slightly relaxed for those.