### PR TITLE
build: add a hard dependency on PythonKit with SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-numerics", .branch("main")),
+    .package(url: "https://github.com/pvieito/PythonKit.git", .branch("master")),
   ],
   targets: [
     .target(
@@ -43,6 +44,7 @@ let package = Package(
       name: "TensorFlow",
       dependencies: [
         "Tensor",
+        "PythonKit",
         .product(name: "Numerics", package: "swift-numerics"),
       ]),
     .target(


### PR DESCRIPTION
Unlike CMake, SPM does not permit any control over build configuration.
Make PythonKit a hard dependency for the package.  This along with the
remainder of the changes that have been made to the build system now
enable building Swift APIs with SPM in a complete configuration of
PythonKit + Swift Numerics + X10.  This simplifies the path towards
getting a SPM built Swift APIs with X10 and PythonKit support with a
standard toolchain.