### PR TITLE
CTensorFlow: add `shim.c`

### DIFF
--- a/Sources/CTensorFlow/shim.c
+++ b/Sources/CTensorFlow/shim.c
@@ -1,0 +1,15 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern int _;


### PR DESCRIPTION
This empty translation unit serves no use other than to appease Swift
Package Manager which requires that any non-Swift library must have a
source file (even if one is not required).  Simply add an empty source
file.  However, because C does not permit a completely empty source
file, add an unused declaration.