### PR TITLE
Revert "build: correct the install rule for swiftdocs"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,7 +281,7 @@ if(ENABLE_SWIFT_NUMERICS)
 
     if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
       install(FILES $<TARGET_PROPERTY:${module},INTERFACE_INCLUDE_DIRECTORIES>/${module}.swiftdoc
-        DESTINATION lib/swift/${swift_os}/${module}.swiftdoc
+        DESTINATION lib/swift/${swift_os}/${module}.swiftmodule
         RENAME ${swift_arch}.swiftdoc)
       install(FILES $<TARGET_PROPERTY:${module},INTERFACE_INCLUDE_DIRECTORIES>/${module}.swiftmodule
         DESTINATION lib/swift/${swift_os}/${module}.swiftmodule


### PR DESCRIPTION
Reverts tensorflow/swift-apis#1137

The install location was previously correct for Darwin targets.  I missed spotting that the next line performs the import renaming.  This installs the swiftdoc properly as a child of the swiftmodule directory.