### PR TITLE
build: correct the install rules for Darwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,16 +280,17 @@ if(ENABLE_SWIFT_NUMERICS)
         DESTINATION lib/swift/${swift_os})
     endif()
 
+    get_target_property(${module}_INTERFACE_INCLUDE_DIRECTORIES ${module}
+      INTERFACE_INCLUDE_DIRECTORIES)
+
     if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-      install(FILES $<TARGET_PROPERTY:${module},INTERFACE_INCLUDE_DIRECTORIES>/${module}.swiftdoc
-        DESTINATION lib/swift/${swift_os}/${module}.swiftmodule
+      install(FILES ${${module}_INTERFACE_INCLUDE_DIRECTORIES}/${module}.swiftdoc
+        DESTINATION lib/swift/${swift_os}/${module}.swiftmodule/
         RENAME ${swift_arch}.swiftdoc)
-      install(FILES $<TARGET_PROPERTY:${module},INTERFACE_INCLUDE_DIRECTORIES>/${module}.swiftmodule
-        DESTINATION lib/swift/${swift_os}/${module}.swiftmodule
+      install(FILES ${${module}_INTERFACE_INCLUDE_DIRECTORIES}/${module}.swiftmodule
+        DESTINATION lib/swift/${swift_os}/${module}.swiftmodule/
         RENAME ${swift_arch}.swiftmodule)
     else()
-      get_target_property(${module}_INTERFACE_INCLUDE_DIRECTORIES ${module}
-        INTERFACE_INCLUDE_DIRECTORIES)
       install(FILES
         ${${module}_INTERFACE_INCLUDE_DIRECTORIES}/${module}.swiftdoc
         ${${module}_INTERFACE_INCLUDE_DIRECTORIES}/${module}.swiftmodule


### PR DESCRIPTION
We were using the generator expression for the installation of the swift
modules on Darwin.  However, with swift-numerics, the Numerics module
has an implicit link against `_NumericsShims`.  This results in the
interface include directories having multiple values when computed late.
Use `get_target_property` to get the value prior to the additions,
allowing us to rename the file into place.

Thanks to @dan-zheng for reporting the issue!