### PR TITLE
NFC: fix warnings related to `VectorProtocol.VectorSpaceScalar`.

### DIFF
--- a/Sources/TensorFlow/Layers/Sequential.swift
+++ b/Sources/TensorFlow/Layers/Sequential.swift
@@ -47,8 +47,7 @@ import _Differentiation
 /// ````
 public struct Sequential<Layer1: Module, Layer2: Layer>: Module
 where
-  Layer1.Output == Layer2.Input,
-  Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar
+  Layer1.Output == Layer2.Input
 {
   public var layer1: Layer1
   public var layer2: Layer2
@@ -78,42 +77,28 @@ extension Sequential: Layer where Layer1: Layer {
 /// A layer that sequentially composes 3 layers.
 public typealias Sequential3<L1: Module, L2: Layer, L3: Layer> = Sequential<L1, Sequential<L2, L3>>
 where
-  L1.Output == L2.Input, L2.Output == L3.Input,
-  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
-  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar
+  L1.Output == L2.Input, L2.Output == L3.Input
 
 /// A layer that sequentially composes 4 layers.
 public typealias Sequential4<L1: Module, L2: Layer, L3: Layer, L4: Layer> = Sequential<
   L1, Sequential<L2, Sequential<L3, L4>>
 >
 where
-  L1.Output == L2.Input, L2.Output == L3.Input, L3.Output == L4.Input,
-  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
-  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
-  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar
+  L1.Output == L2.Input, L2.Output == L3.Input, L3.Output == L4.Input
 
 /// A layer that sequentially composes 5 layers.
 public typealias Sequential5<L1: Module, L2: Layer, L3: Layer, L4: Layer, L5: Layer> = Sequential<
   L1, Sequential<L2, Sequential<L3, Sequential<L4, L5>>>
 >
 where
-  L1.Output == L2.Input, L2.Output == L3.Input, L3.Output == L4.Input, L4.Output == L5.Input,
-  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
-  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
-  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
-  L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar
+  L1.Output == L2.Input, L2.Output == L3.Input, L3.Output == L4.Input, L4.Output == L5.Input
 
 /// A layer that sequentially composes 6 layers.
 public typealias Sequential6<L1: Module, L2: Layer, L3: Layer, L4: Layer, L5: Layer, L6: Layer> =
   Sequential<L1, Sequential<L2, Sequential<L3, Sequential<L4, Sequential<L5, L6>>>>>
 where
   L1.Output == L2.Input, L2.Output == L3.Input, L3.Output == L4.Input, L4.Output == L5.Input,
-  L5.Output == L6.Input,
-  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
-  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
-  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
-  L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
-  L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar
+  L5.Output == L6.Input
 
 /// A layer that sequentially composes 7 layers.
 public typealias Sequential7<
@@ -123,13 +108,7 @@ public typealias Sequential7<
 >
 where
   L1.Output == L2.Input, L2.Output == L3.Input, L3.Output == L4.Input, L4.Output == L5.Input,
-  L5.Output == L6.Input, L6.Output == L7.Input,
-  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
-  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
-  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
-  L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
-  L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
-  L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar
+  L5.Output == L6.Input, L6.Output == L7.Input
 
 /// A layer that sequentially composes 8 layers.
 public typealias Sequential8<
@@ -140,14 +119,7 @@ public typealias Sequential8<
 >
 where
   L1.Output == L2.Input, L2.Output == L3.Input, L3.Output == L4.Input, L4.Output == L5.Input,
-  L5.Output == L6.Input, L6.Output == L7.Input, L7.Output == L8.Input,
-  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
-  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
-  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
-  L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
-  L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
-  L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar,
-  L7.TangentVector.VectorSpaceScalar == L8.TangentVector.VectorSpaceScalar
+  L5.Output == L6.Input, L6.Output == L7.Input, L7.Output == L8.Input
 
 /// A layer that sequentially composes 9 layers.
 public typealias Sequential9<
@@ -163,15 +135,7 @@ public typealias Sequential9<
 >
 where
   L1.Output == L2.Input, L2.Output == L3.Input, L3.Output == L4.Input, L4.Output == L5.Input,
-  L5.Output == L6.Input, L6.Output == L7.Input, L7.Output == L8.Input, L8.Output == L9.Input,
-  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
-  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
-  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
-  L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
-  L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
-  L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar,
-  L7.TangentVector.VectorSpaceScalar == L8.TangentVector.VectorSpaceScalar,
-  L8.TangentVector.VectorSpaceScalar == L9.TangentVector.VectorSpaceScalar
+  L5.Output == L6.Input, L6.Output == L7.Input, L7.Output == L8.Input, L8.Output == L9.Input
 
 /// A layer that sequentially composes 10 layers.
 public typealias Sequential10<
@@ -192,16 +156,7 @@ public typealias Sequential10<
 where
   L1.Output == L2.Input, L2.Output == L3.Input, L3.Output == L4.Input, L4.Output == L5.Input,
   L5.Output == L6.Input, L6.Output == L7.Input, L7.Output == L8.Input, L8.Output == L9.Input,
-  L9.Output == L10.Input,
-  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
-  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
-  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
-  L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
-  L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
-  L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar,
-  L7.TangentVector.VectorSpaceScalar == L8.TangentVector.VectorSpaceScalar,
-  L8.TangentVector.VectorSpaceScalar == L9.TangentVector.VectorSpaceScalar,
-  L9.TangentVector.VectorSpaceScalar == L10.TangentVector.VectorSpaceScalar
+  L9.Output == L10.Input
 
 @resultBuilder
 public struct LayerBuilder {
@@ -218,9 +173,7 @@ public struct LayerBuilder {
     -> Sequential<L1, Sequential<L2, L3>>
   where
     L1.Output == L2.Input,
-    L2.Output == L3.Input,
-    L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
-    L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar
+    L2.Output == L3.Input
   {
     Sequential(l1, Sequential(l2, l3))
   }
@@ -235,10 +188,7 @@ public struct LayerBuilder {
   where
     L1.Output == L2.Input,
     L2.Output == L3.Input,
-    L3.Output == L4.Input,
-    L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
-    L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
-    L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar
+    L3.Output == L4.Input
   {
     Sequential(l1, Sequential(l2, Sequential(l3, l4)))
   }
@@ -255,11 +205,7 @@ public struct LayerBuilder {
     L1.Output == L2.Input,
     L2.Output == L3.Input,
     L3.Output == L4.Input,
-    L4.Output == L5.Input,
-    L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
-    L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
-    L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
-    L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar
+    L4.Output == L5.Input
   {
     Sequential(l1, Sequential(l2, Sequential(l3, Sequential(l4, l5))))
   }
@@ -278,12 +224,7 @@ public struct LayerBuilder {
     L2.Output == L3.Input,
     L3.Output == L4.Input,
     L4.Output == L5.Input,
-    L5.Output == L6.Input,
-    L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
-    L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
-    L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
-    L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
-    L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar
+    L5.Output == L6.Input
   {
     Sequential(l1, Sequential(l2, Sequential(l3, Sequential(l4, Sequential(l5, l6)))))
   }
@@ -306,13 +247,7 @@ public struct LayerBuilder {
     L3.Output == L4.Input,
     L4.Output == L5.Input,
     L5.Output == L6.Input,
-    L6.Output == L7.Input,
-    L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
-    L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
-    L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
-    L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
-    L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
-    L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar
+    L6.Output == L7.Input
   {
     Sequential(
       l1, Sequential(l2, Sequential(l3, Sequential(l4, Sequential(l5, Sequential(l6, l7))))))
@@ -341,14 +276,7 @@ public struct LayerBuilder {
     L4.Output == L5.Input,
     L5.Output == L6.Input,
     L6.Output == L7.Input,
-    L7.Output == L8.Input,
-    L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
-    L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
-    L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
-    L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
-    L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
-    L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar,
-    L7.TangentVector.VectorSpaceScalar == L8.TangentVector.VectorSpaceScalar
+    L7.Output == L8.Input
   {
     Sequential(
       l1,
@@ -384,15 +312,7 @@ public struct LayerBuilder {
     L5.Output == L6.Input,
     L6.Output == L7.Input,
     L7.Output == L8.Input,
-    L8.Output == L9.Input,
-    L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
-    L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
-    L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
-    L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
-    L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
-    L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar,
-    L7.TangentVector.VectorSpaceScalar == L8.TangentVector.VectorSpaceScalar,
-    L8.TangentVector.VectorSpaceScalar == L9.TangentVector.VectorSpaceScalar
+    L8.Output == L9.Input
   {
     Sequential(
       l1,
@@ -438,16 +358,7 @@ public struct LayerBuilder {
     L6.Output == L7.Input,
     L7.Output == L8.Input,
     L8.Output == L9.Input,
-    L9.Output == L10.Input,
-    L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
-    L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
-    L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
-    L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
-    L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
-    L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar,
-    L7.TangentVector.VectorSpaceScalar == L8.TangentVector.VectorSpaceScalar,
-    L8.TangentVector.VectorSpaceScalar == L9.TangentVector.VectorSpaceScalar,
-    L9.TangentVector.VectorSpaceScalar == L10.TangentVector.VectorSpaceScalar
+    L9.Output == L10.Input
   {
     Sequential(
       l1,

--- a/Sources/TensorFlow/Layers/Sequential.swift.gyb
+++ b/Sources/TensorFlow/Layers/Sequential.swift.gyb
@@ -46,8 +46,7 @@ import _Differentiation
 /// }
 /// ````
 public struct Sequential<Layer1: Module, Layer2: Layer>: Module
-    where Layer1.Output == Layer2.Input,
-          Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar {
+    where Layer1.Output == Layer2.Input {
     public var layer1: Layer1
     public var layer2: Layer2
 
@@ -94,8 +93,7 @@ def sequential_type(arity):
 %for n in SEQUENTIAL_ARITY_RANGE:
 /// A layer that sequentially composes ${n} layers.
 public typealias Sequential${n}<${generic_parameters(n, ", ")}> = ${sequential_type(n)}
-  where ${", ".join(["L{}.Output == L{}.Input".format(i, i+1) for i in range(1, n)])},
-        ${", ".join(["L{}.TangentVector.VectorSpaceScalar == L{}.TangentVector.VectorSpaceScalar".format(i, i+1) for i in range(1, n)])}
+  where ${", ".join(["L{}.Output == L{}.Input".format(i, i+1) for i in range(1, n)])}
 
 %end
 
@@ -112,9 +110,6 @@ public struct LayerBuilder {
     >(${", ".join(["_ l{}: L{}".format(i, i) for i in range(1, n+1)])})
         -> ${sequential_type(n)} where
         ${",\n        ".join(["L{}.Output == L{}.Input".format(i, i+1)
-                          for i in range(1, n)])},
-        ${",\n        ".join(["L{}.TangentVector.VectorSpaceScalar == ".format(i) +
-                          "L{}.TangentVector.VectorSpaceScalar".format(i+1)
                           for i in range(1, n)])}
     {
         ${"".join(["Sequential(l{}, ".format(i) for i in range(1, n)])}l${n}${"".join([")" for _ in range(1, n)])}

--- a/Sources/TensorFlow/Optimizers/MomentumBased.swift
+++ b/Sources/TensorFlow/Optimizers/MomentumBased.swift
@@ -33,8 +33,7 @@ import Numerics
 public class RMSProp<Model: Differentiable>: Optimizer
 where
   Model.TangentVector: VectorProtocol & PointwiseMultiplicative
-    & ElementaryFunctions & KeyPathIterable,
-  Model.TangentVector.VectorSpaceScalar == Float
+    & ElementaryFunctions & KeyPathIterable
 {
   public typealias Model = Model
   /// The learning rate.
@@ -108,8 +107,7 @@ where
 public class AdaGrad<Model: Differentiable>: Optimizer
 where
   Model.TangentVector: VectorProtocol & PointwiseMultiplicative
-    & ElementaryFunctions & KeyPathIterable,
-  Model.TangentVector.VectorSpaceScalar == Float
+    & ElementaryFunctions & KeyPathIterable
 {
   public typealias Model = Model
   /// The learning rate.
@@ -169,8 +167,7 @@ where
 public class AdaDelta<Model: Differentiable>: Optimizer
 where
   Model.TangentVector: VectorProtocol & PointwiseMultiplicative
-    & ElementaryFunctions & KeyPathIterable,
-  Model.TangentVector.VectorSpaceScalar == Float
+    & ElementaryFunctions & KeyPathIterable
 {
   public typealias Model = Model
   /// The learning rate.
@@ -319,8 +316,7 @@ where
 public class Adam<Model: Differentiable>: Optimizer
 where
   Model.TangentVector: VectorProtocol & PointwiseMultiplicative
-    & ElementaryFunctions & KeyPathIterable,
-  Model.TangentVector.VectorSpaceScalar == Float
+    & ElementaryFunctions & KeyPathIterable
 {
   public typealias Model = Model
   /// The learning rate.
@@ -403,8 +399,7 @@ where
 public class AdaMax<Model: Differentiable & KeyPathIterable>: Optimizer
 where
   Model.TangentVector: VectorProtocol & PointwiseMultiplicative & ElementaryFunctions
-    & KeyPathIterable,
-  Model.TangentVector.VectorSpaceScalar == Float
+    & KeyPathIterable
 {
   public typealias Model = Model
   /// The learning rate.
@@ -489,8 +484,7 @@ where
 public class AMSGrad<Model: Differentiable & KeyPathIterable>: Optimizer
 where
   Model.TangentVector: VectorProtocol & PointwiseMultiplicative & ElementaryFunctions
-    & KeyPathIterable,
-  Model.TangentVector.VectorSpaceScalar == Float
+    & KeyPathIterable
 {
   public typealias Model = Model
   /// The learning rate.
@@ -582,8 +576,7 @@ where
 public class RAdam<Model: Differentiable>: Optimizer
 where
   Model.TangentVector: VectorProtocol & PointwiseMultiplicative & ElementaryFunctions
-    & KeyPathIterable,
-  Model.TangentVector.VectorSpaceScalar == Float
+    & KeyPathIterable
 {
   public typealias Model = Model
   /// The learning rate.

--- a/Sources/TensorFlow/Optimizers/SGD.swift
+++ b/Sources/TensorFlow/Optimizers/SGD.swift
@@ -38,8 +38,7 @@ import Numerics
 /// (Nesterov, 1983)
 public class SGD<Model: Differentiable>: Optimizer
 where
-  Model.TangentVector: VectorProtocol & ElementaryFunctions & KeyPathIterable,
-  Model.TangentVector.VectorSpaceScalar == Float
+  Model.TangentVector: VectorProtocol & ElementaryFunctions & KeyPathIterable
 {
   public typealias Model = Model
   /// The learning rate.


### PR DESCRIPTION
`VectorProtocol.VectorSpaceScalar` [was changed](https://github.com/tensorflow/swift-apis/pull/1139/files#r537911457) from an associated type to a hardcoded typealias for `Float`.

(I believe this simplification (removing `VectorSpaceScalar` as a customization point) made it easier to enable building `tensorflow/swift-apis` with standard toolchains.)

Fix warnings related to this change.

---

Example warnings:

<details>

<p>

```console
$ swift build -Xcc -I$HOME/Library/tensorflow-2.4.0/usr/include -Xlinker -L$HOME/Library/tensorflow-2.4.0/usr/lib -Xswiftc -DTENSORFLOW_USE_STANDARD_TOOLCHAIN

[1/4] Compiling TensorFlow SGD.swift
Sources/TensorFlow/Optimizers/SGD.swift:42:41: warning: neither type in same-type constraint ('Model.TangentVector.VectorSpaceScalar' (aka 'Float') or 'Float') refers to a generic parameter or associated type
  Model.TangentVector.VectorSpaceScalar == Float
                                        ^
[2/4] Compiling TensorFlow MomentumBased.swift
Sources/TensorFlow/Optimizers/MomentumBased.swift:37:41: warning: neither type in same-type constraint ('Model.TangentVector.VectorSpaceScalar' (aka 'Float') or 'Float') refers to a generic parameter or associated type
  Model.TangentVector.VectorSpaceScalar == Float
                                        ^
Sources/TensorFlow/Optimizers/MomentumBased.swift:112:41: warning: neither type in same-type constraint ('Model.TangentVector.VectorSpaceScalar' (aka 'Float') or 'Float') refers to a generic parameter or associated type
  Model.TangentVector.VectorSpaceScalar == Float
                                        ^
Sources/TensorFlow/Optimizers/MomentumBased.swift:173:41: warning: neither type in same-type constraint ('Model.TangentVector.VectorSpaceScalar' (aka 'Float') or 'Float') refers to a generic parameter or associated type
  Model.TangentVector.VectorSpaceScalar == Float
                                        ^
Sources/TensorFlow/Optimizers/MomentumBased.swift:323:41: warning: neither type in same-type constraint ('Model.TangentVector.VectorSpaceScalar' (aka 'Float') or 'Float') refers to a generic parameter or associated type
  Model.TangentVector.VectorSpaceScalar == Float
                                        ^
Sources/TensorFlow/Optimizers/MomentumBased.swift:407:41: warning: neither type in same-type constraint ('Model.TangentVector.VectorSpaceScalar' (aka 'Float') or 'Float') refers to a generic parameter or associated type
  Model.TangentVector.VectorSpaceScalar == Float
                                        ^
Sources/TensorFlow/Optimizers/MomentumBased.swift:493:41: warning: neither type in same-type constraint ('Model.TangentVector.VectorSpaceScalar' (aka 'Float') or 'Float') refers to a generic parameter or associated type
  Model.TangentVector.VectorSpaceScalar == Float
                                        ^
Sources/TensorFlow/Optimizers/MomentumBased.swift:586:41: warning: neither type in same-type constraint ('Model.TangentVector.VectorSpaceScalar' (aka 'Float') or 'Float') refers to a generic parameter or associated type
  Model.TangentVector.VectorSpaceScalar == Float
                                        ^
[3/4] Compiling TensorFlow Sequential.swift
Sources/TensorFlow/Layers/Sequential.swift:51:42: warning: neither type in same-type constraint ('Layer1.TangentVector.VectorSpaceScalar' (aka 'Float') or 'Layer2.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar
                                         ^
Sources/TensorFlow/Layers/Sequential.swift:82:38: warning: neither type in same-type constraint ('L1.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L2.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:83:38: warning: neither type in same-type constraint ('L2.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L3.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:91:38: warning: neither type in same-type constraint ('L1.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L2.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:92:38: warning: neither type in same-type constraint ('L2.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L3.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:93:38: warning: neither type in same-type constraint ('L3.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L4.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:101:38: warning: neither type in same-type constraint ('L1.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L2.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:102:38: warning: neither type in same-type constraint ('L2.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L3.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:103:38: warning: neither type in same-type constraint ('L3.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L4.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:104:38: warning: neither type in same-type constraint ('L4.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L5.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:112:38: warning: neither type in same-type constraint ('L1.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L2.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:113:38: warning: neither type in same-type constraint ('L2.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L3.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:114:38: warning: neither type in same-type constraint ('L3.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L4.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:115:38: warning: neither type in same-type constraint ('L4.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L5.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:116:38: warning: neither type in same-type constraint ('L5.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L6.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:127:38: warning: neither type in same-type constraint ('L1.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L2.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:128:38: warning: neither type in same-type constraint ('L2.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L3.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:129:38: warning: neither type in same-type constraint ('L3.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L4.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:130:38: warning: neither type in same-type constraint ('L4.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L5.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:131:38: warning: neither type in same-type constraint ('L5.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L6.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:132:38: warning: neither type in same-type constraint ('L6.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L7.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:144:38: warning: neither type in same-type constraint ('L1.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L2.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:145:38: warning: neither type in same-type constraint ('L2.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L3.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:146:38: warning: neither type in same-type constraint ('L3.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L4.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:147:38: warning: neither type in same-type constraint ('L4.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L5.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:148:38: warning: neither type in same-type constraint ('L5.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L6.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:149:38: warning: neither type in same-type constraint ('L6.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L7.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:150:38: warning: neither type in same-type constraint ('L7.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L8.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L7.TangentVector.VectorSpaceScalar == L8.TangentVector.VectorSpaceScalar
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:167:38: warning: neither type in same-type constraint ('L1.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L2.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:168:38: warning: neither type in same-type constraint ('L2.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L3.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:169:38: warning: neither type in same-type constraint ('L3.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L4.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:170:38: warning: neither type in same-type constraint ('L4.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L5.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:171:38: warning: neither type in same-type constraint ('L5.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L6.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:172:38: warning: neither type in same-type constraint ('L6.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L7.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:173:38: warning: neither type in same-type constraint ('L7.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L8.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L7.TangentVector.VectorSpaceScalar == L8.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:174:38: warning: neither type in same-type constraint ('L8.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L9.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L8.TangentVector.VectorSpaceScalar == L9.TangentVector.VectorSpaceScalar
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:196:38: warning: neither type in same-type constraint ('L1.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L2.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:197:38: warning: neither type in same-type constraint ('L2.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L3.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:198:38: warning: neither type in same-type constraint ('L3.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L4.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:199:38: warning: neither type in same-type constraint ('L4.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L5.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:200:38: warning: neither type in same-type constraint ('L5.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L6.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:201:38: warning: neither type in same-type constraint ('L6.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L7.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:202:38: warning: neither type in same-type constraint ('L7.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L8.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L7.TangentVector.VectorSpaceScalar == L8.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:203:38: warning: neither type in same-type constraint ('L8.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L9.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L8.TangentVector.VectorSpaceScalar == L9.TangentVector.VectorSpaceScalar,
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:204:38: warning: neither type in same-type constraint ('L9.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L10.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
  L9.TangentVector.VectorSpaceScalar == L10.TangentVector.VectorSpaceScalar
                                     ^
Sources/TensorFlow/Layers/Sequential.swift:222:40: warning: neither type in same-type constraint ('L1.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L2.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:223:40: warning: neither type in same-type constraint ('L2.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L3.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:239:40: warning: neither type in same-type constraint ('L1.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L2.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:240:40: warning: neither type in same-type constraint ('L2.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L3.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:241:40: warning: neither type in same-type constraint ('L3.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L4.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:259:40: warning: neither type in same-type constraint ('L1.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L2.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:260:40: warning: neither type in same-type constraint ('L2.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L3.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:261:40: warning: neither type in same-type constraint ('L3.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L4.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:262:40: warning: neither type in same-type constraint ('L4.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L5.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:282:40: warning: neither type in same-type constraint ('L1.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L2.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:283:40: warning: neither type in same-type constraint ('L2.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L3.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:284:40: warning: neither type in same-type constraint ('L3.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L4.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:285:40: warning: neither type in same-type constraint ('L4.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L5.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:286:40: warning: neither type in same-type constraint ('L5.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L6.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:310:40: warning: neither type in same-type constraint ('L1.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L2.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:311:40: warning: neither type in same-type constraint ('L2.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L3.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:312:40: warning: neither type in same-type constraint ('L3.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L4.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:313:40: warning: neither type in same-type constraint ('L4.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L5.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:314:40: warning: neither type in same-type constraint ('L5.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L6.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:315:40: warning: neither type in same-type constraint ('L6.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L7.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:345:40: warning: neither type in same-type constraint ('L1.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L2.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:346:40: warning: neither type in same-type constraint ('L2.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L3.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:347:40: warning: neither type in same-type constraint ('L3.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L4.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:348:40: warning: neither type in same-type constraint ('L4.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L5.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:349:40: warning: neither type in same-type constraint ('L5.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L6.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:350:40: warning: neither type in same-type constraint ('L6.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L7.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:351:40: warning: neither type in same-type constraint ('L7.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L8.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L7.TangentVector.VectorSpaceScalar == L8.TangentVector.VectorSpaceScalar
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:388:40: warning: neither type in same-type constraint ('L1.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L2.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:389:40: warning: neither type in same-type constraint ('L2.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L3.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:390:40: warning: neither type in same-type constraint ('L3.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L4.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:391:40: warning: neither type in same-type constraint ('L4.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L5.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:392:40: warning: neither type in same-type constraint ('L5.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L6.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:393:40: warning: neither type in same-type constraint ('L6.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L7.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:394:40: warning: neither type in same-type constraint ('L7.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L8.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L7.TangentVector.VectorSpaceScalar == L8.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:395:40: warning: neither type in same-type constraint ('L8.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L9.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L8.TangentVector.VectorSpaceScalar == L9.TangentVector.VectorSpaceScalar
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:442:40: warning: neither type in same-type constraint ('L1.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L2.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L1.TangentVector.VectorSpaceScalar == L2.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:443:40: warning: neither type in same-type constraint ('L2.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L3.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L2.TangentVector.VectorSpaceScalar == L3.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:444:40: warning: neither type in same-type constraint ('L3.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L4.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L3.TangentVector.VectorSpaceScalar == L4.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:445:40: warning: neither type in same-type constraint ('L4.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L5.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L4.TangentVector.VectorSpaceScalar == L5.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:446:40: warning: neither type in same-type constraint ('L5.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L6.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L5.TangentVector.VectorSpaceScalar == L6.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:447:40: warning: neither type in same-type constraint ('L6.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L7.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L6.TangentVector.VectorSpaceScalar == L7.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:448:40: warning: neither type in same-type constraint ('L7.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L8.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L7.TangentVector.VectorSpaceScalar == L8.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:449:40: warning: neither type in same-type constraint ('L8.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L9.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L8.TangentVector.VectorSpaceScalar == L9.TangentVector.VectorSpaceScalar,
                                       ^
Sources/TensorFlow/Layers/Sequential.swift:450:40: warning: neither type in same-type constraint ('L9.TangentVector.VectorSpaceScalar' (aka 'Float') or 'L10.TangentVector.VectorSpaceScalar' (aka 'Float')) refers to a generic parameter or associated type
    L9.TangentVector.VectorSpaceScalar == L10.TangentVector.VectorSpaceScalar
                                       ^
[4/37] Compiling TensorFlow Context.swift
[5/37] Compiling TensorFlow BroadcastingPullback.swift
[6/37] Compiling TensorFlow Algorithms.swift
[7/37] Compiling TensorFlow Backend.swift
[8/37] Compiling TensorFlow LazyTensorTFFunctionBuilder.swift
[9/37] Compiling TensorFlow LazyTensorTraceCache.swift
[10/37] Compiling TensorFlow Collatable.swift
[11/37] Compiling TensorFlow NonuniformTrainingEpochs.swift
[12/37] Compiling TensorFlow LazyTensorContext.swift
[13/37] Compiling TensorFlow LazyTensorOperation.swift
[14/37] Compiling TensorFlow ShapedArray.swift
[15/37] Compiling TensorFlow Tensor.swift
[16/37] Compiling TensorFlow Image.swift
[17/37] Compiling TensorFlow LinearAlgebra.swift
[18/37] Compiling TensorFlow Initializers.swift
[19/37] Compiling TensorFlow Layer.swift
[20/37] Compiling TensorFlow RawOpsManual.swift
[21/37] Compiling TensorFlow XLATensor.swift
[22/37] Compiling TensorFlow Dropout.swift
[23/37] Compiling TensorFlow Embedding.swift
[24/37] Compiling TensorFlow Basic.swift
[25/37] Compiling TensorFlow Dataset.swift
[26/37] Compiling TensorFlow Morphological.swift
[27/37] Compiling TensorFlow Normalization.swift
[28/37] Compiling TensorFlow Convolutional.swift
[29/37] Compiling TensorFlow Dense.swift
[30/37] Compiling TensorFlow Math.swift
[31/37] Compiling TensorFlow NN.swift
[32/37] Compiling TensorFlow Recurrent.swift
[33/37] Compiling TensorFlow Loss.swift
[34/37] Compiling TensorFlow EagerExecution.swift
[35/37] Compiling TensorFlow RawOpsDispatching.swift
[36/37] Compiling TensorFlow RawOpsGenerated.swift
[37/38] Merging module TensorFlow
ld: warning: dylib (Library/tensorflow-2.4.0/usr/lib/libx10.dylib) was built for newer macOS version (10.15) than being linked (10.13)
[38/38] Linking libTensorFlow.dylib
[38/38] Linking libTensorFlow.dylib

* Build Completed!
```
</p>

</details>