### PR TITLE
fix dimension order in TransposedConv2D.init doc comment

### DIFF
--- a/Sources/TensorFlow/Layers/Convolutional.swift
+++ b/Sources/TensorFlow/Layers/Convolutional.swift
@@ -561,7 +561,7 @@ extension TransposedConv2D {
   ///
   /// - Parameters:
   ///   - filterShape: A 4-D tensor of shape
-  ///     `[width, height, input channel count, output channel count]`.
+  ///     `[width, height, output channel count, input channel count]`.
   ///   - strides: The strides of the sliding window for spatial dimensions.
   ///   - padding: The padding algorithm for convolution.
   ///   - activation: The element-wise activation function.


### PR DESCRIPTION
As discovered in https://bugs.swift.org/projects/TF/issues/TF-1349, the documented order is wrong.