### PR TITLE
TensorFlow: annotate functions using `_forEachFieldWithKeyPath`

### DIFF
--- a/Sources/TensorFlow/Core/ElementaryFunctions.swift
+++ b/Sources/TensorFlow/Core/ElementaryFunctions.swift
@@ -13,12 +13,18 @@
 // limitations under the License.
 
 #if TENSORFLOW_USE_STANDARD_TOOLCHAIN
+
 import Numerics
 @_spi(Reflection) import Swift
+
 extension ElementaryFunctions {
   internal static func visitChildren(
     _ body: (PartialKeyPath<Self>, ElementaryFunctionsVisit.Type) -> Void
   ) {
+    guard #available(macOS 9999, *) else {
+      fatalError("\(#function) is unavailable")
+    }
+
     if !_forEachFieldWithKeyPath(
       of: Self.self,
       body: { name, kp in
@@ -164,4 +170,5 @@ extension ElementaryFunctions {
   public static func root(_ x: Self, _ n: Int) -> Self { .init(mapped: Functor_root(n: n), x) }
   public static func pow(_ x: Self, _ y: Self) -> Self { .init(mapped: Functor_pow2(), x, y) }
 }
+
 #endif

--- a/Sources/TensorFlow/Core/EuclideanDifferentiable.swift
+++ b/Sources/TensorFlow/Core/EuclideanDifferentiable.swift
@@ -15,9 +15,14 @@
 import _Differentiation
 
 #if TENSORFLOW_USE_STANDARD_TOOLCHAIN
+
 @_spi(Reflection) import Swift
 
 func listFields<Root>(of type: Root.Type) -> [(String, PartialKeyPath<Root>)] {
+  guard #available(macOS 9999, *) else {
+    fatalError("\(#function) is unavailable")
+  }
+
   var out = [(String, PartialKeyPath<Root>)]()
   _forEachFieldWithKeyPath(of: type, options: .ignoreUnknown) { name, kp in
     out.append((String(validatingUTF8: name)!, kp))
@@ -27,8 +32,11 @@ func listFields<Root>(of type: Root.Type) -> [(String, PartialKeyPath<Root>)] {
 }
 
 extension Differentiable {
-  static var differentiableFields: [(String, PartialKeyPath<Self>, PartialKeyPath<TangentVector>)]
-  {
+  static var differentiableFields: [(String, PartialKeyPath<Self>, PartialKeyPath<TangentVector>)] {
+    guard #available(macOS 9999, *) else {
+      fatalError("\(#function) is unavailable")
+    }
+
     let tangentFields = listFields(of: TangentVector.self)
     var i = 0
     var out = [(String, PartialKeyPath<Self>, PartialKeyPath<TangentVector>)]()

--- a/Sources/TensorFlow/Core/KeyPathIterable.swift
+++ b/Sources/TensorFlow/Core/KeyPathIterable.swift
@@ -21,6 +21,7 @@
 import _Differentiation
 
 #if TENSORFLOW_USE_STANDARD_TOOLCHAIN
+
 @_spi(Reflection) import Swift
 
 /// An implementation detail of `KeyPathIterable`; do not use this protocol
@@ -42,6 +43,10 @@ public protocol KeyPathIterable: _KeyPathIterableBase {
 
 public extension KeyPathIterable {
   var allKeyPaths: [PartialKeyPath<Self>] {
+    guard #available(macOS 9999, *) else {
+      fatalError("\(#function) is unavailable")
+    }
+
     var out = [PartialKeyPath<Self>]()
     _forEachFieldWithKeyPath(of: Self.self, options: .ignoreUnknown) { name, kp in
       out.append(kp)
@@ -171,4 +176,5 @@ extension Optional.TangentVector: KeyPathIterable {
     return []
   }
 }
+
 #endif

--- a/Sources/TensorFlow/Core/PointwiseMultiplicative.swift
+++ b/Sources/TensorFlow/Core/PointwiseMultiplicative.swift
@@ -15,6 +15,7 @@
 import _Differentiation
 
 #if TENSORFLOW_USE_STANDARD_TOOLCHAIN
+
 @_spi(Reflection) import Swift
 
 infix operator .*: MultiplicationPrecedence
@@ -114,6 +115,10 @@ extension PointwiseMultiplicative {
   internal static func visitChildren(
     _ body: (PartialKeyPath<Self>, _PointwiseMultiplicative.Type) -> Void
   ) {
+    guard #available(macOS 9999, *) else {
+      fatalError("\(#function) is unavailable")
+    }
+
     if !_forEachFieldWithKeyPath(
       of: Self.self,
       body: { name, kp in
@@ -134,4 +139,5 @@ extension PointwiseMultiplicative {
 extension Array.DifferentiableView: _PointwiseMultiplicative
 where Element: Differentiable & PointwiseMultiplicative {}
 extension Tensor: _PointwiseMultiplicative where Scalar: Numeric {}
+
 #endif

--- a/Sources/TensorFlow/Core/VectorProtocol.swift
+++ b/Sources/TensorFlow/Core/VectorProtocol.swift
@@ -15,6 +15,7 @@
 import _Differentiation
 
 #if TENSORFLOW_USE_STANDARD_TOOLCHAIN
+
 @_spi(Reflection) import Swift
 
 /// Implementation detail for reflection.
@@ -38,6 +39,10 @@ extension VectorProtocol {
   internal static func visitChildren(
     _ body: (PartialKeyPath<Self>, _VectorProtocol.Type) -> Void
   ) {
+    guard #available(macOS 9999, *) else {
+      fatalError("\(#function) is unavailable")
+    }
+
     if !_forEachFieldWithKeyPath(
       of: Self.self,
       body: { name, kp in
@@ -127,4 +132,5 @@ extension VectorProtocol {
 extension Tensor: _VectorProtocol where Scalar: TensorFlowFloatingPoint {}
 extension Array.DifferentiableView: _VectorProtocol
 where Element: Differentiable & VectorProtocol {}
+
 #endif


### PR DESCRIPTION
Because the standard toolchain support requires the newest runtime in
order to have access to `_forEachFieldWithKeyPath` and the runtime is
bundled into the OS on macOS, we need to annotate the functions with
availability.