### PR TITLE
build: create the directory hierarchy for Numerics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,8 @@ if(ENABLE_SWIFT_NUMERICS)
   import_module(Numerics ${BINARY_DIR} swift-numerics-build)
   import_module(ComplexModule ${BINARY_DIR} swift-numerics-build)
   import_module(RealModule ${BINARY_DIR} swift-numerics-build)
+
+  file(MAKE_DIRECTORY ${BINARY_DIR}/swift)
 endif()
 
 if(ENABLE_PYTHON_SUPPORT)


### PR DESCRIPTION
Ensure that we create the Swift module directory for swift-numerics when
configuring to ensure that a clean build with swift-numerics does not
require the user to create it.