### PR TITLE
TensorFlowTests: adjust a few cases of type conversion

### DIFF
--- a/Tests/TensorFlowTests/LayerTests.swift
+++ b/Tests/TensorFlowTests/LayerTests.swift
@@ -6846,7 +6846,7 @@ final class LayerTests: XCTestCase {
     let epsilon: Float = 0.001
     let bnLayer = BatchNorm<Float>(featureCount: 5, axis: 1, epsilon: epsilon)
     // Test inference before any training.
-    assertEqual(bnLayer.inferring(from: x), x / TensorFlow.sqrt(1 + epsilon), accuracy: 1e-5)
+    assertEqual(bnLayer.inferring(from: x), x / TensorFlow.sqrt(Tensor<Float>(1 + epsilon)), accuracy: 1e-5)
     // Perform one training step, updating the running mean and variance.
     Context.local.learningPhase = .training
     _ = bnLayer(x)  // This line is important and cannot be removed.

--- a/Tests/TensorFlowTests/OperatorTests/MathTests.swift
+++ b/Tests/TensorFlowTests/OperatorTests/MathTests.swift
@@ -307,13 +307,13 @@ final class MathOperatorTests: XCTestCase {
   }
 
   func testIsInfinite() {
-    let x = Tensor<Float>([1, 2, 3, 4, log(0.0)])
+    let x = Tensor<Float>([1, 2, 3, 4, Float(log(0.0))])
     let y = x.isInfinite
     XCTAssertEqual(y, Tensor([false, false, false, false, true]))
   }
 
   func testIsNaN() {
-    let x = Tensor<Float>([1, 2, 3, 4, log(-5.0)])
+    let x = Tensor<Float>([1, 2, 3, 4, Float(log(-5.0))])
     let y = x.isNaN
     XCTAssertEqual(y, Tensor([false, false, false, false, true]))
   }


### PR DESCRIPTION
When building the tests with SPM, these would fail to build due to type
differences (i.e. expecting `Tensor<Float>` or `Float` instead of
`Double`).  Explicitly convert the types.