### PR TITLE
workflows: setup a macOS GitHub workflow for CI

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -1,0 +1,35 @@
+name: macOS
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install swift-DEVELOPMENT-SNAPSHOT-2020-12-14-a
+        run: |
+          curl -sOL https://swift.org/builds/development/xcode/swift-DEVELOPMENT-SNAPSHOT-2020-12-14-a/swift-DEVELOPMENT-SNAPSHOT-2020-12-14-a-osx.pkg
+          xattr -dr com.apple.quarantine swift-DEVELOPMENT-SNAPSHOT-2020-12-14-a-osx.pkg
+          installer -pkg swift-DEVELOPMENT-SNAPSHOT-2020-12-14-a-osx.pkg -target CurrentUserHomeDirectory
+      - name: Set Environment Variables
+        run: |
+          echo "TOOLCHAINS=..." > $GITHUB_ENV
+
+      - name: Install X10
+        run: |
+          curl -sL https://artprodeus21.artifacts.visualstudio.com/A8fd008a0-56bc-482c-ba46-67f9425510be/3133d6ab-80a8-4996-ac4f-03df25cd3224/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2NvbXBuZXJkL3Byb2plY3RJZC8zMTMzZDZhYi04MGE4LTQ5OTYtYWM0Zi0wM2RmMjVjZDMyMjQvYnVpbGRJZC80Mzc2OC9hcnRpZmFjdE5hbWUvdGVuc29yZmxvdy1kYXJ3aW4teDY00/content?format=zip -o tensorflow-darwin-x64.zip
+          unzip tensorflow-darwin-x64.zip
+          mv tensorflow-darwin-x64/Library/tensorflow-2.3.0 ~/Library/
+
+      - name: Build
+        run: |
+          TOOLCHAINS=org.swift.50202012141a swift build -v -Xswiftc -DTENSORFLOW_USE_STANDARD_TOOLCHAIN -Xcc -I${HOME}/Library/tensorflow-2.3.0/usr/include -Xlinker -L${HOME}/Library/tensorflow-2.3.0/usr/lib
+    # - name: Run tests
+    #   run: |
+    #     DYLD_LIBRARY_PATH=${HOME}/Library/tensorflow-2.3.0/usr/lib TOOLCHAINS=org.swift.50202012141a swift test -v -Xswiftc -DTENSORFLOW_USE_STANDARD_TOOLCHAIN -Xcc -I${HOME}/Library/tensorflow-2.3.0/usr/include -Xlinker -L${HOME}/Library/tensorflow-2.3.0/usr/lib
+


### PR DESCRIPTION
Now that we can build with a stock toolchain, we can start investigating
building on macOS with GitHub actions.  This will give us additional
coverage and earlier notifications.