### PR TITLE
Removing zeroTangentVector test

### DIFF
--- a/Tests/TensorFlowTests/TensorTests.swift
+++ b/Tests/TensorFlowTests/TensorTests.swift
@@ -120,18 +120,6 @@ final class TensorTests: XCTestCase {
     )
   }
 
-  func testZeroTangentVectorInitializer() {
-    let shape: TensorShape = [4, 5, 6]
-    let tensor = Tensor<Float>(randomUniform: shape)
-    XCTAssertEqual(tensor.zeroTangentVector, Tensor(zeros: shape))
-
-    struct TensorWrapper: Differentiable {
-      var tensor: Tensor<Float>
-    }
-    let model = TensorWrapper(tensor: tensor)
-    XCTAssertEqual(model.zeroTangentVector, .init(tensor: Tensor(zeros: shape)))
-  }
-
   func testAnnotationsTFEager() {
     let tensor = Tensor<Float>(repeating: 0, shape: [1, 2, 3], on: Device.defaultTFEager)
     XCTAssertEqual(tensor.annotations, "Annotations not available in TF_EAGER.")
@@ -148,7 +136,6 @@ final class TensorTests: XCTestCase {
     ("testTensorShapeCollectionOperations", testTensorShapeCollectionOperations),
     ("testInitShapeScalars", testInitShapeScalars),
     ("testInitShapeScalarsDerivative", testInitShapeScalarsDerivative),
-    ("testZeroTangentVectorInitializer", testZeroTangentVectorInitializer),
     ("testAnnotationsTFEager", testAnnotationsTFEager),
   ]
 }


### PR DESCRIPTION
`zeroTangentVector` [has been removed upstream](https://github.com/apple/swift/pull/35329), and we had one unit test that referred to this and is failing to build as a result. This removes that outdated test.