### PR TITLE
build: require swift-numerics when building with SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,14 +32,19 @@ let package = Package(
       type: .dynamic,
       targets: ["Tensor"]),
   ],
-  dependencies: [],
+  dependencies: [
+    .package(url: "https://github.com/apple/swift-numerics", .branch("main")),
+  ],
   targets: [
     .target(
       name: "Tensor",
       dependencies: []),
     .target(
       name: "TensorFlow",
-      dependencies: ["Tensor"]),
+      dependencies: [
+        "Tensor",
+        .product(name: "Numerics", package: "swift-numerics"),
+      ]),
     .target(
       name: "Experimental",
       dependencies: [],


### PR DESCRIPTION
SPM does not allow for build configurations.  Force swift-numerics to be
used all the time.  This is required in order to be able to build with
standard toolchains which do not have the TensorFlow numerics additions.