### PR TITLE
build: workaround autolinking on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,8 @@ if(ENABLE_SWIFT_NUMERICS)
     else()
       set_target_properties(${module_name} PROPERTIES
         IMPORTED_LOCATION ${build_dir}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}${module_name}${CMAKE_SHARED_LIBRARY_SUFFIX}
-        INTERFACE_INCLUDE_DIRECTORIES ${build_dir}/swift)
+        INTERFACE_INCLUDE_DIRECTORIES ${build_dir}/swift
+        INTERFACE_LINK_DIRECTORIES ${build_dir}/lib)
     endif()
     add_dependencies(${module_name} ${build_target})
   endfunction()


### PR DESCRIPTION
Unfortunately, Linux will attempt to autolink the libraries, so provide
a linker search path entry for Numerics to allow the lookup to succeed.