### PR TITLE
TensorFlow: silence a warning from the compiler

### DIFF
--- a/Sources/TensorFlow/Core/VectorProtocol.swift
+++ b/Sources/TensorFlow/Core/VectorProtocol.swift
@@ -72,8 +72,10 @@ extension _VectorProtocol {
 /// A type that represents an unranked vector space. Values of this type are
 /// elements in this vector space and have either no shape or a static shape.
 public protocol VectorProtocol: _VectorProtocol & AdditiveArithmetic {
+#if !TENSORFLOW_USE_STANDARD_TOOLCHAIN
   /// The type of scalars in the vector space.
   associatedtype VectorSpaceScalar = Float
+#endif
 
   func adding(_ x: VectorSpaceScalar) -> Self
 


### PR DESCRIPTION
Remove the associated type requirement which has been flagged by the
compiler as being duplicate due to the standalone definition of the
`VectorProtocol` type for supporting the standard toolchain.