### PR TITLE
build: add build rules for X10 supplementary modules

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,18 @@ let package = Package(
       name: "Tensor",
       type: .dynamic,
       targets: ["Tensor"]),
+    .library(
+      name: "x10_optimizers_optimizer",
+      type: .dynamic,
+      targets: ["x10_optimizers_optimizer"]),
+    .library(
+      name: "x10_optimizers_tensor_visitor_plan",
+      type: .dynamic,
+      targets: ["x10_optimizers_tensor_visitor_plan"]),
+    .library(
+      name: "x10_training_loop",
+      type: .dynamic,
+      targets: ["x10_training_loop"]),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-numerics", .branch("main")),
@@ -58,6 +70,31 @@ let package = Package(
       swiftSettings: [
         .define("USING_X10_BACKEND"),
         .define("DEFAULT_BACKEND_EAGER"),
+      ]),
+    .target(
+      name: "x10_optimizers_tensor_visitor_plan",
+      dependencies: ["TensorFlow"],
+      path: "Sources/x10",
+      sources: [
+        "swift_bindings/optimizers/TensorVisitorPlan.swift",
+      ]),
+    .target(
+      name: "x10_optimizers_optimizer",
+      dependencies: [
+        "x10_optimizers_tensor_visitor_plan",
+        "TensorFlow",
+      ],
+      path: "Sources/x10",
+      sources: [
+        "swift_bindings/optimizers/Optimizer.swift",
+        "swift_bindings/optimizers/Optimizers.swift",
+      ]),
+    .target(
+      name: "x10_training_loop",
+      dependencies: ["TensorFlow"],
+      path: "Sources/x10",
+      sources: [
+        "swift_bindings/training_loop.swift",
       ]),
     .target(
       name: "Experimental",

--- a/Package.swift
+++ b/Package.swift
@@ -39,10 +39,10 @@ let package = Package(
       name: "x10_optimizers_tensor_visitor_plan",
       type: .dynamic,
       targets: ["x10_optimizers_tensor_visitor_plan"]),
-    .library(
-      name: "x10_training_loop",
-      type: .dynamic,
-      targets: ["x10_training_loop"]),
+    // .library(
+    //   name: "x10_training_loop",
+    //   type: .dynamic,
+    //   targets: ["x10_training_loop"]),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-numerics", .branch("main")),
@@ -89,13 +89,13 @@ let package = Package(
         "swift_bindings/optimizers/Optimizer.swift",
         "swift_bindings/optimizers/Optimizers.swift",
       ]),
-    .target(
-      name: "x10_training_loop",
-      dependencies: ["TensorFlow"],
-      path: "Sources/x10",
-      sources: [
-        "swift_bindings/training_loop.swift",
-      ]),
+    // .target(
+    //   name: "x10_training_loop",
+    //   dependencies: ["TensorFlow"],
+    //   path: "Sources/x10",
+    //   sources: [
+    //     "swift_bindings/training_loop.swift",
+    //   ]),
     .target(
       name: "Experimental",
       dependencies: [],


### PR DESCRIPTION
Add support to build:
- x10_optimizers_optimizer
- x10_optimizers_tensor_visitor_plan
- x10_trailing_loop

These are used by some dependent projects (such as the BERT CoLA model).