### PR TITLE
build: install `_NumericsShims`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,4 +295,9 @@ if(ENABLE_SWIFT_NUMERICS)
         DESTINATION lib/swift/${swift_os}/${swift_arch})
     endif()
   endforeach()
+
+  install(FILES
+    $<TARGET_PROPERTY:_NumericsShims,INTERFACE_INCLUDE_DIRECTORIES>/_NumericsShims.h
+    $<TARGET_PROPERTY:_NumericsShims,INTERFACE_INCLUDE_DIRECTORIES>/module.modulemap
+    DESTINATION lib/swift/_NumericsShims)
 endif()


### PR DESCRIPTION
The `_NumericsShims` module is required for Numerics as we cannot use
the Numerics module as implementation only as we provide extensions via
`ElementaryFunctions`.  This should allow users to actually build
against the build of swift-apis.