### PR TITLE
documentation: add more documentation around macOS builds

### DIFF
--- a/Documentation/Development.md
+++ b/Documentation/Development.md
@@ -249,7 +249,7 @@ $ swift build -Xcc -I/Library/tensorflow-2.4.0/usr/include -Xlinker -L/Library/t
 $ swift test -Xcc -I/Library/tensorflow-2.4.0/usr/include -Xlinker -L/Library/tensorflow-2.4.0/usr/lib
 ```
 
-On macOS, in order to select the proper toolchain, the `TOOLCHAINS` enviornment
+On macOS, in order to select the proper toolchain, the `TOOLCHAINS` environment
 variable can be used to modify the selected Xcode toolchain temporarily.  The
 macOS (Xcode) toolchain distributed from [swift.org](https://swift.org) has a
 bundle identifier which can uniquely identify the toolchain to the system.  The

--- a/Documentation/Development.md
+++ b/Documentation/Development.md
@@ -249,6 +249,23 @@ $ swift build -Xcc -I/Library/tensorflow-2.4.0/usr/include -Xlinker -L/Library/t
 $ swift test -Xcc -I/Library/tensorflow-2.4.0/usr/include -Xlinker -L/Library/tensorflow-2.4.0/usr/lib
 ```
 
+On macOS, in order to select the proper toolchain, the `TOOLCHAINS` enviornment
+variable can be used to modify the selected Xcode toolchain temporarily.  The
+macOS (Xcode) toolchain distributed from [swift.org](https://swift.org) has a
+bundle identifier which can uniquely identify the toolchain to the system.  The
+following attempts to determine the latest toolchain snapshot and extract the
+identifier for it.
+
+```shell
+xpath 2>/dev/null $(find /Library/Developer/Toolchains ~/Library/Developer/Toolchains -type d -depth 1 -regex '.*/swift-DEVELOPMENT-SNAPSHOT-.*.xctoolchain | sort -u | tail -n 1)/Info.plist "/plist/dict/key[. = 'CFBundleIdentifier']/following-sibling::string[1]//text()"
+```
+
+This allows one to build the package as:
+
+```shell
+TOOLCHAINS=$(xpath 2>/dev/null $(find /Library/Developer/Toolchains ~/Library/Developer/Toolchains -type d -depth 1 -regex '.*/swift-DEVELOPMENT-SNAPSHOT-.*.xctoolchain | sort -u | tail -n 1)/Info.plist "/plist/dict/key[. = 'CFBundleIdentifier']/following-sibling::string[1]//text()") swift build -Xswiftc -DTENSORFLOW_USE_STANDARD_TOOLCHAIN -Xcc -I/Library/tensorflow-2.4.0/usr/include -Xlinker -L/Library/tensorflow-2.4.0/usr/lib
+```
+
 #### CMake
 
 *Note: In-tree builds are not supported.*


### PR DESCRIPTION
Building on macOS is a bit more complicated as the toolchain selection
is reliant on Xcode environment variables.  This documents how to query
the toolchain identifier and use that to build the Swift APIs package.